### PR TITLE
feat: add totals cards to festival tickets page

### DIFF
--- a/app/components/dashboard/totals/card.tsx
+++ b/app/components/dashboard/totals/card.tsx
@@ -16,20 +16,20 @@ export default function TotalsCard({
   amount: number;
   title: string;
   description?: string;
-  Icon: LucideIcon;
+  Icon?: LucideIcon;
 }) {
   return (
-    <Card className="flex-1 w-full">
+    <Card className="w-full flex-1">
       <CardHeader className="w-fullp p-6 pb-2">
-        <div className="flex justify-between w-full">
-          <CardTitle className="capitalize text-sm">{title}</CardTitle>
-          <Icon className="w-3 h-3" />
+        <div className="flex w-full justify-between">
+          <CardTitle className="text-sm capitalize">{title}</CardTitle>
+          {Icon && <Icon className="h-3 w-3" />}
         </div>
       </CardHeader>
       <CardContent className="p-6 pt-2">
         <div className="p-2">
-          <div className="font-bold text-2xl text-center mb-2">{amount}</div>
-          <div className="text-muted-foreground text-sm text-center">
+          <div className="mb-2 text-center text-2xl font-bold">{amount}</div>
+          <div className="text-muted-foreground text-center text-sm">
             {description}
           </div>
         </div>

--- a/app/dashboard/festivals/[id]/tickets/page.tsx
+++ b/app/dashboard/festivals/[id]/tickets/page.tsx
@@ -1,6 +1,10 @@
+import { TicketIcon } from "lucide-react";
+
 import { fetchFestival } from "@/app/api/festivals/actions";
+import TotalsCard from "@/app/components/dashboard/totals/card";
 import { columnTitles, columns } from "@/app/components/tickets/table/columns";
 import { DataTable } from "@/app/components/ui/data_table/data-table";
+import { getWeekdayFromDate } from "@/app/lib/formatters";
 
 export default async function Page({ params }: { params: { id: string } }) {
   const festival = await fetchFestival(parseInt(params.id));
@@ -16,7 +20,43 @@ export default async function Page({ params }: { params: { id: string } }) {
 
   return (
     <div className="px:4 container min-h-full md:px-6">
-      <h1>Festival Tickets Page</h1>
+      <h1 className="mb-2 text-2xl font-bold md:text-3xl">
+        Entradas para {festival.name}
+      </h1>
+      <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+        <TotalsCard
+          amount={festival.tickets.length}
+          title="entradas en total"
+          description="Entradas para el evento"
+          Icon={TicketIcon}
+        />
+        <TotalsCard
+          amount={
+            festival.tickets.filter(
+              (ticket) =>
+                ticket.date.toString() === festival.startDate.toString(),
+            ).length
+          }
+          title="entradas primer día"
+          description={`Entradas para el ${getWeekdayFromDate(
+            festival.startDate,
+            "long",
+          )}`}
+        />
+        <TotalsCard
+          amount={
+            festival.tickets.filter(
+              (ticket) =>
+                ticket.date.toString() === festival.endDate.toString(),
+            ).length
+          }
+          title="entradas segundo día"
+          description={`Entradas para el ${getWeekdayFromDate(
+            festival.endDate,
+            "long",
+          )}`}
+        />
+      </div>
 
       <DataTable columns={columns} columnTitles={columnTitles} data={tickets} />
     </div>


### PR DESCRIPTION
The festival tickets page now includes three totals cards that display the number of tickets for different categories. The cards show the total number of tickets for the event, the number of tickets for the first day of the festival, and the number of tickets for the second day of the festival. Each card also includes a corresponding icon.