### PR TITLE
feat(festivals): require auth for activity pages, route by type, and …

### DIFF
--- a/app/(routes)/festivals/[id]/activity/[activityId]/loading.tsx
+++ b/app/(routes)/festivals/[id]/activity/[activityId]/loading.tsx
@@ -3,12 +3,28 @@ import { Skeleton } from "@/app/components/ui/skeleton";
 export default function Loading() {
 	return (
 		<div className="container p-3 md:p-6">
-			<Skeleton className="h-6 w-80" />
-			<Skeleton className="h-5 w-[230px] my-2" />
+			{/* Title */}
+			<Skeleton className="h-8 w-64 mb-2" />
+			{/* Description */}
+			<Skeleton className="h-4 w-96 max-w-full mb-1" />
+			<Skeleton className="h-4 w-72 max-w-full mb-6" />
 
-			<Skeleton className="h-4 w-[250px]" />
-			<Skeleton className="h-4 w-[200px]" />
-			<Skeleton className="h-4 w-20" />
+			{/* Content block */}
+			<div className="flex flex-col gap-4 mt-4">
+				<Skeleton className="h-5 w-48" />
+				<div className="flex flex-col gap-2">
+					<Skeleton className="h-4 w-full" />
+					<Skeleton className="h-4 w-full" />
+					<Skeleton className="h-4 w-3/4" />
+				</div>
+				<div className="flex flex-col gap-2">
+					<Skeleton className="h-4 w-full" />
+					<Skeleton className="h-4 w-5/6" />
+				</div>
+			</div>
+
+			{/* Action button */}
+			<Skeleton className="h-10 w-full mt-8 rounded-md" />
 		</div>
 	);
 }

--- a/app/(routes)/festivals/[id]/activity/[activityId]/page.tsx
+++ b/app/(routes)/festivals/[id]/activity/[activityId]/page.tsx
@@ -5,6 +5,8 @@ import CouponBookActivityPage from "@/app/components/pages/festival_activities/c
 import FestivalStickerActivityPage from "@/app/components/pages/festival_activities/festival-sticker-activity";
 import PassportActivityPage from "@/app/components/pages/festival_activities/passport-activity";
 import { fetchFestivalActivity } from "@/app/lib/festival_activites/actions";
+import { fetchFestivalWithDates } from "@/app/lib/festivals/actions";
+import { formatDate } from "@/app/lib/formatters";
 import { getCurrentUserProfile } from "@/app/lib/users/helpers";
 import Image from "next/image";
 import { notFound, redirect } from "next/navigation";
