### PR TITLE
Feat/add dedicated festival map page

### DIFF
--- a/app/(routes)/festivals/[id]/map/page.tsx
+++ b/app/(routes)/festivals/[id]/map/page.tsx
@@ -62,12 +62,27 @@ export default async function FestivalMapPage(props: {
 		}
 	}
 
+	const passportActivity = activities.find((a) => a.type === "stamp_passport");
+	const passportUserIds: number[] = [];
+
+	for (const detail of passportActivity?.details ?? []) {
+		for (const participant of detail.participants) {
+			const hasApprovedProof = participant.proofs.some(
+				(p) => p.proofStatus === "approved",
+			);
+			if (hasApprovedProof) {
+				passportUserIds.push(participant.user.id);
+			}
+		}
+	}
+
 	return (
 		<FestivalNavMap
 			festivalName={festival.name}
 			sectors={sectors}
 			couponBookUserIds={couponBookUserIds}
 			couponBookProofs={couponBookProofs}
+			passportUserIds={passportUserIds}
 		/>
 	);
 }

--- a/app/(routes)/festivals/[id]/map/page.tsx
+++ b/app/(routes)/festivals/[id]/map/page.tsx
@@ -63,7 +63,7 @@ export default async function FestivalMapPage(props: {
 	}
 
 	const passportActivity = activities.find((a) => a.type === "stamp_passport");
-	const passportUserIds: number[] = [];
+	const passportUserIdSet = new Set<number>();
 
 	for (const detail of passportActivity?.details ?? []) {
 		for (const participant of detail.participants) {
@@ -71,10 +71,11 @@ export default async function FestivalMapPage(props: {
 				(p) => p.proofStatus === "approved",
 			);
 			if (hasApprovedProof) {
-				passportUserIds.push(participant.user.id);
+				passportUserIdSet.add(participant.user.id);
 			}
 		}
 	}
+	const passportUserIds = Array.from(passportUserIdSet);
 
 	return (
 		<FestivalNavMap

--- a/app/(routes)/festivals/[id]/map/page.tsx
+++ b/app/(routes)/festivals/[id]/map/page.tsx
@@ -4,7 +4,10 @@ import { notFound } from "next/navigation";
 
 import FestivalNavMap from "@/app/components/maps/festival-nav/festival-nav-map";
 import { CouponProof } from "@/app/components/maps/festival-nav/festival-nav-stand-drawer";
-import { fetchBaseFestival, fetchFestivalActivitiesByFestivalId } from "@/app/lib/festivals/actions";
+import {
+	fetchBaseFestival,
+	fetchFestivalActivitiesByFestivalId,
+} from "@/app/lib/festivals/actions";
 import { fetchFestivalSectors } from "@/app/lib/festival_sectors/actions";
 
 export const metadata: Metadata = {
@@ -43,12 +46,18 @@ export default async function FestivalMapPage(props: {
 				(p) => p.proofStatus === "approved",
 			);
 			if (approvedProofs.length > 0) {
-				couponBookUserIds.push(participant.user.id);
-				couponBookProofs[participant.user.id] = approvedProofs.map((p) => ({
-					promoHighlight: p.promoHighlight,
-					promoDescription: p.promoDescription,
-					promoConditions: p.promoConditions,
-				}));
+				const userId = participant.user.id;
+				if (!couponBookProofs[userId]) {
+					couponBookUserIds.push(userId);
+					couponBookProofs[userId] = [];
+				}
+				couponBookProofs[userId].push(
+					...approvedProofs.map((p) => ({
+						promoHighlight: p.promoHighlight,
+						promoDescription: p.promoDescription,
+						promoConditions: p.promoConditions,
+					})),
+				);
 			}
 		}
 	}

--- a/app/(routes)/festivals/[id]/map/page.tsx
+++ b/app/(routes)/festivals/[id]/map/page.tsx
@@ -1,0 +1,64 @@
+import { Metadata } from "next";
+import { z } from "zod";
+import { notFound } from "next/navigation";
+
+import FestivalNavMap from "@/app/components/maps/festival-nav/festival-nav-map";
+import { CouponProof } from "@/app/components/maps/festival-nav/festival-nav-stand-drawer";
+import { fetchBaseFestival, fetchFestivalActivitiesByFestivalId } from "@/app/lib/festivals/actions";
+import { fetchFestivalSectors } from "@/app/lib/festival_sectors/actions";
+
+export const metadata: Metadata = {
+	title: "Mapa del festival",
+	description: "Productora Glitter",
+};
+
+const ParamsSchema = z.object({
+	id: z.coerce.number(),
+});
+
+export default async function FestivalMapPage(props: {
+	params: Promise<z.infer<typeof ParamsSchema>>;
+}) {
+	const params = await props.params;
+	const validatedParams = ParamsSchema.safeParse(params);
+	if (!validatedParams.success) notFound();
+
+	const { id } = validatedParams.data;
+
+	const [festival, sectors, activities] = await Promise.all([
+		fetchBaseFestival(id),
+		fetchFestivalSectors(id),
+		fetchFestivalActivitiesByFestivalId(id),
+	]);
+
+	if (!festival) notFound();
+
+	const couponBookActivity = activities.find((a) => a.type === "coupon_book");
+	const couponBookUserIds: number[] = [];
+	const couponBookProofs: Record<number, CouponProof[]> = {};
+
+	for (const detail of couponBookActivity?.details ?? []) {
+		for (const participant of detail.participants) {
+			const approvedProofs = participant.proofs.filter(
+				(p) => p.proofStatus === "approved",
+			);
+			if (approvedProofs.length > 0) {
+				couponBookUserIds.push(participant.user.id);
+				couponBookProofs[participant.user.id] = approvedProofs.map((p) => ({
+					promoHighlight: p.promoHighlight,
+					promoDescription: p.promoDescription,
+					promoConditions: p.promoConditions,
+				}));
+			}
+		}
+	}
+
+	return (
+		<FestivalNavMap
+			festivalName={festival.name}
+			sectors={sectors}
+			couponBookUserIds={couponBookUserIds}
+			couponBookProofs={couponBookProofs}
+		/>
+	);
+}

--- a/app/components/maps/festival-nav/festival-nav-map-canvas.tsx
+++ b/app/components/maps/festival-nav/festival-nav-map-canvas.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useCallback } from "react";
+import { TransformComponent } from "react-zoom-pan-pinch";
+import { MapPin } from "lucide-react";
+
+import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import { MapElementBase } from "@/app/lib/map_elements/definitions";
+import {
+	STAND_SIZE,
+	StandColors,
+	computeCanvasBounds,
+	getPublicStandColors,
+	getStandPosition,
+} from "@/app/components/maps/map-utils";
+import MapCanvas from "@/app/components/maps/map-canvas";
+import MapStand from "@/app/components/maps/map-stand";
+import MapElement from "@/app/components/maps/map-element";
+import MapTransformWrapper from "@/app/components/maps/map-transform-wrapper";
+import FestivalNavMapLegend from "@/app/components/maps/festival-nav/festival-nav-map-legend";
+
+type FestivalNavMapCanvasProps = {
+	stands: StandWithReservationsWithParticipants[];
+	mapElements: MapElementBase[];
+	mapBounds?: { minX: number; minY: number; width: number; height: number };
+	selectedStandId: number | null;
+	couponBookUserIdSet: Set<number>;
+	sectorName: string;
+	onStandSelect: (
+		stand: StandWithReservationsWithParticipants,
+		sectorName: string,
+	) => void;
+};
+
+function isOccupied(stand: StandWithReservationsWithParticipants): boolean {
+	return stand.status === "reserved" || stand.status === "confirmed";
+}
+
+function getStandParticipantUserIds(
+	stand: StandWithReservationsWithParticipants,
+): number[] {
+	return stand.reservations
+		.filter((r) => r.status !== "rejected")
+		.flatMap((r) => r.participants)
+		.map((p) => p.user.id);
+}
+
+function hasCouponParticipant(
+	stand: StandWithReservationsWithParticipants,
+	couponBookUserIdSet: Set<number>,
+): boolean {
+	return getStandParticipantUserIds(stand).some((id) =>
+		couponBookUserIdSet.has(id),
+	);
+}
+
+function getNavStandColors(
+	stand: StandWithReservationsWithParticipants,
+	couponBookUserIdSet: Set<number>,
+): StandColors {
+	if (isOccupied(stand) && hasCouponParticipant(stand, couponBookUserIdSet)) {
+		return {
+			fill: "rgba(217, 119, 6, 0.85)",
+			hoverFill: "rgba(180, 83, 9, 0.95)",
+			stroke: "rgba(146, 64, 14, 0.9)",
+			text: "#ffffff",
+		};
+	}
+	return getPublicStandColors(stand.status);
+}
+
+export default function FestivalNavMapCanvas({
+	stands,
+	mapElements,
+	mapBounds,
+	selectedStandId,
+	couponBookUserIdSet,
+	sectorName,
+	onStandSelect,
+}: FestivalNavMapCanvasProps) {
+	const visibleStands = stands.filter((s) => s.status !== "disabled");
+	const canvasBounds =
+		mapBounds ?? computeCanvasBounds(visibleStands, mapElements);
+
+	const handleStandSelect = useCallback(
+		(stand: StandWithReservationsWithParticipants) => {
+			if (!isOccupied(stand)) return;
+			onStandSelect(stand, sectorName);
+		},
+		[onStandSelect, sectorName],
+	);
+
+	const couponStands = visibleStands.filter(
+		(s) => isOccupied(s) && hasCouponParticipant(s, couponBookUserIdSet),
+	);
+
+	const canvasConfig = {
+		minX: canvasBounds.minX,
+		minY: canvasBounds.minY,
+		width: canvasBounds.width,
+		height: canvasBounds.height,
+	};
+
+	return (
+		<div className="relative w-full border rounded-lg overflow-hidden">
+			<MapTransformWrapper initialScale={1} minScale={1} maxScale={4} centerOnInit>
+				<TransformComponent wrapperStyle={{ width: "100%" }} contentStyle={{ width: "100%" }}>
+					<MapCanvas config={canvasConfig}>
+						{mapElements.map((element) => (
+							<MapElement key={`el-${element.id}`} element={element} />
+						))}
+						{visibleStands.map((stand) => (
+							<MapStand
+								key={stand.id}
+								stand={stand}
+								canBeReserved={false}
+								selected={stand.id === selectedStandId}
+								colors={getNavStandColors(stand, couponBookUserIdSet)}
+								onTouchTap={handleStandSelect}
+								onClick={handleStandSelect}
+							/>
+						))}
+						{/* Coupon badge overlay — painted after stands */}
+						<g aria-hidden="true">
+							{couponStands.map((stand) => {
+								const { left, top } = getStandPosition(stand);
+								return (
+									<g
+										key={`badge-${stand.id}`}
+										transform={`translate(${left}, ${top})`}
+										style={{ pointerEvents: "none" }}
+									>
+										<circle
+											cx={STAND_SIZE - 0.8}
+											cy={0.8}
+											r={1.3}
+											fill="#F59E0B"
+											stroke="#fff"
+											strokeWidth={0.3}
+										/>
+										<text
+											x={STAND_SIZE - 0.8}
+											y={0.8}
+											textAnchor="middle"
+											dominantBaseline="central"
+											fontSize={1.4}
+											fontWeight={700}
+											fill="#fff"
+											style={{ userSelect: "none" }}
+										>
+											%
+										</text>
+									</g>
+								);
+							})}
+						</g>
+					</MapCanvas>
+				</TransformComponent>
+
+				{/* Zoom hint (mobile only) */}
+				<div className="absolute bottom-12 left-1/2 -translate-x-1/2 z-10 md:hidden pointer-events-none">
+					<div className="flex items-center gap-1.5 rounded-full bg-gray-900/80 px-3 py-1.5 text-white backdrop-blur-sm">
+						<MapPin className="h-3 w-3" />
+						<span className="text-xs font-medium">Pellizca para ampliar</span>
+					</div>
+				</div>
+
+				{/* Legend overlay */}
+				<div className="absolute bottom-3 left-3 z-10 bg-white/90 backdrop-blur-sm rounded-lg px-3 py-2 shadow-sm border border-border pointer-events-none">
+					<FestivalNavMapLegend />
+				</div>
+			</MapTransformWrapper>
+		</div>
+	);
+}

--- a/app/components/maps/festival-nav/festival-nav-map-canvas.tsx
+++ b/app/components/maps/festival-nav/festival-nav-map-canvas.tsx
@@ -17,7 +17,6 @@ import MapCanvas from "@/app/components/maps/map-canvas";
 import MapStand from "@/app/components/maps/map-stand";
 import MapElement from "@/app/components/maps/map-element";
 import MapTransformWrapper from "@/app/components/maps/map-transform-wrapper";
-import FestivalNavMapLegend from "@/app/components/maps/festival-nav/festival-nav-map-legend";
 
 type FestivalNavMapCanvasProps = {
 	stands: StandWithReservationsWithParticipants[];
@@ -165,10 +164,6 @@ export default function FestivalNavMapCanvas({
 					</div>
 				</div>
 
-				{/* Legend overlay */}
-				<div className="absolute bottom-3 left-3 z-10 bg-white/90 backdrop-blur-sm rounded-lg px-3 py-2 shadow-sm border border-border pointer-events-none">
-					<FestivalNavMapLegend />
-				</div>
 			</MapTransformWrapper>
 		</div>
 	);

--- a/app/components/maps/festival-nav/festival-nav-map-canvas.tsx
+++ b/app/components/maps/festival-nav/festival-nav-map-canvas.tsx
@@ -24,6 +24,7 @@ type FestivalNavMapCanvasProps = {
 	mapBounds?: { minX: number; minY: number; width: number; height: number };
 	selectedStandId: number | null;
 	couponBookUserIdSet: Set<number>;
+	passportUserIdSet: Set<number>;
 	sectorName: string;
 	onStandSelect: (
 		stand: StandWithReservationsWithParticipants,
@@ -44,20 +45,24 @@ function getStandParticipantUserIds(
 		.map((p) => p.user.id);
 }
 
-function hasCouponParticipant(
+function hasActivityParticipant(
 	stand: StandWithReservationsWithParticipants,
-	couponBookUserIdSet: Set<number>,
+	userIdSet: Set<number>,
 ): boolean {
-	return getStandParticipantUserIds(stand).some((id) =>
-		couponBookUserIdSet.has(id),
-	);
+	return getStandParticipantUserIds(stand).some((id) => userIdSet.has(id));
 }
 
 function getNavStandColors(
 	stand: StandWithReservationsWithParticipants,
 	couponBookUserIdSet: Set<number>,
+	passportUserIdSet: Set<number>,
 ): StandColors {
-	if (isOccupied(stand) && hasCouponParticipant(stand, couponBookUserIdSet)) {
+	if (!isOccupied(stand)) return getPublicStandColors(stand.status);
+
+	const hasCoupon = hasActivityParticipant(stand, couponBookUserIdSet);
+	const hasPassport = hasActivityParticipant(stand, passportUserIdSet);
+
+	if (hasCoupon) {
 		return {
 			fill: "rgba(217, 119, 6, 0.85)",
 			hoverFill: "rgba(180, 83, 9, 0.95)",
@@ -65,6 +70,16 @@ function getNavStandColors(
 			text: "#ffffff",
 		};
 	}
+
+	if (hasPassport) {
+		return {
+			fill: "rgba(5, 150, 105, 0.85)",
+			hoverFill: "rgba(4, 120, 87, 0.95)",
+			stroke: "rgba(6, 95, 70, 0.9)",
+			text: "#ffffff",
+		};
+	}
+
 	return getPublicStandColors(stand.status);
 }
 
@@ -74,6 +89,7 @@ export default function FestivalNavMapCanvas({
 	mapBounds,
 	selectedStandId,
 	couponBookUserIdSet,
+	passportUserIdSet,
 	sectorName,
 	onStandSelect,
 }: FestivalNavMapCanvasProps) {
@@ -89,8 +105,12 @@ export default function FestivalNavMapCanvas({
 		[onStandSelect, sectorName],
 	);
 
-	const couponStands = visibleStands.filter(
-		(s) => isOccupied(s) && hasCouponParticipant(s, couponBookUserIdSet),
+	const occupiedStands = visibleStands.filter(isOccupied);
+	const couponStands = occupiedStands.filter((s) =>
+		hasActivityParticipant(s, couponBookUserIdSet),
+	);
+	const passportStands = occupiedStands.filter((s) =>
+		hasActivityParticipant(s, passportUserIdSet),
 	);
 
 	const canvasConfig = {
@@ -102,8 +122,16 @@ export default function FestivalNavMapCanvas({
 
 	return (
 		<div className="relative w-full border rounded-lg overflow-hidden">
-			<MapTransformWrapper initialScale={1} minScale={1} maxScale={4} centerOnInit>
-				<TransformComponent wrapperStyle={{ width: "100%" }} contentStyle={{ width: "100%" }}>
+			<MapTransformWrapper
+				initialScale={1}
+				minScale={1}
+				maxScale={4}
+				centerOnInit
+			>
+				<TransformComponent
+					wrapperStyle={{ width: "100%" }}
+					contentStyle={{ width: "100%" }}
+				>
 					<MapCanvas config={canvasConfig}>
 						{mapElements.map((element) => (
 							<MapElement key={`el-${element.id}`} element={element} />
@@ -114,18 +142,22 @@ export default function FestivalNavMapCanvas({
 								stand={stand}
 								canBeReserved={false}
 								selected={stand.id === selectedStandId}
-								colors={getNavStandColors(stand, couponBookUserIdSet)}
+								colors={getNavStandColors(
+									stand,
+									couponBookUserIdSet,
+									passportUserIdSet,
+								)}
 								onTouchTap={handleStandSelect}
 								onClick={handleStandSelect}
 							/>
 						))}
-						{/* Coupon badge overlay — painted after stands */}
+						{/* Activity badge overlay — painted after stands */}
 						<g aria-hidden="true">
 							{couponStands.map((stand) => {
 								const { left, top } = getStandPosition(stand);
 								return (
 									<g
-										key={`badge-${stand.id}`}
+										key={`coupon-${stand.id}`}
 										transform={`translate(${left}, ${top})`}
 										style={{ pointerEvents: "none" }}
 									>
@@ -152,6 +184,43 @@ export default function FestivalNavMapCanvas({
 									</g>
 								);
 							})}
+							{passportStands.map((stand) => {
+								const { left, top } = getStandPosition(stand);
+								// If stand also has a coupon badge, shift the passport badge left
+								const hasCoupon = hasActivityParticipant(
+									stand,
+									couponBookUserIdSet,
+								);
+								const cx = hasCoupon ? STAND_SIZE - 2.8 : STAND_SIZE - 0.8;
+								return (
+									<g
+										key={`passport-${stand.id}`}
+										transform={`translate(${left}, ${top})`}
+										style={{ pointerEvents: "none" }}
+									>
+										<circle
+											cx={cx}
+											cy={0.8}
+											r={1.3}
+											fill="#059669"
+											stroke="#fff"
+											strokeWidth={0.3}
+										/>
+										<text
+											x={cx}
+											y={0.8}
+											textAnchor="middle"
+											dominantBaseline="central"
+											fontSize={1.4}
+											fontWeight={700}
+											fill="#fff"
+											style={{ userSelect: "none" }}
+										>
+											★
+										</text>
+									</g>
+								);
+							})}
 						</g>
 					</MapCanvas>
 				</TransformComponent>
@@ -163,7 +232,6 @@ export default function FestivalNavMapCanvas({
 						<span className="text-xs font-medium">Pellizca para ampliar</span>
 					</div>
 				</div>
-
 			</MapTransformWrapper>
 		</div>
 	);

--- a/app/components/maps/festival-nav/festival-nav-map-legend.tsx
+++ b/app/components/maps/festival-nav/festival-nav-map-legend.tsx
@@ -1,0 +1,22 @@
+export default function FestivalNavMapLegend() {
+	return (
+		<div className="flex flex-col gap-1.5">
+			<div className="flex items-center gap-2">
+				<div className="h-3.5 w-3.5 rounded-sm bg-[rgba(109,40,217,0.85)] border border-[rgba(91,33,182,0.8)]" />
+				<span className="text-xs text-foreground">Ocupado</span>
+			</div>
+			<div className="flex items-center gap-2">
+				<div className="relative h-3.5 w-3.5 rounded-sm bg-[rgba(217,119,6,0.85)] border border-[rgba(146,64,14,0.8)]">
+					<span className="absolute inset-0 flex items-center justify-center text-[7px] font-bold text-white leading-none">
+						%
+					</span>
+				</div>
+				<span className="text-xs text-foreground">En cuponera</span>
+			</div>
+			<div className="flex items-center gap-2">
+				<div className="h-3.5 w-3.5 rounded-sm bg-[rgba(221,214,254,0.6)] border border-[rgba(139,92,246,0.6)]" />
+				<span className="text-xs text-foreground">Disponible</span>
+			</div>
+		</div>
+	);
+}

--- a/app/components/maps/festival-nav/festival-nav-map-legend.tsx
+++ b/app/components/maps/festival-nav/festival-nav-map-legend.tsx
@@ -14,6 +14,14 @@ export default function FestivalNavMapLegend() {
 				<span className="text-xs text-foreground">En cuponera</span>
 			</div>
 			<div className="flex items-center gap-2">
+				<div className="relative h-3.5 w-3.5 rounded-sm bg-[rgba(5,150,105,0.85)] border border-[rgba(6,95,70,0.8)]">
+					<span className="absolute inset-0 flex items-center justify-center text-[7px] font-bold text-white leading-none">
+						★
+					</span>
+				</div>
+				<span className="text-xs text-foreground">Carrera de sellos</span>
+			</div>
+			<div className="flex items-center gap-2">
 				<div className="h-3.5 w-3.5 rounded-sm bg-[rgba(221,214,254,0.6)] border border-[rgba(139,92,246,0.6)]" />
 				<span className="text-xs text-foreground">Disponible</span>
 			</div>

--- a/app/components/maps/festival-nav/festival-nav-map-legend.tsx
+++ b/app/components/maps/festival-nav/festival-nav-map-legend.tsx
@@ -1,6 +1,6 @@
 export default function FestivalNavMapLegend() {
 	return (
-		<div className="flex flex-col gap-1.5">
+		<div className="flex flex-wrap gap-x-4 gap-y-1.5">
 			<div className="flex items-center gap-2">
 				<div className="h-3.5 w-3.5 rounded-sm bg-[rgba(109,40,217,0.85)] border border-[rgba(91,33,182,0.8)]" />
 				<span className="text-xs text-foreground">Ocupado</span>

--- a/app/components/maps/festival-nav/festival-nav-map.tsx
+++ b/app/components/maps/festival-nav/festival-nav-map.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+
+import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import { FestivalSectorWithStandsWithReservationsWithParticipants } from "@/app/lib/festival_sectors/definitions";
+import FestivalNavSectorTabs from "@/app/components/maps/festival-nav/festival-nav-sector-tabs";
+import FestivalNavMapCanvas from "@/app/components/maps/festival-nav/festival-nav-map-canvas";
+import FestivalNavSearch, {
+	ParticipantSearchEntry,
+} from "@/app/components/maps/festival-nav/festival-nav-search";
+import FestivalNavStandDrawer, {
+	CouponProof,
+} from "@/app/components/maps/festival-nav/festival-nav-stand-drawer";
+
+type FestivalNavMapProps = {
+	festivalName: string;
+	sectors: FestivalSectorWithStandsWithReservationsWithParticipants[];
+	couponBookUserIds: number[];
+	couponBookProofs: Record<number, CouponProof[]>;
+};
+
+export default function FestivalNavMap({
+	festivalName,
+	sectors,
+	couponBookUserIds,
+	couponBookProofs,
+}: FestivalNavMapProps) {
+	// -1 = "all sectors" view
+	const [activeSectorIndex, setActiveSectorIndex] = useState(-1);
+	const [selectedStand, setSelectedStand] =
+		useState<StandWithReservationsWithParticipants | null>(null);
+	const [selectedSectorName, setSelectedSectorName] = useState("");
+	const [drawerOpen, setDrawerOpen] = useState(false);
+
+	const sectorDivRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+
+	const couponBookUserIdSet = useMemo(
+		() => new Set(couponBookUserIds),
+		[couponBookUserIds],
+	);
+
+	// Build participant search index across all sectors
+	const searchEntries = useMemo<ParticipantSearchEntry[]>(() => {
+		const entries: ParticipantSearchEntry[] = [];
+		sectors.forEach((sector, sectorIndex) => {
+			sector.stands.forEach((stand) => {
+				if (stand.status === "disabled") return;
+				const standLabel = `${stand.label}${stand.standNumber}`;
+				stand.reservations
+					.filter((r) => r.status !== "rejected")
+					.flatMap((r) => r.participants)
+					.forEach((participant) => {
+						if (!participant.user.displayName) return;
+						entries.push({
+							displayName: participant.user.displayName,
+							imageUrl: participant.user.imageUrl,
+							standLabel,
+							sectorName: sector.name,
+							sectorIndex,
+							stand,
+						});
+					});
+			});
+		});
+		return entries;
+	}, [sectors]);
+
+	const handleStandSelect = useCallback(
+		(stand: StandWithReservationsWithParticipants, sectorName: string) => {
+			setSelectedStand(stand);
+			setSelectedSectorName(sectorName);
+			setDrawerOpen(true);
+		},
+		[],
+	);
+
+	const handleSearchSelect = useCallback(
+		(entry: ParticipantSearchEntry) => {
+			setSelectedStand(entry.stand);
+			setSelectedSectorName(entry.sectorName);
+			setDrawerOpen(true);
+
+			if (activeSectorIndex === -1) {
+				// All-view: scroll the page to the sector div
+				const sectorDiv = sectorDivRefs.current.get(
+					sectors[entry.sectorIndex]?.id,
+				);
+				if (sectorDiv) {
+					setTimeout(() => {
+						sectorDiv.scrollIntoView({ behavior: "smooth", block: "start" });
+					}, 50);
+				}
+			} else {
+				// Single-sector view: switch to the correct sector
+				setActiveSectorIndex(entry.sectorIndex);
+			}
+		},
+		[activeSectorIndex, sectors],
+	);
+
+	const showAll = activeSectorIndex === -1;
+	const activeSector = showAll ? null : (sectors[activeSectorIndex] ?? null);
+
+	const getSectorMapBounds = (
+		sector: FestivalSectorWithStandsWithReservationsWithParticipants,
+	) =>
+		sector.mapOriginX != null &&
+		sector.mapOriginY != null &&
+		sector.mapWidth != null &&
+		sector.mapHeight != null
+			? {
+					minX: sector.mapOriginX,
+					minY: sector.mapOriginY,
+					width: sector.mapWidth,
+					height: sector.mapHeight,
+				}
+			: undefined;
+
+	return (
+		<div className="container flex flex-col gap-4 py-4">
+			{/* Compact header */}
+			<div className="px-4">
+				<h1 className="text-base font-semibold truncate">{festivalName}</h1>
+				<p className="text-xs text-muted-foreground">Mapa del festival</p>
+			</div>
+
+			{/* Search + tabs — sticky below navbar */}
+			<div className="sticky top-16 md:top-20 z-20 bg-background border-b">
+				<FestivalNavSearch
+					entries={searchEntries}
+					onSelect={handleSearchSelect}
+				/>
+				<FestivalNavSectorTabs
+					sectors={sectors}
+					activeIndex={activeSectorIndex}
+					onChange={setActiveSectorIndex}
+				/>
+			</div>
+
+			{/* Map area */}
+			<div className="flex justify-center px-4 md:px-0">
+				<div className="w-full md:max-w-3xl">
+					{showAll ? (
+						<div className="flex flex-col gap-4">
+							{sectors.map((sector) => (
+								<div
+									key={sector.id}
+									ref={(el) => {
+										if (el) sectorDivRefs.current.set(sector.id, el);
+										else sectorDivRefs.current.delete(sector.id);
+									}}
+								>
+									{sectors.length > 1 && (
+										<p className="px-4 py-2 text-sm font-semibold text-muted-foreground border-b">
+											{sector.name}
+										</p>
+									)}
+									<FestivalNavMapCanvas
+										stands={sector.stands}
+										mapElements={sector.mapElements ?? []}
+										mapBounds={getSectorMapBounds(sector)}
+										selectedStandId={selectedStand?.id ?? null}
+										couponBookUserIdSet={couponBookUserIdSet}
+										sectorName={sector.name}
+										onStandSelect={handleStandSelect}
+									/>
+								</div>
+							))}
+						</div>
+					) : activeSector ? (
+						<FestivalNavMapCanvas
+							key={activeSector.id}
+							stands={activeSector.stands}
+							mapElements={activeSector.mapElements ?? []}
+							mapBounds={getSectorMapBounds(activeSector)}
+							selectedStandId={selectedStand?.id ?? null}
+							couponBookUserIdSet={couponBookUserIdSet}
+							sectorName={activeSector.name}
+							onStandSelect={handleStandSelect}
+						/>
+					) : (
+						<p className="text-center text-muted-foreground text-sm py-8">
+							No hay mapa disponible.
+						</p>
+					)}
+				</div>
+			</div>
+
+			{/* Stand detail drawer */}
+			<FestivalNavStandDrawer
+				stand={selectedStand}
+				sectorName={selectedSectorName}
+				open={drawerOpen}
+				onOpenChange={setDrawerOpen}
+				couponBookProofs={couponBookProofs}
+			/>
+		</div>
+	);
+}

--- a/app/components/maps/festival-nav/festival-nav-map.tsx
+++ b/app/components/maps/festival-nav/festival-nav-map.tsx
@@ -19,6 +19,7 @@ type FestivalNavMapProps = {
 	sectors: FestivalSectorWithStandsWithReservationsWithParticipants[];
 	couponBookUserIds: number[];
 	couponBookProofs: Record<number, CouponProof[]>;
+	passportUserIds: number[];
 };
 
 export default function FestivalNavMap({
@@ -26,6 +27,7 @@ export default function FestivalNavMap({
 	sectors,
 	couponBookUserIds,
 	couponBookProofs,
+	passportUserIds,
 }: FestivalNavMapProps) {
 	// -1 = "all sectors" view
 	const [activeSectorIndex, setActiveSectorIndex] = useState(-1);
@@ -39,6 +41,11 @@ export default function FestivalNavMap({
 	const couponBookUserIdSet = useMemo(
 		() => new Set(couponBookUserIds),
 		[couponBookUserIds],
+	);
+
+	const passportUserIdSet = useMemo(
+		() => new Set(passportUserIds),
+		[passportUserIds],
 	);
 
 	// Build participant search index across all sectors
@@ -170,6 +177,7 @@ export default function FestivalNavMap({
 										mapBounds={getSectorMapBounds(sector)}
 										selectedStandId={selectedStand?.id ?? null}
 										couponBookUserIdSet={couponBookUserIdSet}
+										passportUserIdSet={passportUserIdSet}
 										sectorName={sector.name}
 										onStandSelect={handleStandSelect}
 									/>
@@ -184,6 +192,7 @@ export default function FestivalNavMap({
 							mapBounds={getSectorMapBounds(activeSector)}
 							selectedStandId={selectedStand?.id ?? null}
 							couponBookUserIdSet={couponBookUserIdSet}
+							passportUserIdSet={passportUserIdSet}
 							sectorName={activeSector.name}
 							onStandSelect={handleStandSelect}
 						/>
@@ -202,6 +211,7 @@ export default function FestivalNavMap({
 				open={drawerOpen}
 				onOpenChange={setDrawerOpen}
 				couponBookProofs={couponBookProofs}
+				passportUserIdSet={passportUserIdSet}
 			/>
 		</div>
 	);

--- a/app/components/maps/festival-nav/festival-nav-map.tsx
+++ b/app/components/maps/festival-nav/festival-nav-map.tsx
@@ -161,6 +161,7 @@ export default function FestivalNavMap({
 							{sectors.map((sector) => (
 								<div
 									key={sector.id}
+									className="scroll-mt-36 md:scroll-mt-40"
 									ref={(el) => {
 										if (el) sectorDivRefs.current.set(sector.id, el);
 										else sectorDivRefs.current.delete(sector.id);

--- a/app/components/maps/festival-nav/festival-nav-map.tsx
+++ b/app/components/maps/festival-nav/festival-nav-map.tsx
@@ -12,6 +12,7 @@ import FestivalNavSearch, {
 import FestivalNavStandDrawer, {
 	CouponProof,
 } from "@/app/components/maps/festival-nav/festival-nav-stand-drawer";
+import FestivalNavMapLegend from "@/app/components/maps/festival-nav/festival-nav-map-legend";
 
 type FestivalNavMapProps = {
 	festivalName: string;
@@ -136,6 +137,13 @@ export default function FestivalNavMap({
 					activeIndex={activeSectorIndex}
 					onChange={setActiveSectorIndex}
 				/>
+			</div>
+
+			{/* Legend */}
+			<div className="flex justify-center px-4 md:px-0">
+				<div className="w-full md:max-w-3xl">
+					<FestivalNavMapLegend />
+				</div>
 			</div>
 
 			{/* Map area */}

--- a/app/components/maps/festival-nav/festival-nav-search.tsx
+++ b/app/components/maps/festival-nav/festival-nav-search.tsx
@@ -26,6 +26,7 @@ export default function FestivalNavSearch({
 }: FestivalNavSearchProps) {
 	const [query, setQuery] = useState("");
 	const [open, setOpen] = useState(false);
+	const wrapperRef = useRef<HTMLDivElement>(null);
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	const normalized = query.trim().toLowerCase();
@@ -44,8 +45,19 @@ export default function FestivalNavSearch({
 		onSelect(entry);
 	}
 
+	function handleWrapperBlur(event: React.FocusEvent<HTMLDivElement>) {
+		const nextTarget = event.relatedTarget as Node | null;
+		if (!nextTarget || !wrapperRef.current?.contains(nextTarget)) {
+			setOpen(false);
+		}
+	}
+
 	return (
-		<div className="relative shrink-0 px-4 py-2">
+		<div
+			ref={wrapperRef}
+			onBlur={handleWrapperBlur}
+			className="relative shrink-0 px-4 py-2"
+		>
 			<div className="relative flex items-center">
 				<Search className="absolute left-3 h-4 w-4 text-muted-foreground pointer-events-none" />
 				<input
@@ -58,10 +70,6 @@ export default function FestivalNavSearch({
 						setOpen(true);
 					}}
 					onFocus={() => setOpen(true)}
-					onBlur={() => {
-						// Delay so click on result fires before blur closes the dropdown
-						setTimeout(() => setOpen(false), 150);
-					}}
 					className="w-full rounded-lg border border-border bg-background pl-9 pr-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
 				/>
 			</div>

--- a/app/components/maps/festival-nav/festival-nav-search.tsx
+++ b/app/components/maps/festival-nav/festival-nav-search.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Search } from "lucide-react";
+
+import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import { Avatar, AvatarImage } from "@/app/components/ui/avatar";
+
+export type ParticipantSearchEntry = {
+	displayName: string;
+	imageUrl: string | null;
+	standLabel: string;
+	sectorName: string;
+	sectorIndex: number;
+	stand: StandWithReservationsWithParticipants;
+};
+
+type FestivalNavSearchProps = {
+	entries: ParticipantSearchEntry[];
+	onSelect: (entry: ParticipantSearchEntry) => void;
+};
+
+export default function FestivalNavSearch({
+	entries,
+	onSelect,
+}: FestivalNavSearchProps) {
+	const [query, setQuery] = useState("");
+	const [open, setOpen] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const normalized = query.trim().toLowerCase();
+	const results =
+		normalized.length > 0
+			? entries.filter(
+					(e) =>
+						e.displayName.toLowerCase().includes(normalized) ||
+						e.standLabel.toLowerCase().includes(normalized),
+				)
+			: [];
+
+	function handleSelect(entry: ParticipantSearchEntry) {
+		setQuery("");
+		setOpen(false);
+		onSelect(entry);
+	}
+
+	return (
+		<div className="relative shrink-0 px-4 py-2">
+			<div className="relative flex items-center">
+				<Search className="absolute left-3 h-4 w-4 text-muted-foreground pointer-events-none" />
+				<input
+					ref={inputRef}
+					type="text"
+					placeholder="Buscar participante..."
+					value={query}
+					onChange={(e) => {
+						setQuery(e.target.value);
+						setOpen(true);
+					}}
+					onFocus={() => setOpen(true)}
+					onBlur={() => {
+						// Delay so click on result fires before blur closes the dropdown
+						setTimeout(() => setOpen(false), 150);
+					}}
+					className="w-full rounded-lg border border-border bg-background pl-9 pr-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+				/>
+			</div>
+
+			{open && results.length > 0 && (
+				<ul className="absolute left-4 right-4 top-full mt-1 z-50 rounded-lg border border-border bg-background shadow-lg overflow-hidden max-h-60 overflow-y-auto">
+					{results.map((entry, i) => (
+						<li key={`${entry.stand.id}-${i}`}>
+							<button
+								className="flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-muted transition-colors"
+								onMouseDown={(e) => e.preventDefault()}
+								onClick={() => handleSelect(entry)}
+							>
+								<Avatar className="h-8 w-8 shrink-0">
+									<AvatarImage
+										src={entry.imageUrl ?? undefined}
+										alt={entry.displayName}
+									/>
+								</Avatar>
+								<div className="flex-1 min-w-0">
+									<p className="text-sm font-medium truncate">
+										{entry.displayName}
+									</p>
+									<p className="text-xs text-muted-foreground">
+										Stand {entry.standLabel} · {entry.sectorName}
+									</p>
+								</div>
+							</button>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}

--- a/app/components/maps/festival-nav/festival-nav-sector-tabs.tsx
+++ b/app/components/maps/festival-nav/festival-nav-sector-tabs.tsx
@@ -1,0 +1,41 @@
+import { FestivalSectorWithStandsWithReservationsWithParticipants } from "@/app/lib/festival_sectors/definitions";
+
+type FestivalNavSectorTabsProps = {
+	sectors: FestivalSectorWithStandsWithReservationsWithParticipants[];
+	activeIndex: number; // -1 = all sectors
+	onChange: (index: number) => void;
+};
+
+export default function FestivalNavSectorTabs({
+	sectors,
+	activeIndex,
+	onChange,
+}: FestivalNavSectorTabsProps) {
+	return (
+		<div className="flex gap-2 overflow-x-auto px-4 py-2 shrink-0 no-scrollbar">
+			<button
+				className={`shrink-0 rounded-full px-3 py-1 text-sm font-medium border transition-colors ${
+					activeIndex === -1
+						? "bg-primary text-primary-foreground border-primary"
+						: "bg-background text-muted-foreground border-border hover:border-primary/50"
+				}`}
+				onClick={() => onChange(-1)}
+			>
+				Todos
+			</button>
+			{sectors.map((sector, i) => (
+				<button
+					key={sector.id}
+					className={`shrink-0 rounded-full px-3 py-1 text-sm font-medium border transition-colors ${
+						i === activeIndex
+							? "bg-primary text-primary-foreground border-primary"
+							: "bg-background text-muted-foreground border-border hover:border-primary/50"
+					}`}
+					onClick={() => onChange(i)}
+				>
+					{sector.name}
+				</button>
+			))}
+		</div>
+	);
+}

--- a/app/components/maps/festival-nav/festival-nav-stand-drawer.tsx
+++ b/app/components/maps/festival-nav/festival-nav-stand-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { BookOpen, Stamp } from "lucide-react";
 
@@ -52,6 +52,10 @@ export default function FestivalNavStandDrawer({
 	passportUserIdSet,
 }: FestivalNavStandDrawerProps) {
 	const [activeTab, setActiveTab] = useState(0);
+
+	useEffect(() => {
+		setActiveTab(0);
+	}, [stand?.id]);
 
 	const participants = stand
 		? stand.reservations

--- a/app/components/maps/festival-nav/festival-nav-stand-drawer.tsx
+++ b/app/components/maps/festival-nav/festival-nav-stand-drawer.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { BookOpen } from "lucide-react";
+
+import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import { Avatar, AvatarImage } from "@/app/components/ui/avatar";
+import { Badge } from "@/app/components/ui/badge";
+import {
+	Drawer,
+	DrawerContent,
+	DrawerHeader,
+} from "@/app/components/ui/drawer";
+import { socialsUrls, socialsIcons } from "@/app/lib/users/utils";
+
+export type CouponProof = {
+	promoHighlight: string | null;
+	promoDescription: string | null;
+	promoConditions: string | null;
+};
+
+type FestivalNavStandDrawerProps = {
+	stand: StandWithReservationsWithParticipants | null;
+	sectorName: string;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	couponBookProofs: Record<number, CouponProof[]>;
+};
+
+function getCategoryLabel(category: string): string {
+	switch (category) {
+		case "illustration":
+		case "new_artist":
+			return "ILUSTRACIÓN";
+		case "gastronomy":
+			return "GASTRONOMÍA";
+		case "entrepreneurship":
+			return "EMPRENDIMIENTO";
+		default:
+			return "";
+	}
+}
+
+export default function FestivalNavStandDrawer({
+	stand,
+	sectorName,
+	open,
+	onOpenChange,
+	couponBookProofs,
+}: FestivalNavStandDrawerProps) {
+	const [activeTab, setActiveTab] = useState(0);
+
+	const participants = stand
+		? stand.reservations
+				.filter((r) => r.status !== "rejected")
+				.flatMap((r) => r.participants)
+		: [];
+
+	const clampedTab = Math.min(activeTab, Math.max(0, participants.length - 1));
+
+	if (!stand) return null;
+
+	const currentParticipant = participants[clampedTab] ?? participants[0];
+	const standLabel = `${stand.label}${stand.standNumber}`;
+	const categoryLabel = getCategoryLabel(stand.standCategory);
+	const products = stand.standSubcategories.map((sc) => sc.subcategory.label);
+
+	const couponProof =
+		currentParticipant != null
+			? (couponBookProofs[currentParticipant.user.id]?.[0] ?? null)
+			: null;
+
+	return (
+		<Drawer open={open} onOpenChange={onOpenChange} modal={false}>
+			<DrawerContent className="max-h-[85vh]">
+				<DrawerHeader className="text-left pb-2">
+					<div className="flex items-center gap-2 flex-wrap">
+						<Badge className="font-bold px-3 py-1 rounded-full">
+							{standLabel}
+						</Badge>
+						{sectorName && (
+							<span className="text-xs text-muted-foreground">{sectorName}</span>
+						)}
+						{categoryLabel && (
+							<Badge
+								variant="outline"
+								className="text-xs font-semibold uppercase rounded-full border-primary text-primary"
+							>
+								{categoryLabel}
+							</Badge>
+						)}
+					</div>
+				</DrawerHeader>
+
+				<div className="overflow-y-auto px-4 pb-6 space-y-4">
+					{participants.length === 0 ? (
+						<p className="text-sm text-muted-foreground text-center py-4">
+							Sin información del participante
+						</p>
+					) : (
+						<>
+							{/* Participant tabs */}
+							{participants.length > 1 && (
+								<div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1 no-scrollbar">
+									{participants.map((p, index) => (
+										<button
+											key={p.id}
+											onClick={() => setActiveTab(index)}
+											className={`flex items-center gap-2 px-3 py-2 rounded-lg border-2 transition-all shrink-0 ${
+												index === clampedTab
+													? "bg-white shadow-sm border-primary"
+													: "bg-muted hover:bg-accent border-border"
+											}`}
+										>
+											<Avatar className="w-6 h-6">
+												<AvatarImage
+													src={p.user.imageUrl ?? undefined}
+													alt={p.user.displayName ?? "Participante"}
+												/>
+											</Avatar>
+											<span className="text-xs font-medium truncate max-w-[100px]">
+												{p.user.displayName ?? "Participante"}
+											</span>
+										</button>
+									))}
+								</div>
+							)}
+
+							{currentParticipant && (
+								<>
+									{/* Participant hero */}
+									<div className="flex items-center gap-3">
+										<Avatar className="w-14 h-14 border-2 border-primary shrink-0">
+											<AvatarImage
+												src={currentParticipant.user.imageUrl ?? undefined}
+												alt={
+													currentParticipant.user.displayName ?? "Participante"
+												}
+											/>
+										</Avatar>
+										<div className="flex-1 min-w-0">
+											<h3 className="text-lg font-bold truncate">
+												{currentParticipant.user.displayName ?? "Participante"}
+											</h3>
+											<p className="text-sm text-muted-foreground">
+												Stand #{standLabel} · {sectorName}
+											</p>
+										</div>
+									</div>
+
+									{/* Coupon section */}
+									{couponProof && (
+										<div className="rounded-lg border border-amber-200 bg-amber-50 p-3 space-y-1">
+											<div className="flex items-center gap-2 text-amber-700 mb-2">
+												<BookOpen className="h-4 w-4 shrink-0" />
+												<span className="text-xs font-semibold uppercase tracking-wide">
+													Disponible en tu cuponera
+												</span>
+											</div>
+											{couponProof.promoHighlight && (
+												<p className="text-sm font-bold text-amber-900">
+													{couponProof.promoHighlight}
+												</p>
+											)}
+											{couponProof.promoDescription && (
+												<p className="text-sm text-amber-800">
+													{couponProof.promoDescription}
+												</p>
+											)}
+											{couponProof.promoConditions && (
+												<p className="text-xs italic text-amber-700">
+													{couponProof.promoConditions}
+												</p>
+											)}
+										</div>
+									)}
+
+									{/* Products */}
+									{products.length > 0 && (
+										<div>
+											<p className="text-xs text-muted-foreground mb-2">
+												Productos
+											</p>
+											<div className="flex flex-wrap gap-2">
+												{products.map((product, index) => (
+													<Badge
+														key={index}
+														variant="outline"
+														className="text-xs rounded-full border-primary text-primary"
+													>
+														{product}
+													</Badge>
+												))}
+											</div>
+										</div>
+									)}
+
+									{/* Social links */}
+									{currentParticipant.user.userSocials.length > 0 && (
+										<div>
+											<p className="text-xs text-muted-foreground mb-2">
+												Contacto
+											</p>
+											<div className="space-y-2">
+												{currentParticipant.user.userSocials.map((social) => (
+													<a
+														key={social.id}
+														href={`${socialsUrls[social.type]}${social.username}`}
+														target="_blank"
+														rel="noopener noreferrer"
+														className="flex items-center gap-2 text-sm hover:underline font-medium"
+														style={{
+															color:
+																social.type === "instagram"
+																	? "#E8356A"
+																	: undefined,
+														}}
+													>
+														<FontAwesomeIcon
+															className="w-4 h-4"
+															icon={socialsIcons[social.type]}
+														/>
+														@{social.username}
+													</a>
+												))}
+											</div>
+										</div>
+									)}
+								</>
+							)}
+						</>
+					)}
+				</div>
+			</DrawerContent>
+		</Drawer>
+	);
+}

--- a/app/components/maps/festival-nav/festival-nav-stand-drawer.tsx
+++ b/app/components/maps/festival-nav/festival-nav-stand-drawer.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { BookOpen } from "lucide-react";
+import { BookOpen, Stamp } from "lucide-react";
 
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
 import { Avatar, AvatarImage } from "@/app/components/ui/avatar";
@@ -26,6 +26,7 @@ type FestivalNavStandDrawerProps = {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	couponBookProofs: Record<number, CouponProof[]>;
+	passportUserIdSet: Set<number>;
 };
 
 function getCategoryLabel(category: string): string {
@@ -48,6 +49,7 @@ export default function FestivalNavStandDrawer({
 	open,
 	onOpenChange,
 	couponBookProofs,
+	passportUserIdSet,
 }: FestivalNavStandDrawerProps) {
 	const [activeTab, setActiveTab] = useState(0);
 
@@ -71,6 +73,11 @@ export default function FestivalNavStandDrawer({
 			? (couponBookProofs[currentParticipant.user.id]?.[0] ?? null)
 			: null;
 
+	const isInPassport =
+		currentParticipant != null
+			? passportUserIdSet.has(currentParticipant.user.id)
+			: false;
+
 	return (
 		<Drawer open={open} onOpenChange={onOpenChange} modal={false}>
 			<DrawerContent className="max-h-[85vh]">
@@ -80,7 +87,9 @@ export default function FestivalNavStandDrawer({
 							{standLabel}
 						</Badge>
 						{sectorName && (
-							<span className="text-xs text-muted-foreground">{sectorName}</span>
+							<span className="text-xs text-muted-foreground">
+								{sectorName}
+							</span>
 						)}
 						{categoryLabel && (
 							<Badge
@@ -173,6 +182,18 @@ export default function FestivalNavStandDrawer({
 													{couponProof.promoConditions}
 												</p>
 											)}
+										</div>
+									)}
+
+									{/* Passport section */}
+									{isInPassport && (
+										<div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3">
+											<div className="flex items-center gap-2 text-emerald-700">
+												<Stamp className="h-4 w-4 shrink-0" />
+												<span className="text-xs font-semibold uppercase tracking-wide">
+													Participa en la carrera de sellos
+												</span>
+											</div>
 										</div>
 									)}
 

--- a/app/components/maps/festival-nav/festival-nav-stand-drawer.tsx
+++ b/app/components/maps/festival-nav/festival-nav-stand-drawer.tsx
@@ -43,6 +43,12 @@ function getCategoryLabel(category: string): string {
 	}
 }
 
+function formatStandLabel(
+	stand: Pick<StandWithReservationsWithParticipants, "label" | "standNumber">,
+): string {
+	return `${stand.label ?? ""}${stand.standNumber}`;
+}
+
 export default function FestivalNavStandDrawer({
 	stand,
 	sectorName,
@@ -68,7 +74,7 @@ export default function FestivalNavStandDrawer({
 	if (!stand) return null;
 
 	const currentParticipant = participants[clampedTab] ?? participants[0];
-	const standLabel = `${stand.label}${stand.standNumber}`;
+	const standLabel = formatStandLabel(stand);
 	const categoryLabel = getCategoryLabel(stand.standCategory);
 	const products = stand.standSubcategories.map((sc) => sc.subcategory.label);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glitter-nextjs",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glitter-nextjs",
-      "version": "2.23.0",
+      "version": "2.24.0",
       "dependencies": {
         "@clerk/localizations": "^3.35.2",
         "@clerk/nextjs": "^6.36.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glitter-nextjs",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive festival map page with sector navigation, sticky controls, and a zoomable/pannable canvas.
  * Visual badges for coupon and passport participation, responsive legend, mobile zoom hint, sector tabs, and participant search with quick stand navigation.
  * Stand detail drawer showing participants, contact links, products, and promotional proofs.
* **Chores**
  * Bumped app version to 2.24.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->