@@ -18,6 +20,16 @@ const ParamsSchema = z.object({
 
 type PageProps = {
 	params: Promise<z.infer<typeof ParamsSchema>>;
+};
+
+const formatSpanishDateTime = (date: Date | null | undefined) => {
+	if (!date) return null;
+	return formatDate(date).toFormat("cccc d 'de' LLLL 'a las' HH:mm'hs'");
+};
+
+const formatSpanishDate = (date: Date | null | undefined) => {
+	if (!date) return null;
+	return formatDate(date).toFormat("cccc d 'de' LLLL");
 };
 
 export default async function Page({ params }: PageProps) {
@@ -34,7 +46,33 @@ export default async function Page({ params }: PageProps) {
 	}
 
 	const activity = await fetchFestivalActivity(activityId);
-	if (!activity) notFound();
+	if (!activity || activity.festivalId !== festivalId) notFound();
+	const festival = await fetchFestivalWithDates(festivalId);
+	if (!festival) notFound();
+
+	const firstFestivalDate =
+		festival.startDate ??
+		festival.festivalDates
+			.map((festivalDate) => festivalDate.startDate)
+			.sort((a, b) => a.getTime() - b.getTime())[0] ??
+		null;
+
+	const proofUploadDeadlineText = formatSpanishDateTime(
+		activity.proofUploadLimitDate,
+	);
+	const registrationDeadlineText = formatSpanishDateTime(
+		activity.registrationEndDate,
+	);
+	const festivalStartDateText = formatSpanishDate(firstFestivalDate);
+	const rawStickerRemovalDeadline =
+		"stickerRemovalDeadline" in activity
+			? activity["stickerRemovalDeadline"]
+			: null;
+	const stickerRemovalDeadlineText = formatSpanishDate(
+		rawStickerRemovalDeadline instanceof Date
+			? rawStickerRemovalDeadline
+			: null,
+	);
 
 	if (activity.type === "stamp_passport") {
 		return (
@@ -188,9 +226,11 @@ export default async function Page({ params }: PageProps) {
 					</li>
 					<li>
 						El ilustrador deberá subir el diseño de su sticker al sitio web en
-						formato PNG con un tamaño máximo de 2MB hasta el miércoles 9 de
-						abril a las 18:00hs. (Esta opción no se encuentra disponible en este
-						momento pero se comunicará los ilustradores cuando esté disponible).
+						formato PNG con un tamaño máximo de 2MB hasta{" "}
+						{proofUploadDeadlineText ??
+							"la fecha límite definida para la actividad"}
+						. (Esta opción no se encuentra disponible en este momento pero se
+						comunicará los ilustradores cuando esté disponible).
 					</li>
 					<li>
 						El ilustrador se hará cargo de la impresión y la venta o
@@ -212,17 +252,22 @@ export default async function Page({ params }: PageProps) {
 						festival.
 					</li>
 					<li>
-						La fecha límite para inscribirse a la actividad es el domingo 6 de
-						abril a las 18:00hs.
+						La fecha límite para inscribirse a la actividad es{" "}
+						{registrationDeadlineText ??
+							"la fecha de cierre de registro configurada para la actividad"}
+						.
 					</li>
 					<li>
 						En caso de que un diseño de Sticker-Print no cumpla con la cantidad
 						mínima de participantes, podrá ser retirado de la actividad lo cual
-						se comunicará hasta el lunes 7 de abril.
+						{stickerRemovalDeadlineText
+							? ` se comunicará hasta el ${stickerRemovalDeadlineText}.`
+							: " se comunicará oportunamente por los canales oficiales del festival."}
 					</li>
 					<li>
 						El ilustrador se compromete a tener sus stickers coleccionables
-						listos para el primer día del evento: sábado 12 de abril.
+						listos para el primer día del evento:{" "}
+						{festivalStartDateText ?? "la fecha de inicio del festival"}.
 					</li>
 					<li>
 						El ilustrador comprende que la venta de cada diseño de Sticker-Print

--- a/app/(routes)/festivals/[id]/activity/[activityId]/page.tsx
+++ b/app/(routes)/festivals/[id]/activity/[activityId]/page.tsx
@@ -1,9 +1,14 @@
-import Title from "@/app/components/atoms/heading";
-import FestivalActivityContent from "@/app/components/festivals/festival-activity-content";
+import EnrollRedirectButton from "@/app/components/festivals/festival_activities/enroll-redirect-button";
+import BestStandActivityPage from "@/app/components/pages/festival_activities/best-stand-activity";
+import BestStandActivitySkeleton from "@/app/components/pages/festival_activities/best-stand-activity-skeleton";
+import CouponBookActivityPage from "@/app/components/pages/festival_activities/coupon-book-activity";
+import FestivalStickerActivityPage from "@/app/components/pages/festival_activities/festival-sticker-activity";
+import PassportActivityPage from "@/app/components/pages/festival_activities/passport-activity";
 import { fetchFestivalActivity } from "@/app/lib/festival_activites/actions";
-import { fetchFestival } from "@/app/lib/festivals/actions";
-import { fetchPublicReservationsByFestivalId } from "@/app/lib/reservations/actions";
-import { notFound } from "next/navigation";
+import { getCurrentUserProfile } from "@/app/lib/users/helpers";
+import Image from "next/image";
+import { notFound, redirect } from "next/navigation";
+import { Suspense } from "react";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
@@ -21,25 +26,216 @@ export default async function Page({ params }: PageProps) {
 
 	const { id: festivalId, activityId } = validatedParams.data;
 
+	const currentProfile = await getCurrentUserProfile();
+	if (!currentProfile) {
+		redirect(
+			`/sign_in?returnUrl=/festivals/${festivalId}/activity/${activityId}`,
+		);
+	}
+
 	const activity = await fetchFestivalActivity(activityId);
-	const festival = await fetchFestival({
-		id: festivalId,
-		acceptedUsersOnly: true,
-	});
+	if (!activity) notFound();
 
-	if (!activity || !festival) notFound();
+	if (activity.type === "stamp_passport") {
+		return (
+			<div className="container p-3 md:p-6">
+				<PassportActivityPage
+					activity={activity}
+					currentProfile={currentProfile}
+					forProfile={currentProfile}
+					festivalId={festivalId}
+				/>
+			</div>
+		);
+	}
 
-	const reservations = await fetchPublicReservationsByFestivalId(festivalId);
+	if (activity.type === "coupon_book") {
+		return (
+			<div className="container p-3 md:p-6">
+				<CouponBookActivityPage
+					activity={activity}
+					currentProfile={currentProfile}
+					forProfile={currentProfile}
+					festivalId={festivalId}
+				/>
+			</div>
+		);
+	}
+
+	if (activity.type === "festival_sticker") {
+		return (
+			<FestivalStickerActivityPage
+				activity={activity}
+				currentProfile={currentProfile}
+				forProfile={currentProfile}
+				festivalId={festivalId}
+			/>
+		);
+	}
+
+	if (activity.type === "best_stand") {
+		return (
+			<Suspense fallback={<BestStandActivitySkeleton />}>
+				<BestStandActivityPage
+					activity={activity}
+					currentProfile={currentProfile}
+					forProfile={currentProfile}
+				/>
+			</Suspense>
+		);
+	}
 
 	return (
 		<div className="container p-3 md:p-6">
-			<Title>{activity.name}</Title>
-			<p className="text-muted-foreground">{activity.visitorsDescription}</p>
-
-			<FestivalActivityContent
+			<h1 className="text-2xl font-bold my-3">Sticker-Print</h1>
+			<div className="flex flex-col gap-3 mt-6">
+				<h2 className="text-lg font-bold">¿Qué es el Sticker-Print?</h2>
+				<p>
+					El Sticker-Print es una actividad en la cual incentivaremos al público
+					asistente del evento a coleccionar stickers.
+				</p>
+				<p>
+					Como artistas/ilustradores, sabemos que el potencial de los stickers
+					es enorme y como Productora Glitter, queremos que nuestro público
+					también lo vea.
+				</p>
+			</div>
+			<div className="flex flex-col gap-3 mt-6">
+				<h2 className="text-lg font-bold">¿Cómo funciona?</h2>
+				<p>
+					Tendremos 4 diseños distintos de prints tamaño doble oficio que los
+					asistentes del evento podrán adquirir en el stand de Glitter al
+					ingresar al festival por un valor de 15Bs. En total se imprimirán 160
+					Sticker-Prints, lo que equivale a 40 unidades de cada diseño.
+				</p>
+				<p>
+					Cada diseño de print tendrá espacio para pegar 9 stickers
+					coleccionables:
+				</p>
+				<ul className="ml-4 list-disc list-inside">
+					<li>
+						8 espacios estarán disponibles para los distintos ilustradores que
+						se inscriban a la actividad. Cada ilustrador deberá diseñar un
+						sticker exclusivo para el Sticker-Print.
+					</li>
+					<li>
+						El 9no espacio estará reservado para la Productora Glitter que
+						entregará un sticker coleccionable como premio a quienes completen
+						la actividad.
+					</li>
+				</ul>
+				<p>
+					Al ser 4 diseños, en total podremos contar con la participación de 32
+					ilustradores distintos.
+				</p>
+				<p>
+					Los asistentes que compren el Sticker-Print deberán recorrer el
+					festival para encontrar a los ilustradores que forman parte de su
+					diseño de print y adquirir los stickers coleccionables para pegar en
+					los espacios asignados.
+				</p>
+			</div>
+			<div className="flex flex-col gap-3 mt-6">
+				<h2 className="font-semibold">Diseños de Sticker-Print</h2>
+				<p>Estos son los 4 diseños disponibles para participar:</p>
+				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 mx-auto">
+					{activity.details.map((detail) => (
+						<div key={detail.id} className="">
+							<Image
+								className="mx-auto"
+								src={detail.imageUrl ?? "/images/placeholder.png"}
+								alt="Sticker Print Example"
+								width={320}
+								height={480}
+							/>
+							<p className="text-center text-muted-foreground text-sm">
+								Medidas: 432 mm x 330 mm
+							</p>
+						</div>
+					))}
+				</div>
+			</div>
+			<div className="flex flex-col gap-3 mt-6">
+				<h2 className="text-lg font-bold">¿Cómo se puede participar?</h2>
+				<p>
+					Luego de leer las condiciones de participación, debes darle clic al
+					botón de &quot;Registrarme&quot; que te llevará a una pantalla donde
+					podrás seleccionar el diseño del print en el que deseas participar.
+				</p>
+			</div>
+			<div className="flex flex-col gap-3 mt-6">
+				<h2 className="text-lg font-bold">Condiciones:</h2>
+				<ul className="ml-4 list-disc list-inside">
+					<li>Tener una reserva confirmada para el festival</li>
+					<li>
+						El ilustrador solo puede ser parte de un diseño de Sticker-Print
+					</li>
+					<li>
+						Luego de haber seleccionado el diseño y haberse inscrito en la
+						actividad, no se podrá cambiar de diseño.
+					</li>
+					<li>
+						El ilustrador debe diseñar un sticker exclusivo para la actividad el
+						cual deberá medir 4cm x 4cm sin excepción.
+					</li>
+					<li>
+						El sticker deberá tener una paleta de color acorde al diseño del
+						print seleccionado.
+					</li>
+					<li>
+						El diseño del sticker debe ser apto para todo público, es decir, no
+						puede contener contenido sexual, violento, o que pueda ser ofensivo.
+					</li>
+					<li>
+						El ilustrador deberá subir el diseño de su sticker al sitio web en
+						formato PNG con un tamaño máximo de 2MB hasta el miércoles 9 de
+						abril a las 18:00hs. (Esta opción no se encuentra disponible en este
+						momento pero se comunicará los ilustradores cuando esté disponible).
+					</li>
+					<li>
+						El ilustrador se hará cargo de la impresión y la venta o
+						distribución de sus propios stickers.
+					</li>
+					<li>
+						El ilustrador es libre de elegir la dinámica con la cual otorgará
+						los stickers coleccionables. En caso de venderlos, el precio máximo
+						por sticker será de 5Bs.
+					</li>
+					<li>
+						La cantidad mínima de stickers coleccionables que el ilustrador
+						deberá tener disponibles designados exclusivamente para la actividad
+						será de 40 unidades.
+					</li>
+					<li>
+						El número de espacio que el ilustrador ocupe en el diseño del
+						Sticker-Print que elija será asignado por la organización del
+						festival.
+					</li>
+					<li>
+						La fecha límite para inscribirse a la actividad es el domingo 6 de
+						abril a las 18:00hs.
+					</li>
+					<li>
+						En caso de que un diseño de Sticker-Print no cumpla con la cantidad
+						mínima de participantes, podrá ser retirado de la actividad lo cual
+						se comunicará hasta el lunes 7 de abril.
+					</li>
+					<li>
+						El ilustrador se compromete a tener sus stickers coleccionables
+						listos para el primer día del evento: sábado 12 de abril.
+					</li>
+					<li>
+						El ilustrador comprende que la venta de cada diseño de Sticker-Print
+						depende de la demanda del público asistente y que no es
+						responsabilidad de la organización del festival.
+					</li>
+				</ul>
+			</div>
+			<EnrollRedirectButton
+				currentProfile={currentProfile}
+				forProfile={currentProfile}
+				festivalId={festivalId}
 				activity={activity}
-				reservations={reservations}
-				festival={festival}
 			/>
 		</div>
 	);

--- a/app/components/festivals/festival_activities/activity-summary-card.tsx
+++ b/app/components/festivals/festival_activities/activity-summary-card.tsx
@@ -3,6 +3,7 @@ import { PencilIcon, ClipboardListIcon, ChevronRightIcon } from "lucide-react";
 
 import { RedirectButton } from "@/app/components/redirect-button";
 import { Button } from "@/app/components/ui/button";
+import CopyActivityLinkButton from "@/app/components/festivals/festival_activities/copy-activity-link-button";
 import {
 	Card,
 	CardContent,
@@ -187,6 +188,10 @@ export default function ActivitySummaryCard({
 						<ClipboardListIcon className="w-4 h-4 mr-1" />
 						Iniciar revisión
 					</RedirectButton>
+					<CopyActivityLinkButton
+						festivalId={festivalId}
+						activityId={activity.id}
+					/>
 				</div>
 			</CardContent>
 		</Card>

--- a/app/components/festivals/festival_activities/copy-activity-link-button.tsx
+++ b/app/components/festivals/festival_activities/copy-activity-link-button.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import CopyToClipboardButton from "@/app/components/common/copy-to-clipboard-button";
+import { useEffect, useState } from "react";
+
+type CopyActivityLinkButtonProps = {
+	festivalId: number;
+	activityId: number;
+};
+
+export default function CopyActivityLinkButton({
+	festivalId,
+	activityId,
+}: CopyActivityLinkButtonProps) {
+	const path = `/festivals/${festivalId}/activity/${activityId}`;
+	const [url, setUrl] = useState(path);
+
+	useEffect(() => {
+		setUrl(window.location.origin + path);
+	}, [path]);
+
+	return (
+		<CopyToClipboardButton
+			text={url}
+			toastLabel="Enlace copiado al portapapeles"
+			label="Copiar enlace para participar"
+		/>
+	);
+}

--- a/app/sign_in/[[...sign_in]]/page.tsx
+++ b/app/sign_in/[[...sign_in]]/page.tsx
@@ -1,9 +1,19 @@
 import { SignIn } from "@clerk/nextjs";
 
-export default function Page() {
-  return (
-    <div className="flex justify-center my-4">
-      <SignIn />
-    </div>
-  );
+type PageProps = {
+	searchParams: Promise<{ returnUrl?: string }>;
+};
+
+export default async function Page({ searchParams }: PageProps) {
+	const { returnUrl } = await searchParams;
+	const safeReturnUrl =
+		returnUrl?.startsWith("/") && !returnUrl.startsWith("//")
+			? returnUrl
+			: undefined;
+
+	return (
+		<div className="flex justify-center my-4">
+			<SignIn forceRedirectUrl={safeReturnUrl} />
+		</div>
+	);
 }

--- a/app/sign_in/[[...sign_in]]/page.tsx
+++ b/app/sign_in/[[...sign_in]]/page.tsx
@@ -1,14 +1,18 @@
 import { SignIn } from "@clerk/nextjs";
 
 type PageProps = {
-	searchParams: Promise<{ returnUrl?: string }>;
+	searchParams: Promise<{ returnUrl?: string | string[] }>;
 };
 
 export default async function Page({ searchParams }: PageProps) {
 	const { returnUrl } = await searchParams;
+	const rawReturnUrl = Array.isArray(returnUrl) ? returnUrl[0] : returnUrl;
+	const decodedUrl = rawReturnUrl
+		? decodeURIComponent(rawReturnUrl)
+		: undefined;
 	const safeReturnUrl =
-		returnUrl?.startsWith("/") && !returnUrl.startsWith("//")
-			? returnUrl
+		decodedUrl?.startsWith("/") && !decodedUrl.startsWith("//")
+			? decodedUrl
 			: undefined;
 
 	return (


### PR DESCRIPTION
…add copy-link for admins

- Redirect unauthenticated visitors to sign-in with a validated returnUrl; pass it through Clerk.
- Render passport, coupon book, sticker, and best-stand flows via dedicated page components; keep Sticker-Print as inline content with enrollment.
- Let admins copy the public activity URL from the summary card; refresh loading skeletons to match the new layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copy-to-clipboard button for sharing activity links.
  * Sign-in flow accepts return URLs and redirects back after authentication.
  * Activity pages render distinct, type-specific layouts (including redirects when sign-in is required).

* **Improvements**
  * Redesigned loading skeletons with clearer sections, spacing, and a full-width action placeholder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->