### PR TITLE
Feat/add stands management page

### DIFF
--- a/app/api/stands/actions.ts
+++ b/app/api/stands/actions.ts
@@ -5,6 +5,7 @@ import {
 	FestivalWithDates,
 	FestivalWithUserRequests,
 } from "@/app/lib/festivals/definitions";
+import { getCurrentUserProfile } from "@/app/lib/users/helpers";
 import { db } from "@/db";
 import {
 	reservationParticipants,
@@ -12,9 +13,44 @@ import {
 	stands,
 	users,
 } from "@/db/schema";
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, not } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+
+const standStatusZ = z.enum([
+	"available",
+	"held",
+	"reserved",
+	"confirmed",
+	"disabled",
+]);
+
+const standCategoryZ = z.enum([
+	"none",
+	"illustration",
+	"gastronomy",
+	"entrepreneurship",
+	"new_artist",
+]);
+
+function normalizeStandLabelForCompare(label: string | null | undefined) {
+	return label?.trim() ?? "";
+}
+
+/** Dashboard-only actions; require festival or global admin. */
+async function requireFestivalOrAdmin() {
+	const profile = await getCurrentUserProfile();
+	if (!profile) {
+		return { ok: false as const, message: "Inicia sesión para continuar." };
+	}
+	if (profile.role !== "festival_admin" && profile.role !== "admin") {
+		return {
+			ok: false as const,
+			message: "No tienes permisos para realizar esta acción.",
+		};
+	}
+	return { ok: true as const, profile };
+}
 
 export type Participant = typeof reservationParticipants.$inferSelect & {
 	user: typeof users.$inferSelect;
@@ -134,11 +170,9 @@ const updateStandSchema = z.object({
 	id: z.number().int().positive(),
 	label: z.string().min(1),
 	standNumber: z.coerce.number().int().min(1),
-	status: z.enum(["available", "held", "reserved", "confirmed", "disabled"]),
+	status: standStatusZ,
 	price: z.number().min(0).optional(),
-	standCategory: z
-		.enum(["none", "illustration", "gastronomy", "entrepreneurship", "new_artist"])
-		.optional(),
+	standCategory: standCategoryZ.optional(),
 });
 
 export async function updateStand(
@@ -222,5 +256,165 @@ export async function deleteStands(
 	} catch (error) {
 		console.error("Error deleting stands", error);
 		return { success: false, message: "Error al eliminar los espacios" };
+	}
+}
+
+const bulkUpdateStandsSchema = z.object({
+	festivalId: z.coerce.number().int().positive(),
+	standIds: z.array(z.coerce.number().int().positive()).min(1),
+	patch: z
+		.object({
+			status: standStatusZ.optional(),
+			label: z.string().min(1).optional(),
+			price: z.coerce.number().min(0).optional(),
+			standCategory: standCategoryZ.optional(),
+		})
+		.refine(
+			(p) =>
+				p.status !== undefined ||
+				p.label !== undefined ||
+				p.price !== undefined ||
+				p.standCategory !== undefined,
+			{ message: "Debes indicar al menos un cambio" },
+		),
+});
+
+export async function bulkUpdateStands(
+	input: z.infer<typeof bulkUpdateStandsSchema>,
+): Promise<{ success: boolean; message: string; updatedCount?: number }> {
+	const auth = await requireFestivalOrAdmin();
+	if (!auth.ok) {
+		return { success: false, message: auth.message };
+	}
+	try {
+		const parsed = bulkUpdateStandsSchema.parse(input);
+		const { festivalId, standIds, patch } = parsed;
+
+		const uniqueIds = [...new Set(standIds)];
+
+		const rows = await db
+			.select()
+			.from(stands)
+			.where(
+				and(eq(stands.festivalId, festivalId), inArray(stands.id, uniqueIds)),
+			);
+
+		if (rows.length !== uniqueIds.length) {
+			return {
+				success: false,
+				message: "Uno o más espacios no pertenecen a este festival.",
+			};
+		}
+
+		const setData: Record<string, unknown> = { updatedAt: new Date() };
+		if (patch.status !== undefined) setData.status = patch.status;
+		if (patch.label !== undefined) setData.label = patch.label;
+		if (patch.price !== undefined) setData.price = patch.price;
+		if (patch.standCategory !== undefined)
+			setData.standCategory = patch.standCategory;
+
+		await db
+			.update(stands)
+			.set(setData)
+			.where(
+				and(eq(stands.festivalId, festivalId), inArray(stands.id, uniqueIds)),
+			);
+
+		revalidatePath("/dashboard/festivals");
+		revalidatePath("/", "layout");
+
+		const n = uniqueIds.length;
+		return {
+			success: true,
+			message: `${n} espacio${n !== 1 ? "s" : ""} actualizado${n !== 1 ? "s" : ""}`,
+			updatedCount: n,
+		};
+	} catch (error) {
+		console.error("Error in bulkUpdateStands", error);
+		return { success: false, message: "Error al actualizar los espacios" };
+	}
+}
+
+const renumberStandsSequentiallySchema = z.object({
+	festivalId: z.coerce.number().int().positive(),
+	standIds: z.array(z.coerce.number().int().positive()).min(1),
+	startNumber: z.coerce.number().int().min(1),
+});
+
+export async function renumberStandsSequentially(
+	input: z.infer<typeof renumberStandsSequentiallySchema>,
+): Promise<{ success: boolean; message: string }> {
+	const auth = await requireFestivalOrAdmin();
+	if (!auth.ok) {
+		return { success: false, message: auth.message };
+	}
+	try {
+		const parsed = renumberStandsSequentiallySchema.parse(input);
+		const { festivalId, standIds, startNumber } = parsed;
+		const uniqueIds = [...new Set(standIds)];
+
+		const selectedRows = await db
+			.select()
+			.from(stands)
+			.where(
+				and(eq(stands.festivalId, festivalId), inArray(stands.id, uniqueIds)),
+			);
+
+		if (selectedRows.length !== uniqueIds.length) {
+			return {
+				success: false,
+				message: "Uno o más espacios no pertenecen a este festival.",
+			};
+		}
+
+		const sorted = [...selectedRows].sort(
+			(a, b) => a.standNumber - b.standNumber || a.id - b.id,
+		);
+
+		const newAssignments = sorted.map((row, i) => ({
+			id: row.id,
+			label: row.label,
+			standNumber: startNumber + i,
+		}));
+
+		const unselected = await db
+			.select()
+			.from(stands)
+			.where(
+				and(
+					eq(stands.festivalId, festivalId),
+					not(inArray(stands.id, uniqueIds)),
+				),
+			);
+
+		for (const a of newAssignments) {
+			const aLabel = normalizeStandLabelForCompare(a.label);
+			for (const u of unselected) {
+				if (normalizeStandLabelForCompare(u.label) !== aLabel) continue;
+				if (u.standNumber === a.standNumber) {
+					return {
+						success: false,
+						message: `El número ${a.standNumber} ya está en uso para la etiqueta «${aLabel || "(vacía)"}» en otro espacio.`,
+					};
+				}
+			}
+		}
+
+		await db.transaction(async (tx) => {
+			for (const a of newAssignments) {
+				await tx
+					.update(stands)
+					.set({ standNumber: a.standNumber, updatedAt: new Date() })
+					.where(eq(stands.id, a.id));
+			}
+		});
+
+		revalidatePath("/dashboard/festivals");
+		revalidatePath("/", "layout");
+
+		return { success: true, message: "Números de espacio actualizados" };
+	} catch (error) {
+		console.error("Error in renumberStandsSequentially", error);
+		return { success: false, message: "Error al renumerar los espacios" };
 	}
 }

--- a/app/api/stands/actions.ts
+++ b/app/api/stands/actions.ts
@@ -363,54 +363,54 @@ export async function renumberStandsSequentially(
 		const { festivalId, standIds, startNumber } = parsed;
 		const uniqueIds = [...new Set(standIds)];
 
-		const selectedRows = await db
-			.select()
-			.from(stands)
-			.where(
-				and(eq(stands.festivalId, festivalId), inArray(stands.id, uniqueIds)),
+		await db.transaction(async (tx) => {
+			const selectedRows = await tx
+				.select()
+				.from(stands)
+				.where(
+					and(eq(stands.festivalId, festivalId), inArray(stands.id, uniqueIds)),
+				);
+
+			if (selectedRows.length !== uniqueIds.length) {
+				return {
+					success: false,
+					message: "Uno o más espacios no pertenecen a este festival.",
+				};
+			}
+
+			const sorted = [...selectedRows].sort(
+				(a, b) => a.standNumber - b.standNumber || a.id - b.id,
 			);
 
-		if (selectedRows.length !== uniqueIds.length) {
-			return {
-				success: false,
-				message: "Uno o más espacios no pertenecen a este festival.",
-			};
-		}
+			const newAssignments = sorted.map((row, i) => ({
+				id: row.id,
+				label: row.label,
+				standNumber: startNumber + i,
+			}));
 
-		const sorted = [...selectedRows].sort(
-			(a, b) => a.standNumber - b.standNumber || a.id - b.id,
-		);
+			const unselected = await tx
+				.select()
+				.from(stands)
+				.where(
+					and(
+						eq(stands.festivalId, festivalId),
+						not(inArray(stands.id, uniqueIds)),
+					),
+				);
 
-		const newAssignments = sorted.map((row, i) => ({
-			id: row.id,
-			label: row.label,
-			standNumber: startNumber + i,
-		}));
-
-		const unselected = await db
-			.select()
-			.from(stands)
-			.where(
-				and(
-					eq(stands.festivalId, festivalId),
-					not(inArray(stands.id, uniqueIds)),
-				),
-			);
-
-		for (const a of newAssignments) {
-			const aLabel = normalizeStandLabelForCompare(a.label);
-			for (const u of unselected) {
-				if (normalizeStandLabelForCompare(u.label) !== aLabel) continue;
-				if (u.standNumber === a.standNumber) {
-					return {
-						success: false,
-						message: `El número ${a.standNumber} ya está en uso para la etiqueta «${aLabel || "(vacía)"}» en otro espacio.`,
-					};
+			for (const a of newAssignments) {
+				const aLabel = normalizeStandLabelForCompare(a.label);
+				for (const u of unselected) {
+					if (normalizeStandLabelForCompare(u.label) !== aLabel) continue;
+					if (u.standNumber === a.standNumber) {
+						return {
+							success: false,
+							message: `El número ${a.standNumber} ya está en uso para la etiqueta «${aLabel || "(vacía)"}» en otro espacio.`,
+						};
+					}
 				}
 			}
-		}
 
-		await db.transaction(async (tx) => {
 			for (const a of newAssignments) {
 				await tx
 					.update(stands)
@@ -420,7 +420,6 @@ export async function renumberStandsSequentially(
 		});
 
 		revalidatePath("/dashboard/festivals");
-		revalidatePath("/", "layout");
 
 		return { success: true, message: "Números de espacio actualizados" };
 	} catch (error) {

--- a/app/api/stands/actions.ts
+++ b/app/api/stands/actions.ts
@@ -292,20 +292,6 @@ export async function bulkUpdateStands(
 
 		const uniqueIds = [...new Set(standIds)];
 
-		const rows = await db
-			.select()
-			.from(stands)
-			.where(
-				and(eq(stands.festivalId, festivalId), inArray(stands.id, uniqueIds)),
-			);
-
-		if (rows.length !== uniqueIds.length) {
-			return {
-				success: false,
-				message: "Uno o más espacios no pertenecen a este festival.",
-			};
-		}
-
 		const setData: Record<string, unknown> = { updatedAt: new Date() };
 		if (patch.status !== undefined) setData.status = patch.status;
 		if (patch.label !== undefined) setData.label = patch.label;
@@ -313,17 +299,41 @@ export async function bulkUpdateStands(
 		if (patch.standCategory !== undefined)
 			setData.standCategory = patch.standCategory;
 
-		await db
-			.update(stands)
-			.set(setData)
-			.where(
-				and(eq(stands.festivalId, festivalId), inArray(stands.id, uniqueIds)),
-			);
+		const result = await db.transaction(async (tx) => {
+			const rows = await tx
+				.select({ id: stands.id })
+				.from(stands)
+				.where(
+					and(eq(stands.festivalId, festivalId), inArray(stands.id, uniqueIds)),
+				)
+				.for("update");
+
+			if (rows.length !== uniqueIds.length) {
+				return {
+					success: false as const,
+					message: "Uno o más espacios no pertenecen a este festival.",
+				};
+			}
+
+			const updated = await tx
+				.update(stands)
+				.set(setData)
+				.where(
+					and(eq(stands.festivalId, festivalId), inArray(stands.id, uniqueIds)),
+				)
+				.returning({ id: stands.id });
+
+			return { success: true as const, updatedCount: updated.length };
+		});
+
+		if (!result.success) {
+			return { success: false, message: result.message };
+		}
 
 		revalidatePath("/dashboard/festivals");
 		revalidatePath("/", "layout");
 
-		const n = uniqueIds.length;
+		const n = result.updatedCount;
 		return {
 			success: true,
 			message: `${n} espacio${n !== 1 ? "s" : ""} actualizado${n !== 1 ? "s" : ""}`,

--- a/app/components/festivals/festival-card.tsx
+++ b/app/components/festivals/festival-card.tsx
@@ -62,6 +62,13 @@ export default function FestivalCard({
 					>
 						Editor del mapa
 					</RedirectButton>
+					<RedirectButton
+						variant="outline"
+						size="sm"
+						href={`/dashboard/festivals/${festival.id}/stands/manage`}
+					>
+						Gestionar espacios
+					</RedirectButton>
 				</div>
 				<FestivalSwitches festival={festival} />
 				<div className="p-4 border rounded-lg space-y-3">

--- a/app/components/maps/admin/stand-manage-table.tsx
+++ b/app/components/maps/admin/stand-manage-table.tsx
@@ -1,0 +1,755 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useMemo, useState } from "react";
+import { toast } from "sonner";
+import Link from "next/link";
+import { ListTree, X } from "lucide-react";
+
+import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import {
+	bulkUpdateStands,
+	deleteStands,
+	renumberStandsSequentially,
+	updateStand,
+} from "@/app/api/stands/actions";
+import { FestivalSectorWithStandsWithReservationsWithParticipants } from "@/app/lib/festival_sectors/definitions";
+import { Badge } from "@/app/components/ui/badge";
+import { Button } from "@/app/components/ui/button";
+import { Checkbox } from "@/app/components/ui/checkbox";
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/app/components/ui/dialog";
+import { Input } from "@/app/components/ui/input";
+import { Label } from "@/app/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/app/components/ui/select";
+import { StandStatusBadge } from "@/app/components/stands/status-badge";
+
+const STAND_STATUS_OPTIONS = [
+	{ value: "available", label: "Disponible" },
+	{ value: "held", label: "En espera" },
+	{ value: "reserved", label: "Reservado" },
+	{ value: "confirmed", label: "Confirmado" },
+	{ value: "disabled", label: "Deshabilitado" },
+] as const;
+
+type StandStatus = (typeof STAND_STATUS_OPTIONS)[number]["value"];
+
+const CATEGORY_OPTIONS = [
+	{ value: "none", label: "Ninguna" },
+	{ value: "illustration", label: "Ilustración" },
+	{ value: "gastronomy", label: "Gastronomía" },
+	{ value: "entrepreneurship", label: "Emprendimiento" },
+	{ value: "new_artist", label: "Artista nuevo" },
+] as const;
+
+type StandCategory = (typeof CATEGORY_OPTIONS)[number]["value"];
+
+function formatPrice(amount: number) {
+	return new Intl.NumberFormat("es-BO", {
+		style: "currency",
+		currency: "BOB",
+		minimumFractionDigits: 2,
+	}).format(amount);
+}
+
+function sortStands(
+	list: StandWithReservationsWithParticipants[],
+): StandWithReservationsWithParticipants[] {
+	return [...list].sort(
+		(a, b) =>
+			a.standCategory.localeCompare(b.standCategory) ||
+			a.standNumber - b.standNumber ||
+			a.id - b.id,
+	);
+}
+
+type Props = {
+	festivalId: number;
+	festivalName: string;
+	sectors: FestivalSectorWithStandsWithReservationsWithParticipants[];
+};
+
+export default function StandManageTable({
+	festivalId,
+	festivalName,
+	sectors,
+}: Props) {
+	const router = useRouter();
+	const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+	const [bulkStatusOpen, setBulkStatusOpen] = useState(false);
+	const [bulkStatus, setBulkStatus] = useState<StandStatus>("available");
+
+	const [bulkPriceOpen, setBulkPriceOpen] = useState(false);
+	const [bulkPrice, setBulkPrice] = useState(0);
+
+	const [bulkLabelOpen, setBulkLabelOpen] = useState(false);
+	const [bulkLabel, setBulkLabel] = useState("");
+
+	const [bulkCategoryOpen, setBulkCategoryOpen] = useState(false);
+	const [bulkCategory, setBulkCategory] =
+		useState<StandCategory>("illustration");
+
+	const [renumberOpen, setRenumberOpen] = useState(false);
+	const [renumberStart, setRenumberStart] = useState(1);
+
+	const [deleteOpen, setDeleteOpen] = useState(false);
+
+	const [singleOpen, setSingleOpen] = useState(false);
+	const [editStand, setEditStand] =
+		useState<StandWithReservationsWithParticipants | null>(null);
+	const [editLabel, setEditLabel] = useState("");
+	const [editStandNumber, setEditStandNumber] = useState(1);
+	const [editStatus, setEditStatus] = useState<StandStatus>("available");
+	const [editPrice, setEditPrice] = useState(0);
+	const [editCategory, setEditCategory] =
+		useState<StandCategory>("illustration");
+	const [isSaving, setIsSaving] = useState(false);
+	const [pendingBulk, setPendingBulk] = useState(false);
+
+	const allStands = useMemo(() => {
+		const out: StandWithReservationsWithParticipants[] = [];
+		for (const s of sectors) {
+			for (const st of s.stands) out.push(st);
+		}
+		return out;
+	}, [sectors]);
+
+	const standById = useMemo(() => {
+		const m = new Map<number, StandWithReservationsWithParticipants>();
+		for (const s of allStands) m.set(s.id, s);
+		return m;
+	}, [allStands]);
+
+	const selectedCount = selectedIds.size;
+	const selectedIdsArr = useMemo(() => Array.from(selectedIds), [selectedIds]);
+
+	const selectedHaveReservation = useMemo(() => {
+		for (const id of selectedIds) {
+			const st = standById.get(id);
+			if (st && st.reservations.length > 0) return true;
+		}
+		return false;
+	}, [selectedIds, standById]);
+
+	const toggleStand = (id: number) => {
+		setSelectedIds((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
+	};
+
+	const toggleSector = (
+		sectorStands: StandWithReservationsWithParticipants[],
+	) => {
+		const ids = sectorStands.map((s) => s.id);
+		setSelectedIds((prev) => {
+			const next = new Set(prev);
+			const allOn = ids.length > 0 && ids.every((id) => next.has(id));
+			if (allOn) ids.forEach((id) => next.delete(id));
+			else ids.forEach((id) => next.add(id));
+			return next;
+		});
+	};
+
+	const clearSelection = useCallback(() => {
+		setSelectedIds(new Set());
+	}, []);
+
+	const runBulk = async (
+		fn: () => Promise<{ success: boolean; message: string }>,
+		onSuccess?: () => void,
+	) => {
+		if (selectedIds.size === 0) return;
+		setPendingBulk(true);
+		try {
+			const res = await fn();
+			if (res.success) {
+				toast.success(res.message);
+				onSuccess?.();
+				clearSelection();
+				router.refresh();
+			} else {
+				toast.error(res.message);
+			}
+		} finally {
+			setPendingBulk(false);
+		}
+	};
+
+	const openSingleEdit = (stand: StandWithReservationsWithParticipants) => {
+		setEditStand(stand);
+		setEditLabel(stand.label ?? "");
+		setEditStandNumber(stand.standNumber);
+		setEditStatus(stand.status as StandStatus);
+		setEditPrice(stand.price ?? 0);
+		setEditCategory(stand.standCategory as StandCategory);
+		setSingleOpen(true);
+	};
+
+	const handleSingleSave = async () => {
+		if (!editStand || !editLabel.trim()) return;
+		setIsSaving(true);
+		try {
+			const res = await updateStand({
+				id: editStand.id,
+				label: editLabel.trim(),
+				standNumber: editStandNumber,
+				status: editStatus,
+				price: editPrice,
+				standCategory: editCategory,
+			});
+			if (res.success) {
+				toast.success(res.message);
+				setSingleOpen(false);
+				setEditStand(null);
+				router.refresh();
+			} else {
+				toast.error(res.message);
+			}
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	return (
+		<>
+			<div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+				<div>
+					<h1 className="text-2xl font-bold md:text-3xl">
+						Gestión de espacios — {festivalName}
+					</h1>
+					<p className="mt-1 text-sm text-muted-foreground">
+						Edita metadatos de uno o varios stands. Selecciona filas y usa las
+						acciones inferiores. El orden al renumerar es: número de stand
+						ascendente y luego ID.
+					</p>
+				</div>
+				<Button variant="outline" size="sm" asChild>
+					<Link href={`/dashboard/festivals/${festivalId}/stands`}>
+						<ListTree className="mr-2 h-4 w-4" />
+						Ir al editor de mapa
+					</Link>
+				</Button>
+			</div>
+
+			<div className="flex flex-col gap-8 pb-32">
+				{sectors.map((sector) => {
+					const sectorStands = sortStands(sector.stands);
+					const sectorIds = sectorStands.map((s) => s.id);
+					const allSectorSelected =
+						sectorIds.length > 0 &&
+						sectorIds.every((id) => selectedIds.has(id));
+					const someSectorSelected = sectorIds.some((id) =>
+						selectedIds.has(id),
+					);
+
+					return (
+						<div key={sector.id}>
+							<div className="mb-3 flex items-center gap-3">
+								<Checkbox
+									checked={
+										allSectorSelected
+											? true
+											: someSectorSelected
+												? "indeterminate"
+												: false
+									}
+									onCheckedChange={() => toggleSector(sectorStands)}
+									aria-label={`Seleccionar todos en ${sector.name}`}
+								/>
+								<h2 className="text-base font-semibold">{sector.name}</h2>
+							</div>
+
+							{sectorStands.length === 0 ? (
+								<p className="pl-7 text-sm text-muted-foreground">
+									Sin stands en este sector
+								</p>
+							) : (
+								<div className="divide-y rounded-lg border">
+									{sectorStands.map((stand) => {
+										const isSelected = selectedIds.has(stand.id);
+										const hasRes = stand.reservations.length > 0;
+										const standLabel = `${stand.label ?? ""}${stand.standNumber}`;
+
+										return (
+											<div
+												key={stand.id}
+												className={`flex flex-wrap items-center gap-3 px-4 py-3 transition-colors ${
+													isSelected ? "bg-muted/50" : ""
+												}`}
+											>
+												<Checkbox
+													checked={isSelected}
+													onCheckedChange={() => toggleStand(stand.id)}
+													aria-label={`Seleccionar stand ${standLabel}`}
+												/>
+												<div className="min-w-0 flex-1">
+													<div className="flex flex-wrap items-center gap-2">
+														<span className="shrink-0 text-sm font-medium">
+															Stand {standLabel}
+														</span>
+														<StandStatusBadge status={stand.status} />
+														<span className="text-xs capitalize text-muted-foreground">
+															{stand.standCategory}
+														</span>
+														{hasRes && (
+															<Badge variant="secondary" className="text-xs">
+																Con reserva
+															</Badge>
+														)}
+													</div>
+													<p className="text-xs text-muted-foreground">
+														{formatPrice(stand.price ?? 0)}
+													</p>
+												</div>
+												<Button
+													variant="outline"
+													size="sm"
+													onClick={() => openSingleEdit(stand)}
+												>
+													Editar
+												</Button>
+											</div>
+										);
+									})}
+								</div>
+							)}
+						</div>
+					);
+				})}
+			</div>
+
+			{selectedCount > 0 && (
+				<div className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background px-4 py-3 shadow-lg">
+					<div className="mx-auto flex max-w-3xl flex-wrap items-center gap-2">
+						<span className="text-sm font-medium">
+							{selectedCount} espacio{selectedCount !== 1 ? "s" : ""}{" "}
+							seleccionado
+							{selectedCount !== 1 ? "s" : ""}
+						</span>
+						<div className="ml-auto flex flex-wrap items-center gap-2">
+							<Button
+								variant="secondary"
+								size="sm"
+								disabled={pendingBulk}
+								onClick={() => setBulkStatusOpen(true)}
+							>
+								Estado
+							</Button>
+							<Button
+								variant="secondary"
+								size="sm"
+								disabled={pendingBulk}
+								onClick={() => setBulkPriceOpen(true)}
+							>
+								Precio
+							</Button>
+							<Button
+								variant="secondary"
+								size="sm"
+								disabled={pendingBulk}
+								onClick={() => setBulkLabelOpen(true)}
+							>
+								Etiqueta
+							</Button>
+							<Button
+								variant="secondary"
+								size="sm"
+								disabled={pendingBulk}
+								onClick={() => setBulkCategoryOpen(true)}
+							>
+								Categoría
+							</Button>
+							<Button
+								variant="secondary"
+								size="sm"
+								disabled={pendingBulk}
+								onClick={() => setRenumberOpen(true)}
+							>
+								Renumerar
+							</Button>
+							<Button
+								variant="destructive"
+								size="sm"
+								disabled={pendingBulk || selectedHaveReservation}
+								title={
+									selectedHaveReservation
+										? "No se pueden eliminar stands con reservas"
+										: undefined
+								}
+								onClick={() => setDeleteOpen(true)}
+							>
+								Eliminar
+							</Button>
+							<Button variant="ghost" size="sm" onClick={clearSelection}>
+								<X className="mr-1 h-4 w-4" />
+								Limpiar
+							</Button>
+						</div>
+					</div>
+				</div>
+			)}
+
+			<Dialog open={bulkStatusOpen} onOpenChange={setBulkStatusOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Cambiar estado ({selectedCount})</DialogTitle>
+					</DialogHeader>
+					<div className="grid gap-2">
+						<Label>Estado</Label>
+						<Select
+							value={bulkStatus}
+							onValueChange={(v) => setBulkStatus(v as StandStatus)}
+						>
+							<SelectTrigger>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{STAND_STATUS_OPTIONS.map((o) => (
+									<SelectItem key={o.value} value={o.value}>
+										{o.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setBulkStatusOpen(false)}>
+							Cancelar
+						</Button>
+						<Button
+							disabled={pendingBulk}
+							onClick={() => {
+								void runBulk(
+									() =>
+										bulkUpdateStands({
+											festivalId,
+											standIds: selectedIdsArr,
+											patch: { status: bulkStatus },
+										}),
+									() => setBulkStatusOpen(false),
+								);
+							}}
+						>
+							Guardar
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={bulkPriceOpen} onOpenChange={setBulkPriceOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Establecer precio ({selectedCount})</DialogTitle>
+					</DialogHeader>
+					<div className="grid gap-2">
+						<Label htmlFor="bulk-price">Precio (BOB)</Label>
+						<Input
+							id="bulk-price"
+							type="number"
+							min={0}
+							step={1}
+							value={bulkPrice}
+							onChange={(e) =>
+								setBulkPrice(Math.max(0, Number(e.target.value) || 0))
+							}
+						/>
+					</div>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setBulkPriceOpen(false)}>
+							Cancelar
+						</Button>
+						<Button
+							disabled={pendingBulk}
+							onClick={() => {
+								void runBulk(
+									() =>
+										bulkUpdateStands({
+											festivalId,
+											standIds: selectedIdsArr,
+											patch: { price: bulkPrice },
+										}),
+									() => setBulkPriceOpen(false),
+								);
+							}}
+						>
+							Guardar
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={bulkLabelOpen} onOpenChange={setBulkLabelOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Establecer etiqueta ({selectedCount})</DialogTitle>
+					</DialogHeader>
+					<p className="text-sm text-muted-foreground">
+						Se aplicará el mismo prefijo de etiqueta a todos los stands
+						seleccionados (p. ej. &quot;S&quot;).
+					</p>
+					<div className="grid gap-2">
+						<Label htmlFor="bulk-label">Etiqueta</Label>
+						<Input
+							id="bulk-label"
+							value={bulkLabel}
+							onChange={(e) => setBulkLabel(e.target.value)}
+						/>
+					</div>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setBulkLabelOpen(false)}>
+							Cancelar
+						</Button>
+						<Button
+							disabled={pendingBulk || !bulkLabel.trim()}
+							onClick={() => {
+								const label = bulkLabel.trim();
+								void runBulk(
+									() =>
+										bulkUpdateStands({
+											festivalId,
+											standIds: selectedIdsArr,
+											patch: { label },
+										}),
+									() => {
+										setBulkLabelOpen(false);
+										setBulkLabel("");
+									},
+								);
+							}}
+						>
+							Guardar
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={bulkCategoryOpen} onOpenChange={setBulkCategoryOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Cambiar categoría ({selectedCount})</DialogTitle>
+					</DialogHeader>
+					<div className="grid gap-2">
+						<Label>Categoría</Label>
+						<Select
+							value={bulkCategory}
+							onValueChange={(v) => setBulkCategory(v as StandCategory)}
+						>
+							<SelectTrigger>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{CATEGORY_OPTIONS.map((o) => (
+									<SelectItem key={o.value} value={o.value}>
+										{o.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setBulkCategoryOpen(false)}
+						>
+							Cancelar
+						</Button>
+						<Button
+							disabled={pendingBulk}
+							onClick={() => {
+								void runBulk(
+									() =>
+										bulkUpdateStands({
+											festivalId,
+											standIds: selectedIdsArr,
+											patch: { standCategory: bulkCategory },
+										}),
+									() => setBulkCategoryOpen(false),
+								);
+							}}
+						>
+							Guardar
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={renumberOpen} onOpenChange={setRenumberOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Renumerar en secuencia ({selectedCount})</DialogTitle>
+					</DialogHeader>
+					<p className="text-sm text-muted-foreground">
+						El primer stand seleccionado (según el orden: número de stand, luego
+						ID) recibirá el número indicado; los siguientes serán consecutivos.
+					</p>
+					<div className="grid gap-2">
+						<Label htmlFor="renumber-start">Número inicial</Label>
+						<Input
+							id="renumber-start"
+							type="number"
+							min={1}
+							value={renumberStart}
+							onChange={(e) =>
+								setRenumberStart(Math.max(1, Number(e.target.value) || 1))
+							}
+						/>
+					</div>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setRenumberOpen(false)}>
+							Cancelar
+						</Button>
+						<Button
+							disabled={pendingBulk}
+							onClick={() => {
+								void runBulk(
+									() =>
+										renumberStandsSequentially({
+											festivalId,
+											standIds: selectedIdsArr,
+											startNumber: renumberStart,
+										}),
+									() => setRenumberOpen(false),
+								);
+							}}
+						>
+							Aplicar
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Eliminar {selectedCount} espacio(s)</DialogTitle>
+					</DialogHeader>
+					<p className="text-sm text-muted-foreground">
+						Esta acción no se puede deshacer. No puedes eliminar stands con
+						reservas.
+					</p>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setDeleteOpen(false)}>
+							Cancelar
+						</Button>
+						<Button
+							variant="destructive"
+							disabled={pendingBulk || selectedHaveReservation}
+							onClick={() => {
+								void runBulk(
+									() => deleteStands(selectedIdsArr),
+									() => setDeleteOpen(false),
+								);
+							}}
+						>
+							Eliminar
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={singleOpen} onOpenChange={setSingleOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Editar espacio</DialogTitle>
+					</DialogHeader>
+					<div className="grid gap-4 py-2">
+						<div className="grid gap-2">
+							<Label htmlFor="single-label">Etiqueta</Label>
+							<Input
+								id="single-label"
+								value={editLabel}
+								onChange={(e) => setEditLabel(e.target.value)}
+							/>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="single-number">Número</Label>
+							<Input
+								id="single-number"
+								type="number"
+								min={1}
+								value={editStandNumber}
+								onChange={(e) =>
+									setEditStandNumber(Math.max(1, Number(e.target.value) || 1))
+								}
+							/>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="single-status">Estado</Label>
+							<Select
+								value={editStatus}
+								onValueChange={(v) => setEditStatus(v as StandStatus)}
+							>
+								<SelectTrigger id="single-status">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{STAND_STATUS_OPTIONS.map((o) => (
+										<SelectItem key={o.value} value={o.value}>
+											{o.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						<div className="grid grid-cols-2 gap-4">
+							<div className="grid gap-2">
+								<Label htmlFor="single-price">Precio</Label>
+								<Input
+									id="single-price"
+									type="number"
+									min={0}
+									step={1}
+									value={editPrice}
+									onChange={(e) =>
+										setEditPrice(Math.max(0, Number(e.target.value) || 0))
+									}
+								/>
+							</div>
+							<div className="grid gap-2">
+								<Label htmlFor="single-cat">Categoría</Label>
+								<Select
+									value={editCategory}
+									onValueChange={(v) => setEditCategory(v as StandCategory)}
+								>
+									<SelectTrigger id="single-cat">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{CATEGORY_OPTIONS.map((o) => (
+											<SelectItem key={o.value} value={o.value}>
+												{o.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							onClick={handleSingleSave}
+							disabled={isSaving || !editLabel.trim()}
+						>
+							{isSaving ? "Guardando…" : "Guardar"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}

--- a/app/components/maps/admin/stand-manage-table.tsx
+++ b/app/components/maps/admin/stand-manage-table.tsx
@@ -3,8 +3,17 @@
 import { ListTree } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useOptimistic,
+	useState,
+	useTransition,
+} from "react";
 import { toast } from "sonner";
+
+import { cn } from "@/lib/utils";
 
 import { bulkUpdateStands } from "@/app/api/stands/actions";
 import {
@@ -87,6 +96,9 @@ export default function StandManageTable({
 			: ALL_SECTOR_VALUE;
 	}, [urlSector, liveSectors]);
 
+	const [isTabPending, startTabTransition] = useTransition();
+	const [optimisticTab, setOptimisticTab] = useOptimistic(activeTab);
+
 	const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 	const [editStand, setEditStand] =
 		useState<StandWithReservationsWithParticipants | null>(null);
@@ -110,10 +122,10 @@ export default function StandManageTable({
 	}, [liveSectors]);
 
 	const rowsForTab = useMemo(() => {
-		if (activeTab === ALL_SECTOR_VALUE) return allRows;
-		const sectorId = Number(activeTab);
+		if (optimisticTab === ALL_SECTOR_VALUE) return allRows;
+		const sectorId = Number(optimisticTab);
 		return allRows.filter((r) => r.sectorId === sectorId);
-	}, [allRows, activeTab]);
+	}, [allRows, optimisticTab]);
 
 	const rowsById = useMemo(() => {
 		const m = new Map<number, StandRow>();
@@ -138,12 +150,16 @@ export default function StandManageTable({
 	);
 
 	function handleTabChange(value: string) {
+		if (value === optimisticTab) return;
 		setSelectedIds(new Set());
-		const params = new URLSearchParams(searchParams.toString());
-		if (value === ALL_SECTOR_VALUE) params.delete("sector");
-		else params.set("sector", value);
-		const query = params.toString();
-		router.replace(query ? `?${query}` : "?", { scroll: false });
+		startTabTransition(() => {
+			setOptimisticTab(value);
+			const params = new URLSearchParams(searchParams.toString());
+			if (value === ALL_SECTOR_VALUE) params.delete("sector");
+			else params.set("sector", value);
+			const query = params.toString();
+			router.replace(query ? `?${query}` : "?", { scroll: false });
+		});
 	}
 
 	const isSelected = useCallback(
@@ -250,7 +266,7 @@ export default function StandManageTable({
 				options: reservation,
 			},
 		];
-		if (activeTab === ALL_SECTOR_VALUE) {
+		if (optimisticTab === ALL_SECTOR_VALUE) {
 			base.unshift({
 				columnId: "sector",
 				label: "Sector",
@@ -261,7 +277,7 @@ export default function StandManageTable({
 			});
 		}
 		return base;
-	}, [liveSectors, activeTab]);
+	}, [liveSectors, optimisticTab]);
 
 	const bulkMenu = (
 		<StandBulkActionsMenu
@@ -275,6 +291,7 @@ export default function StandManageTable({
 			}}
 			onOptimisticStatus={onOptimisticStatus}
 			onOptimisticCategory={onOptimisticCategory}
+			onFailure={() => router.refresh()}
 		/>
 	);
 
@@ -321,7 +338,11 @@ export default function StandManageTable({
 				</CardContent>
 			</Card>
 
-			<Tabs value={activeTab} onValueChange={handleTabChange} className="mb-4">
+			<Tabs
+				value={optimisticTab}
+				onValueChange={handleTabChange}
+				className="mb-4"
+			>
 				<TabsList className="flex h-auto w-full flex-wrap justify-start gap-1 bg-muted p-1">
 					<TabsTrigger value={ALL_SECTOR_VALUE}>
 						Todos
@@ -356,24 +377,31 @@ export default function StandManageTable({
 				</div>
 			)}
 
-			<div className="hidden md:block">
-				<DataTable
-					key={activeTab}
-					columns={columns}
-					data={rowsForTab}
-					columnTitles={columnTitles}
-					filters={tableFilters}
-				/>
-			</div>
+			<div
+				className={cn(
+					"transition-opacity",
+					isTabPending && "opacity-60 pointer-events-none",
+				)}
+			>
+				<div className="hidden md:block">
+					<DataTable
+						key={optimisticTab}
+						columns={columns}
+						data={rowsForTab}
+						columnTitles={columnTitles}
+						filters={tableFilters}
+					/>
+				</div>
 
-			<div className="block pb-32 md:hidden">
-				<StandManageCardList
-					stands={rowsForTab}
-					selectedIds={selectedIds}
-					onToggle={onToggle}
-					onToggleAll={onToggleAll}
-					onEdit={onEdit}
-				/>
+				<div className="block pb-32 md:hidden">
+					<StandManageCardList
+						stands={rowsForTab}
+						selectedIds={selectedIds}
+						onToggle={onToggle}
+						onToggleAll={onToggleAll}
+						onEdit={onEdit}
+					/>
+				</div>
 			</div>
 
 			{selectedIds.size > 0 && (

--- a/app/components/maps/admin/stand-manage-table.tsx
+++ b/app/components/maps/admin/stand-manage-table.tsx
@@ -68,7 +68,7 @@ function sortStands(
 ): StandWithReservationsWithParticipants[] {
 	return [...list].sort(
 		(a, b) =>
-			a.standCategory.localeCompare(b.standCategory) ||
+			(a.standCategory ?? "").localeCompare(b.standCategory ?? "") ||
 			a.standNumber - b.standNumber ||
 			a.id - b.id,
 	);

--- a/app/components/maps/admin/stand-manage-table.tsx
+++ b/app/components/maps/admin/stand-manage-table.tsx
@@ -7,7 +7,6 @@ import {
 	useCallback,
 	useEffect,
 	useMemo,
-	useOptimistic,
 	useState,
 	useTransition,
 } from "react";
@@ -21,6 +20,7 @@ import {
 	StandWithReservationsWithParticipants,
 } from "@/app/api/stands/definitions";
 import { FestivalSectorWithStandsWithReservationsWithParticipants } from "@/app/lib/festival_sectors/definitions";
+import { useMediaQuery } from "@/app/hooks/use-media-query";
 import { Button } from "@/app/components/ui/button";
 import { Card, CardContent } from "@/app/components/ui/card";
 import { DataTable } from "@/app/components/ui/data_table/data-table";
@@ -82,6 +82,7 @@ export default function StandManageTable({
 }: Props) {
 	const router = useRouter();
 	const searchParams = useSearchParams();
+	const isDesktop = useMediaQuery("(min-width: 768px)");
 
 	const [liveSectors, setLiveSectors] = useState(sectors);
 	useEffect(() => {
@@ -89,7 +90,7 @@ export default function StandManageTable({
 	}, [sectors]);
 
 	const urlSector = searchParams.get("sector") ?? ALL_SECTOR_VALUE;
-	const activeTab = useMemo(() => {
+	const resolvedUrlTab = useMemo(() => {
 		if (urlSector === ALL_SECTOR_VALUE) return ALL_SECTOR_VALUE;
 		return liveSectors.some((s) => String(s.id) === urlSector)
 			? urlSector
@@ -97,7 +98,10 @@ export default function StandManageTable({
 	}, [urlSector, liveSectors]);
 
 	const [isTabPending, startTabTransition] = useTransition();
-	const [optimisticTab, setOptimisticTab] = useOptimistic(activeTab);
+	const [activeTab, setActiveTab] = useState(resolvedUrlTab);
+	useEffect(() => {
+		setActiveTab(resolvedUrlTab);
+	}, [resolvedUrlTab]);
 
 	const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 	const [editStand, setEditStand] =
@@ -122,10 +126,10 @@ export default function StandManageTable({
 	}, [liveSectors]);
 
 	const rowsForTab = useMemo(() => {
-		if (optimisticTab === ALL_SECTOR_VALUE) return allRows;
-		const sectorId = Number(optimisticTab);
+		if (activeTab === ALL_SECTOR_VALUE) return allRows;
+		const sectorId = Number(activeTab);
 		return allRows.filter((r) => r.sectorId === sectorId);
-	}, [allRows, optimisticTab]);
+	}, [allRows, activeTab]);
 
 	const rowsById = useMemo(() => {
 		const m = new Map<number, StandRow>();
@@ -150,10 +154,10 @@ export default function StandManageTable({
 	);
 
 	function handleTabChange(value: string) {
-		if (value === optimisticTab) return;
+		if (value === activeTab) return;
 		setSelectedIds(new Set());
+		setActiveTab(value);
 		startTabTransition(() => {
-			setOptimisticTab(value);
 			const params = new URLSearchParams(searchParams.toString());
 			if (value === ALL_SECTOR_VALUE) params.delete("sector");
 			else params.set("sector", value);
@@ -266,7 +270,7 @@ export default function StandManageTable({
 				options: reservation,
 			},
 		];
-		if (optimisticTab === ALL_SECTOR_VALUE) {
+		if (activeTab === ALL_SECTOR_VALUE) {
 			base.unshift({
 				columnId: "sector",
 				label: "Sector",
@@ -277,7 +281,7 @@ export default function StandManageTable({
 			});
 		}
 		return base;
-	}, [liveSectors, optimisticTab]);
+	}, [liveSectors, activeTab]);
 
 	const bulkMenu = (
 		<StandBulkActionsMenu
@@ -339,7 +343,7 @@ export default function StandManageTable({
 			</Card>
 
 			<Tabs
-				value={optimisticTab}
+				value={activeTab}
 				onValueChange={handleTabChange}
 				className="mb-4"
 			>
@@ -371,43 +375,50 @@ export default function StandManageTable({
 				</TabsList>
 			</Tabs>
 
-			{selectedIds.size > 0 && (
-				<div className="mb-3 hidden rounded-lg border bg-background p-3 md:block">
-					{bulkMenu}
-				</div>
-			)}
-
-			<div
-				className={cn(
-					"transition-opacity",
-					isTabPending && "opacity-60 pointer-events-none",
-				)}
-			>
-				<div className="hidden md:block">
-					<DataTable
-						key={optimisticTab}
-						columns={columns}
-						data={rowsForTab}
-						columnTitles={columnTitles}
-						filters={tableFilters}
-					/>
-				</div>
-
-				<div className="block pb-32 md:hidden">
-					<StandManageCardList
-						stands={rowsForTab}
-						selectedIds={selectedIds}
-						onToggle={onToggle}
-						onToggleAll={onToggleAll}
-						onEdit={onEdit}
-					/>
-				</div>
-			</div>
-
-			{selectedIds.size > 0 && (
-				<div className="fixed bottom-0 left-0 right-0 z-50 block border-t bg-background px-4 py-3 shadow-lg md:hidden">
-					<div className="mx-auto max-w-3xl">{bulkMenu}</div>
-				</div>
+			{isDesktop ? (
+				<>
+					{selectedIds.size > 0 && (
+						<div className="mb-3 rounded-lg border bg-background p-3">
+							{bulkMenu}
+						</div>
+					)}
+					<div
+						className={cn(
+							"transition-opacity",
+							isTabPending && "opacity-60 pointer-events-none",
+						)}
+					>
+						<DataTable
+							key={activeTab}
+							columns={columns}
+							data={rowsForTab}
+							columnTitles={columnTitles}
+							filters={tableFilters}
+						/>
+					</div>
+				</>
+			) : (
+				<>
+					<div
+						className={cn(
+							"pb-32 transition-opacity",
+							isTabPending && "opacity-60 pointer-events-none",
+						)}
+					>
+						<StandManageCardList
+							stands={rowsForTab}
+							selectedIds={selectedIds}
+							onToggle={onToggle}
+							onToggleAll={onToggleAll}
+							onEdit={onEdit}
+						/>
+					</div>
+					{selectedIds.size > 0 && (
+						<div className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background px-4 py-3 shadow-lg">
+							<div className="mx-auto max-w-3xl">{bulkMenu}</div>
+						</div>
+					)}
+				</>
 			)}
 
 			<StandEditFormDialog

--- a/app/components/maps/admin/stand-manage-table.tsx
+++ b/app/components/maps/admin/stand-manage-table.tsx
@@ -1,84 +1,70 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useCallback, useMemo, useState } from "react";
-import { toast } from "sonner";
+import { ListTree } from "lucide-react";
 import Link from "next/link";
-import { ListTree, X } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 
-import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import { bulkUpdateStands } from "@/app/api/stands/actions";
 import {
-	bulkUpdateStands,
-	deleteStands,
-	renumberStandsSequentially,
-	updateStand,
-} from "@/app/api/stands/actions";
+	StandBase,
+	StandWithReservationsWithParticipants,
+} from "@/app/api/stands/definitions";
 import { FestivalSectorWithStandsWithReservationsWithParticipants } from "@/app/lib/festival_sectors/definitions";
-import { Badge } from "@/app/components/ui/badge";
 import { Button } from "@/app/components/ui/button";
-import { Checkbox } from "@/app/components/ui/checkbox";
+import { Card, CardContent } from "@/app/components/ui/card";
+import { DataTable } from "@/app/components/ui/data_table/data-table";
+import { Tabs, TabsList, TabsTrigger } from "@/app/components/ui/tabs";
+
+import StandBulkActionsMenu from "@/app/components/maps/admin/stand-manage/bulk-actions-menu";
+import StandManageCardList from "@/app/components/maps/admin/stand-manage/card-list";
 import {
-	Dialog,
-	DialogContent,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-} from "@/app/components/ui/dialog";
-import { Input } from "@/app/components/ui/input";
-import { Label } from "@/app/components/ui/label";
+	StandRow,
+	columnTitles,
+	createColumns,
+	standFilterOptions,
+} from "@/app/components/maps/admin/stand-manage/columns";
+import StandEditFormDialog from "@/app/components/maps/admin/stand-manage/edit-form-dialog";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/app/components/ui/select";
-import { StandStatusBadge } from "@/app/components/stands/status-badge";
+	STAND_STATUS_OPTIONS,
+	StandCategory,
+	StandStatus,
+	getStatusLabel,
+} from "@/app/components/maps/admin/stand-manage/shared";
 
-const STAND_STATUS_OPTIONS = [
-	{ value: "available", label: "Disponible" },
-	{ value: "held", label: "En espera" },
-	{ value: "reserved", label: "Reservado" },
-	{ value: "confirmed", label: "Confirmado" },
-	{ value: "disabled", label: "Deshabilitado" },
-] as const;
-
-type StandStatus = (typeof STAND_STATUS_OPTIONS)[number]["value"];
-
-const CATEGORY_OPTIONS = [
-	{ value: "none", label: "Ninguna" },
-	{ value: "illustration", label: "Ilustración" },
-	{ value: "gastronomy", label: "Gastronomía" },
-	{ value: "entrepreneurship", label: "Emprendimiento" },
-	{ value: "new_artist", label: "Artista nuevo" },
-] as const;
-
-type StandCategory = (typeof CATEGORY_OPTIONS)[number]["value"];
-
-function formatPrice(amount: number) {
-	return new Intl.NumberFormat("es-BO", {
-		style: "currency",
-		currency: "BOB",
-		minimumFractionDigits: 2,
-	}).format(amount);
-}
-
-function sortStands(
-	list: StandWithReservationsWithParticipants[],
-): StandWithReservationsWithParticipants[] {
-	return [...list].sort(
-		(a, b) =>
-			(a.standCategory ?? "").localeCompare(b.standCategory ?? "") ||
-			a.standNumber - b.standNumber ||
-			a.id - b.id,
-	);
-}
+type Sector = FestivalSectorWithStandsWithReservationsWithParticipants;
 
 type Props = {
 	festivalId: number;
 	festivalName: string;
-	sectors: FestivalSectorWithStandsWithReservationsWithParticipants[];
+	sectors: Sector[];
 };
+
+const ALL_SECTOR_VALUE = "all";
+
+function patchSectors(
+	sectors: Sector[],
+	ids: Set<number>,
+	patch: Partial<StandBase>,
+): Sector[] {
+	return sectors.map((s) => ({
+		...s,
+		stands: s.stands.map((st) =>
+			ids.has(st.id) ? ({ ...st, ...patch } as typeof st) : st,
+		),
+	}));
+}
+
+function countByStatus(stands: StandWithReservationsWithParticipants[]) {
+	return stands.reduce(
+		(acc, s) => {
+			acc[s.status as StandStatus] = (acc[s.status as StandStatus] ?? 0) + 1;
+			return acc;
+		},
+		{} as Record<StandStatus, number>,
+	);
+}
 
 export default function StandManageTable({
 	festivalId,
@@ -86,144 +72,211 @@ export default function StandManageTable({
 	sectors,
 }: Props) {
 	const router = useRouter();
-	const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+	const searchParams = useSearchParams();
 
-	const [bulkStatusOpen, setBulkStatusOpen] = useState(false);
-	const [bulkStatus, setBulkStatus] = useState<StandStatus>("available");
-
-	const [bulkPriceOpen, setBulkPriceOpen] = useState(false);
-	const [bulkPrice, setBulkPrice] = useState(0);
-
-	const [bulkLabelOpen, setBulkLabelOpen] = useState(false);
-	const [bulkLabel, setBulkLabel] = useState("");
-
-	const [bulkCategoryOpen, setBulkCategoryOpen] = useState(false);
-	const [bulkCategory, setBulkCategory] =
-		useState<StandCategory>("illustration");
-
-	const [renumberOpen, setRenumberOpen] = useState(false);
-	const [renumberStart, setRenumberStart] = useState(1);
-
-	const [deleteOpen, setDeleteOpen] = useState(false);
-
-	const [singleOpen, setSingleOpen] = useState(false);
-	const [editStand, setEditStand] =
-		useState<StandWithReservationsWithParticipants | null>(null);
-	const [editLabel, setEditLabel] = useState("");
-	const [editStandNumber, setEditStandNumber] = useState(1);
-	const [editStatus, setEditStatus] = useState<StandStatus>("available");
-	const [editPrice, setEditPrice] = useState(0);
-	const [editCategory, setEditCategory] =
-		useState<StandCategory>("illustration");
-	const [isSaving, setIsSaving] = useState(false);
-	const [pendingBulk, setPendingBulk] = useState(false);
-
-	const allStands = useMemo(() => {
-		const out: StandWithReservationsWithParticipants[] = [];
-		for (const s of sectors) {
-			for (const st of s.stands) out.push(st);
-		}
-		return out;
+	const [liveSectors, setLiveSectors] = useState(sectors);
+	useEffect(() => {
+		setLiveSectors(sectors);
 	}, [sectors]);
 
-	const standById = useMemo(() => {
-		const m = new Map<number, StandWithReservationsWithParticipants>();
-		for (const s of allStands) m.set(s.id, s);
-		return m;
-	}, [allStands]);
+	const urlSector = searchParams.get("sector") ?? ALL_SECTOR_VALUE;
+	const activeTab = useMemo(() => {
+		if (urlSector === ALL_SECTOR_VALUE) return ALL_SECTOR_VALUE;
+		return liveSectors.some((s) => String(s.id) === urlSector)
+			? urlSector
+			: ALL_SECTOR_VALUE;
+	}, [urlSector, liveSectors]);
 
-	const selectedCount = selectedIds.size;
+	const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+	const [editStand, setEditStand] =
+		useState<StandWithReservationsWithParticipants | null>(null);
+	const [editOpen, setEditOpen] = useState(false);
+	const [pendingQuickStatusId, setPendingQuickStatusId] = useState<
+		number | null
+	>(null);
+
+	const allRows: StandRow[] = useMemo(() => {
+		const out: StandRow[] = [];
+		for (const sector of liveSectors) {
+			for (const stand of sector.stands) {
+				out.push({
+					...stand,
+					sectorId: sector.id,
+					sectorName: sector.name,
+				});
+			}
+		}
+		return out;
+	}, [liveSectors]);
+
+	const rowsForTab = useMemo(() => {
+		if (activeTab === ALL_SECTOR_VALUE) return allRows;
+		const sectorId = Number(activeTab);
+		return allRows.filter((r) => r.sectorId === sectorId);
+	}, [allRows, activeTab]);
+
+	const rowsById = useMemo(() => {
+		const m = new Map<number, StandRow>();
+		for (const r of allRows) m.set(r.id, r);
+		return m;
+	}, [allRows]);
+
 	const selectedIdsArr = useMemo(() => Array.from(selectedIds), [selectedIds]);
 
 	const selectedHaveReservation = useMemo(() => {
 		for (const id of selectedIds) {
-			const st = standById.get(id);
-			if (st && st.reservations.length > 0) return true;
+			const r = rowsById.get(id);
+			if (r && r.reservations.length > 0) return true;
 		}
 		return false;
-	}, [selectedIds, standById]);
+	}, [selectedIds, rowsById]);
 
-	const toggleStand = (id: number) => {
+	const statusCounts = useMemo(() => countByStatus(allRows), [allRows]);
+	const reservationCount = useMemo(
+		() => allRows.filter((r) => r.reservations.length > 0).length,
+		[allRows],
+	);
+
+	function handleTabChange(value: string) {
+		setSelectedIds(new Set());
+		const params = new URLSearchParams(searchParams.toString());
+		if (value === ALL_SECTOR_VALUE) params.delete("sector");
+		else params.set("sector", value);
+		const query = params.toString();
+		router.replace(query ? `?${query}` : "?", { scroll: false });
+	}
+
+	const isSelected = useCallback(
+		(id: number) => selectedIds.has(id),
+		[selectedIds],
+	);
+
+	const onToggle = useCallback((id: number) => {
 		setSelectedIds((prev) => {
 			const next = new Set(prev);
 			if (next.has(id)) next.delete(id);
 			else next.add(id);
 			return next;
 		});
-	};
+	}, []);
 
-	const toggleSector = (
-		sectorStands: StandWithReservationsWithParticipants[],
-	) => {
-		const ids = sectorStands.map((s) => s.id);
+	const onToggleAll = useCallback((ids: number[], allOn: boolean) => {
 		setSelectedIds((prev) => {
 			const next = new Set(prev);
-			const allOn = ids.length > 0 && ids.every((id) => next.has(id));
 			if (allOn) ids.forEach((id) => next.delete(id));
 			else ids.forEach((id) => next.add(id));
 			return next;
 		});
-	};
+	}, []);
 
 	const clearSelection = useCallback(() => {
 		setSelectedIds(new Set());
 	}, []);
 
-	const runBulk = async (
-		fn: () => Promise<{ success: boolean; message: string }>,
-		onSuccess?: () => void,
-	) => {
-		if (selectedIds.size === 0) return;
-		setPendingBulk(true);
-		try {
-			const res = await fn();
-			if (res.success) {
-				toast.success(res.message);
-				onSuccess?.();
+	const onEdit = useCallback((stand: StandWithReservationsWithParticipants) => {
+		setEditStand(stand);
+		setEditOpen(true);
+	}, []);
+
+	const onOptimisticStatus = useCallback(
+		(ids: number[], status: StandStatus) => {
+			const idSet = new Set(ids);
+			setLiveSectors((curr) => patchSectors(curr, idSet, { status }));
+		},
+		[],
+	);
+
+	const onOptimisticCategory = useCallback(
+		(ids: number[], standCategory: StandCategory) => {
+			const idSet = new Set(ids);
+			setLiveSectors((curr) => patchSectors(curr, idSet, { standCategory }));
+		},
+		[],
+	);
+
+	const onQuickStatus = useCallback(
+		async (stand: StandRow, status: StandStatus) => {
+			if (stand.status === status) return;
+			setPendingQuickStatusId(stand.id);
+			onOptimisticStatus([stand.id], status);
+			try {
+				const res = await bulkUpdateStands({
+					festivalId,
+					standIds: [stand.id],
+					patch: { status },
+				});
+				if (res.success) {
+					toast.success("Estado actualizado");
+					router.refresh();
+				} else {
+					toast.error(res.message);
+					onOptimisticStatus([stand.id], stand.status as StandStatus);
+				}
+			} finally {
+				setPendingQuickStatusId(null);
+			}
+		},
+		[festivalId, router, onOptimisticStatus],
+	);
+
+	const columns = useMemo(
+		() =>
+			createColumns({
+				onEdit,
+				onQuickStatus,
+				pendingQuickStatusId,
+				isSelected,
+				onToggle,
+				onToggleAll,
+			}),
+		[
+			onEdit,
+			onQuickStatus,
+			pendingQuickStatusId,
+			isSelected,
+			onToggle,
+			onToggleAll,
+		],
+	);
+
+	const tableFilters = useMemo(() => {
+		const { status, category, reservation } = standFilterOptions();
+		const base = [
+			{ columnId: "status", label: "Estado", options: status },
+			{ columnId: "standCategory", label: "Categoría", options: category },
+			{
+				columnId: "reservation",
+				label: "Reservas",
+				options: reservation,
+			},
+		];
+		if (activeTab === ALL_SECTOR_VALUE) {
+			base.unshift({
+				columnId: "sector",
+				label: "Sector",
+				options: liveSectors.map((s) => ({
+					value: String(s.id),
+					label: s.name,
+				})),
+			});
+		}
+		return base;
+	}, [liveSectors, activeTab]);
+
+	const bulkMenu = (
+		<StandBulkActionsMenu
+			festivalId={festivalId}
+			selectedIds={selectedIdsArr}
+			hasReservation={selectedHaveReservation}
+			onCleared={clearSelection}
+			onDone={() => {
 				clearSelection();
 				router.refresh();
-			} else {
-				toast.error(res.message);
-			}
-		} finally {
-			setPendingBulk(false);
-		}
-	};
-
-	const openSingleEdit = (stand: StandWithReservationsWithParticipants) => {
-		setEditStand(stand);
-		setEditLabel(stand.label ?? "");
-		setEditStandNumber(stand.standNumber);
-		setEditStatus(stand.status as StandStatus);
-		setEditPrice(stand.price ?? 0);
-		setEditCategory(stand.standCategory as StandCategory);
-		setSingleOpen(true);
-	};
-
-	const handleSingleSave = async () => {
-		if (!editStand || !editLabel.trim()) return;
-		setIsSaving(true);
-		try {
-			const res = await updateStand({
-				id: editStand.id,
-				label: editLabel.trim(),
-				standNumber: editStandNumber,
-				status: editStatus,
-				price: editPrice,
-				standCategory: editCategory,
-			});
-			if (res.success) {
-				toast.success(res.message);
-				setSingleOpen(false);
-				setEditStand(null);
-				router.refresh();
-			} else {
-				toast.error(res.message);
-			}
-		} finally {
-			setIsSaving(false);
-		}
-	};
+			}}
+			onOptimisticStatus={onOptimisticStatus}
+			onOptimisticCategory={onOptimisticCategory}
+		/>
+	);
 
 	return (
 		<>
@@ -233,9 +286,8 @@ export default function StandManageTable({
 						Gestión de espacios — {festivalName}
 					</h1>
 					<p className="mt-1 text-sm text-muted-foreground">
-						Edita metadatos de uno o varios stands. Selecciona filas y usa las
-						acciones inferiores. El orden al renumerar es: número de stand
-						ascendente y luego ID.
+						Filtra, selecciona y edita espacios en lote. Cambia el estado
+						rápidamente tocando su etiqueta.
 					</p>
 				</div>
 				<Button variant="outline" size="sm" asChild>
@@ -246,510 +298,101 @@ export default function StandManageTable({
 				</Button>
 			</div>
 
-			<div className="flex flex-col gap-8 pb-32">
-				{sectors.map((sector) => {
-					const sectorStands = sortStands(sector.stands);
-					const sectorIds = sectorStands.map((s) => s.id);
-					const allSectorSelected =
-						sectorIds.length > 0 &&
-						sectorIds.every((id) => selectedIds.has(id));
-					const someSectorSelected = sectorIds.some((id) =>
-						selectedIds.has(id),
-					);
-
-					return (
-						<div key={sector.id}>
-							<div className="mb-3 flex items-center gap-3">
-								<Checkbox
-									checked={
-										allSectorSelected
-											? true
-											: someSectorSelected
-												? "indeterminate"
-												: false
-									}
-									onCheckedChange={() => toggleSector(sectorStands)}
-									aria-label={`Seleccionar todos en ${sector.name}`}
-								/>
-								<h2 className="text-base font-semibold">{sector.name}</h2>
-							</div>
-
-							{sectorStands.length === 0 ? (
-								<p className="pl-7 text-sm text-muted-foreground">
-									Sin stands en este sector
-								</p>
-							) : (
-								<div className="divide-y rounded-lg border">
-									{sectorStands.map((stand) => {
-										const isSelected = selectedIds.has(stand.id);
-										const hasRes = stand.reservations.length > 0;
-										const standLabel = `${stand.label ?? ""}${stand.standNumber}`;
-
-										return (
-											<div
-												key={stand.id}
-												className={`flex flex-wrap items-center gap-3 px-4 py-3 transition-colors ${
-													isSelected ? "bg-muted/50" : ""
-												}`}
-											>
-												<Checkbox
-													checked={isSelected}
-													onCheckedChange={() => toggleStand(stand.id)}
-													aria-label={`Seleccionar stand ${standLabel}`}
-												/>
-												<div className="min-w-0 flex-1">
-													<div className="flex flex-wrap items-center gap-2">
-														<span className="shrink-0 text-sm font-medium">
-															Stand {standLabel}
-														</span>
-														<StandStatusBadge status={stand.status} />
-														<span className="text-xs capitalize text-muted-foreground">
-															{stand.standCategory}
-														</span>
-														{hasRes && (
-															<Badge variant="secondary" className="text-xs">
-																Con reserva
-															</Badge>
-														)}
-													</div>
-													<p className="text-xs text-muted-foreground">
-														{formatPrice(stand.price ?? 0)}
-													</p>
-												</div>
-												<Button
-													variant="outline"
-													size="sm"
-													onClick={() => openSingleEdit(stand)}
-												>
-													Editar
-												</Button>
-											</div>
-										);
-									})}
-								</div>
-							)}
-						</div>
-					);
-				})}
-			</div>
-
-			{selectedCount > 0 && (
-				<div className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background px-4 py-3 shadow-lg">
-					<div className="mx-auto flex max-w-3xl flex-wrap items-center gap-2">
-						<span className="text-sm font-medium">
-							{selectedCount} espacio{selectedCount !== 1 ? "s" : ""}{" "}
-							seleccionado
-							{selectedCount !== 1 ? "s" : ""}
-						</span>
-						<div className="ml-auto flex flex-wrap items-center gap-2">
-							<Button
-								variant="secondary"
-								size="sm"
-								disabled={pendingBulk}
-								onClick={() => setBulkStatusOpen(true)}
-							>
-								Estado
-							</Button>
-							<Button
-								variant="secondary"
-								size="sm"
-								disabled={pendingBulk}
-								onClick={() => setBulkPriceOpen(true)}
-							>
-								Precio
-							</Button>
-							<Button
-								variant="secondary"
-								size="sm"
-								disabled={pendingBulk}
-								onClick={() => setBulkLabelOpen(true)}
-							>
-								Etiqueta
-							</Button>
-							<Button
-								variant="secondary"
-								size="sm"
-								disabled={pendingBulk}
-								onClick={() => setBulkCategoryOpen(true)}
-							>
-								Categoría
-							</Button>
-							<Button
-								variant="secondary"
-								size="sm"
-								disabled={pendingBulk}
-								onClick={() => setRenumberOpen(true)}
-							>
-								Renumerar
-							</Button>
-							<Button
-								variant="destructive"
-								size="sm"
-								disabled={pendingBulk || selectedHaveReservation}
-								title={
-									selectedHaveReservation
-										? "No se pueden eliminar stands con reservas"
-										: undefined
-								}
-								onClick={() => setDeleteOpen(true)}
-							>
-								Eliminar
-							</Button>
-							<Button variant="ghost" size="sm" onClick={clearSelection}>
-								<X className="mr-1 h-4 w-4" />
-								Limpiar
-							</Button>
-						</div>
+			<Card className="mb-4">
+				<CardContent className="flex flex-wrap items-center gap-x-6 gap-y-2 p-4 text-sm">
+					<div>
+						<span className="text-muted-foreground">Total:</span>{" "}
+						<span className="font-semibold">{allRows.length}</span>
 					</div>
+					{STAND_STATUS_OPTIONS.map((o) => (
+						<div key={o.value}>
+							<span className="text-muted-foreground">
+								{getStatusLabel(o.value)}:
+							</span>{" "}
+							<span className="font-semibold">
+								{statusCounts[o.value] ?? 0}
+							</span>
+						</div>
+					))}
+					<div>
+						<span className="text-muted-foreground">Con reserva:</span>{" "}
+						<span className="font-semibold">{reservationCount}</span>
+					</div>
+				</CardContent>
+			</Card>
+
+			<Tabs value={activeTab} onValueChange={handleTabChange} className="mb-4">
+				<TabsList className="flex h-auto w-full flex-wrap justify-start gap-1 bg-muted p-1">
+					<TabsTrigger value={ALL_SECTOR_VALUE}>
+						Todos
+						<span className="ml-2 rounded bg-background/80 px-1.5 py-0.5 text-xs">
+							{allRows.length}
+						</span>
+					</TabsTrigger>
+					{liveSectors.map((s) => {
+						const sectorReservations = s.stands.filter(
+							(st) => st.reservations.length > 0,
+						).length;
+						return (
+							<TabsTrigger key={s.id} value={String(s.id)}>
+								{s.name}
+								<span className="ml-2 rounded bg-background/80 px-1.5 py-0.5 text-xs">
+									{s.stands.length}
+								</span>
+								{sectorReservations > 0 && (
+									<span className="ml-1 rounded bg-emerald-500/10 px-1.5 py-0.5 text-xs text-emerald-700">
+										{sectorReservations} res.
+									</span>
+								)}
+							</TabsTrigger>
+						);
+					})}
+				</TabsList>
+			</Tabs>
+
+			{selectedIds.size > 0 && (
+				<div className="mb-3 hidden rounded-lg border bg-background p-3 md:block">
+					{bulkMenu}
 				</div>
 			)}
 
-			<Dialog open={bulkStatusOpen} onOpenChange={setBulkStatusOpen}>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>Cambiar estado ({selectedCount})</DialogTitle>
-					</DialogHeader>
-					<div className="grid gap-2">
-						<Label>Estado</Label>
-						<Select
-							value={bulkStatus}
-							onValueChange={(v) => setBulkStatus(v as StandStatus)}
-						>
-							<SelectTrigger>
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								{STAND_STATUS_OPTIONS.map((o) => (
-									<SelectItem key={o.value} value={o.value}>
-										{o.label}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</div>
-					<DialogFooter>
-						<Button variant="outline" onClick={() => setBulkStatusOpen(false)}>
-							Cancelar
-						</Button>
-						<Button
-							disabled={pendingBulk}
-							onClick={() => {
-								void runBulk(
-									() =>
-										bulkUpdateStands({
-											festivalId,
-											standIds: selectedIdsArr,
-											patch: { status: bulkStatus },
-										}),
-									() => setBulkStatusOpen(false),
-								);
-							}}
-						>
-							Guardar
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+			<div className="hidden md:block">
+				<DataTable
+					key={activeTab}
+					columns={columns}
+					data={rowsForTab}
+					columnTitles={columnTitles}
+					filters={tableFilters}
+				/>
+			</div>
 
-			<Dialog open={bulkPriceOpen} onOpenChange={setBulkPriceOpen}>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>Establecer precio ({selectedCount})</DialogTitle>
-					</DialogHeader>
-					<div className="grid gap-2">
-						<Label htmlFor="bulk-price">Precio (BOB)</Label>
-						<Input
-							id="bulk-price"
-							type="number"
-							min={0}
-							step={1}
-							value={bulkPrice}
-							onChange={(e) =>
-								setBulkPrice(Math.max(0, Number(e.target.value) || 0))
-							}
-						/>
-					</div>
-					<DialogFooter>
-						<Button variant="outline" onClick={() => setBulkPriceOpen(false)}>
-							Cancelar
-						</Button>
-						<Button
-							disabled={pendingBulk}
-							onClick={() => {
-								void runBulk(
-									() =>
-										bulkUpdateStands({
-											festivalId,
-											standIds: selectedIdsArr,
-											patch: { price: bulkPrice },
-										}),
-									() => setBulkPriceOpen(false),
-								);
-							}}
-						>
-							Guardar
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+			<div className="block pb-32 md:hidden">
+				<StandManageCardList
+					stands={rowsForTab}
+					selectedIds={selectedIds}
+					onToggle={onToggle}
+					onToggleAll={onToggleAll}
+					onEdit={onEdit}
+				/>
+			</div>
 
-			<Dialog open={bulkLabelOpen} onOpenChange={setBulkLabelOpen}>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>Establecer etiqueta ({selectedCount})</DialogTitle>
-					</DialogHeader>
-					<p className="text-sm text-muted-foreground">
-						Se aplicará el mismo prefijo de etiqueta a todos los stands
-						seleccionados (p. ej. &quot;S&quot;).
-					</p>
-					<div className="grid gap-2">
-						<Label htmlFor="bulk-label">Etiqueta</Label>
-						<Input
-							id="bulk-label"
-							value={bulkLabel}
-							onChange={(e) => setBulkLabel(e.target.value)}
-						/>
-					</div>
-					<DialogFooter>
-						<Button variant="outline" onClick={() => setBulkLabelOpen(false)}>
-							Cancelar
-						</Button>
-						<Button
-							disabled={pendingBulk || !bulkLabel.trim()}
-							onClick={() => {
-								const label = bulkLabel.trim();
-								void runBulk(
-									() =>
-										bulkUpdateStands({
-											festivalId,
-											standIds: selectedIdsArr,
-											patch: { label },
-										}),
-									() => {
-										setBulkLabelOpen(false);
-										setBulkLabel("");
-									},
-								);
-							}}
-						>
-							Guardar
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+			{selectedIds.size > 0 && (
+				<div className="fixed bottom-0 left-0 right-0 z-50 block border-t bg-background px-4 py-3 shadow-lg md:hidden">
+					<div className="mx-auto max-w-3xl">{bulkMenu}</div>
+				</div>
+			)}
 
-			<Dialog open={bulkCategoryOpen} onOpenChange={setBulkCategoryOpen}>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>Cambiar categoría ({selectedCount})</DialogTitle>
-					</DialogHeader>
-					<div className="grid gap-2">
-						<Label>Categoría</Label>
-						<Select
-							value={bulkCategory}
-							onValueChange={(v) => setBulkCategory(v as StandCategory)}
-						>
-							<SelectTrigger>
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								{CATEGORY_OPTIONS.map((o) => (
-									<SelectItem key={o.value} value={o.value}>
-										{o.label}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</div>
-					<DialogFooter>
-						<Button
-							variant="outline"
-							onClick={() => setBulkCategoryOpen(false)}
-						>
-							Cancelar
-						</Button>
-						<Button
-							disabled={pendingBulk}
-							onClick={() => {
-								void runBulk(
-									() =>
-										bulkUpdateStands({
-											festivalId,
-											standIds: selectedIdsArr,
-											patch: { standCategory: bulkCategory },
-										}),
-									() => setBulkCategoryOpen(false),
-								);
-							}}
-						>
-							Guardar
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
-
-			<Dialog open={renumberOpen} onOpenChange={setRenumberOpen}>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>Renumerar en secuencia ({selectedCount})</DialogTitle>
-					</DialogHeader>
-					<p className="text-sm text-muted-foreground">
-						El primer stand seleccionado (según el orden: número de stand, luego
-						ID) recibirá el número indicado; los siguientes serán consecutivos.
-					</p>
-					<div className="grid gap-2">
-						<Label htmlFor="renumber-start">Número inicial</Label>
-						<Input
-							id="renumber-start"
-							type="number"
-							min={1}
-							value={renumberStart}
-							onChange={(e) =>
-								setRenumberStart(Math.max(1, Number(e.target.value) || 1))
-							}
-						/>
-					</div>
-					<DialogFooter>
-						<Button variant="outline" onClick={() => setRenumberOpen(false)}>
-							Cancelar
-						</Button>
-						<Button
-							disabled={pendingBulk}
-							onClick={() => {
-								void runBulk(
-									() =>
-										renumberStandsSequentially({
-											festivalId,
-											standIds: selectedIdsArr,
-											startNumber: renumberStart,
-										}),
-									() => setRenumberOpen(false),
-								);
-							}}
-						>
-							Aplicar
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
-
-			<Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>Eliminar {selectedCount} espacio(s)</DialogTitle>
-					</DialogHeader>
-					<p className="text-sm text-muted-foreground">
-						Esta acción no se puede deshacer. No puedes eliminar stands con
-						reservas.
-					</p>
-					<DialogFooter>
-						<Button variant="outline" onClick={() => setDeleteOpen(false)}>
-							Cancelar
-						</Button>
-						<Button
-							variant="destructive"
-							disabled={pendingBulk || selectedHaveReservation}
-							onClick={() => {
-								void runBulk(
-									() => deleteStands(selectedIdsArr),
-									() => setDeleteOpen(false),
-								);
-							}}
-						>
-							Eliminar
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
-
-			<Dialog open={singleOpen} onOpenChange={setSingleOpen}>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>Editar espacio</DialogTitle>
-					</DialogHeader>
-					<div className="grid gap-4 py-2">
-						<div className="grid gap-2">
-							<Label htmlFor="single-label">Etiqueta</Label>
-							<Input
-								id="single-label"
-								value={editLabel}
-								onChange={(e) => setEditLabel(e.target.value)}
-							/>
-						</div>
-						<div className="grid gap-2">
-							<Label htmlFor="single-number">Número</Label>
-							<Input
-								id="single-number"
-								type="number"
-								min={1}
-								value={editStandNumber}
-								onChange={(e) =>
-									setEditStandNumber(Math.max(1, Number(e.target.value) || 1))
-								}
-							/>
-						</div>
-						<div className="grid gap-2">
-							<Label htmlFor="single-status">Estado</Label>
-							<Select
-								value={editStatus}
-								onValueChange={(v) => setEditStatus(v as StandStatus)}
-							>
-								<SelectTrigger id="single-status">
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									{STAND_STATUS_OPTIONS.map((o) => (
-										<SelectItem key={o.value} value={o.value}>
-											{o.label}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						</div>
-						<div className="grid grid-cols-2 gap-4">
-							<div className="grid gap-2">
-								<Label htmlFor="single-price">Precio</Label>
-								<Input
-									id="single-price"
-									type="number"
-									min={0}
-									step={1}
-									value={editPrice}
-									onChange={(e) =>
-										setEditPrice(Math.max(0, Number(e.target.value) || 0))
-									}
-								/>
-							</div>
-							<div className="grid gap-2">
-								<Label htmlFor="single-cat">Categoría</Label>
-								<Select
-									value={editCategory}
-									onValueChange={(v) => setEditCategory(v as StandCategory)}
-								>
-									<SelectTrigger id="single-cat">
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										{CATEGORY_OPTIONS.map((o) => (
-											<SelectItem key={o.value} value={o.value}>
-												{o.label}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
-							</div>
-						</div>
-					</div>
-					<DialogFooter>
-						<Button
-							onClick={handleSingleSave}
-							disabled={isSaving || !editLabel.trim()}
-						>
-							{isSaving ? "Guardando…" : "Guardar"}
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+			<StandEditFormDialog
+				stand={editStand}
+				open={editOpen}
+				onOpenChange={(open) => {
+					setEditOpen(open);
+					if (!open) setEditStand(null);
+				}}
+				onSaved={() => {
+					router.refresh();
+				}}
+			/>
 		</>
 	);
 }

--- a/app/components/maps/admin/stand-manage/bulk-actions-menu.tsx
+++ b/app/components/maps/admin/stand-manage/bulk-actions-menu.tsx
@@ -60,6 +60,7 @@ type Props = {
 	onDone?: () => void;
 	onOptimisticStatus?: (ids: number[], status: StandStatus) => void;
 	onOptimisticCategory?: (ids: number[], category: StandCategory) => void;
+	onFailure?: () => void;
 };
 
 type DialogKey =
@@ -89,6 +90,7 @@ export default function StandBulkActionsMenu({
 	onDone,
 	onOptimisticStatus,
 	onOptimisticCategory,
+	onFailure,
 }: Props) {
 	const [dialog, setDialog] = useState<DialogKey>(null);
 	const [pending, setPending] = useState(false);
@@ -116,7 +118,11 @@ export default function StandBulkActionsMenu({
 				onDone?.();
 			} else {
 				toast.error(res.message);
+				onFailure?.();
 			}
+		} catch {
+			toast.error("Error al aplicar el cambio. Intenta de nuevo.");
+			onFailure?.();
 		} finally {
 			setPending(false);
 		}

--- a/app/components/maps/admin/stand-manage/bulk-actions-menu.tsx
+++ b/app/components/maps/admin/stand-manage/bulk-actions-menu.tsx
@@ -1,0 +1,456 @@
+"use client";
+
+import {
+	ChevronDownIcon,
+	HashIcon,
+	LayersIcon,
+	SignpostIcon,
+	TagIcon,
+	Trash2Icon,
+	WalletIcon,
+	XIcon,
+} from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import {
+	bulkUpdateStands,
+	deleteStands,
+	renumberStandsSequentially,
+} from "@/app/api/stands/actions";
+import { Button } from "@/app/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/app/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/app/components/ui/dropdown-menu";
+import { Input } from "@/app/components/ui/input";
+import { Label } from "@/app/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/app/components/ui/select";
+
+import {
+	CATEGORY_OPTIONS,
+	CONFIRMATION_THRESHOLD,
+	STAND_STATUS_OPTIONS,
+	StandCategory,
+	StandStatus,
+} from "@/app/components/maps/admin/stand-manage/shared";
+
+type Props = {
+	festivalId: number;
+	selectedIds: number[];
+	hasReservation: boolean;
+	onCleared?: () => void;
+	onDone?: () => void;
+	onOptimisticStatus?: (ids: number[], status: StandStatus) => void;
+	onOptimisticCategory?: (ids: number[], category: StandCategory) => void;
+};
+
+type DialogKey =
+	| null
+	| "status"
+	| "price"
+	| "label"
+	| "category"
+	| "renumber"
+	| "delete";
+
+function confirmationNote(count: number) {
+	if (count <= CONFIRMATION_THRESHOLD) return null;
+	return (
+		<p className="rounded-md bg-amber-50 px-3 py-2 text-sm text-amber-900">
+			Vas a aplicar este cambio a <strong>{count}</strong> espacios. Verifica
+			antes de guardar.
+		</p>
+	);
+}
+
+export default function StandBulkActionsMenu({
+	festivalId,
+	selectedIds,
+	hasReservation,
+	onCleared,
+	onDone,
+	onOptimisticStatus,
+	onOptimisticCategory,
+}: Props) {
+	const [dialog, setDialog] = useState<DialogKey>(null);
+	const [pending, setPending] = useState(false);
+
+	const [status, setStatus] = useState<StandStatus>("available");
+	const [price, setPrice] = useState(0);
+	const [label, setLabel] = useState("");
+	const [category, setCategory] = useState<StandCategory>("illustration");
+	const [renumberStart, setRenumberStart] = useState(1);
+
+	const count = selectedIds.length;
+
+	async function runBulk(
+		fn: () => Promise<{ success: boolean; message: string }>,
+		onSuccess?: () => void,
+	) {
+		if (count === 0) return;
+		setPending(true);
+		try {
+			const res = await fn();
+			if (res.success) {
+				toast.success(res.message);
+				onSuccess?.();
+				setDialog(null);
+				onDone?.();
+			} else {
+				toast.error(res.message);
+			}
+		} finally {
+			setPending(false);
+		}
+	}
+
+	if (count === 0) return null;
+
+	return (
+		<>
+			<div className="flex flex-wrap items-center gap-2">
+				<span className="text-sm font-medium">
+					{count} espacio{count !== 1 ? "s" : ""} seleccionado
+					{count !== 1 ? "s" : ""}
+				</span>
+				<div className="ml-auto flex items-center gap-2">
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button variant="secondary" size="sm" disabled={pending}>
+								Editar selección
+								<ChevronDownIcon className="ml-1 h-4 w-4" />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end">
+							<DropdownMenuItem onSelect={() => setDialog("status")}>
+								<SignpostIcon className="mr-2 h-4 w-4" />
+								Cambiar estado
+							</DropdownMenuItem>
+							<DropdownMenuItem onSelect={() => setDialog("category")}>
+								<LayersIcon className="mr-2 h-4 w-4" />
+								Cambiar categoría
+							</DropdownMenuItem>
+							<DropdownMenuItem onSelect={() => setDialog("price")}>
+								<WalletIcon className="mr-2 h-4 w-4" />
+								Establecer precio
+							</DropdownMenuItem>
+							<DropdownMenuItem onSelect={() => setDialog("label")}>
+								<TagIcon className="mr-2 h-4 w-4" />
+								Establecer etiqueta
+							</DropdownMenuItem>
+							<DropdownMenuSeparator />
+							<DropdownMenuItem onSelect={() => setDialog("renumber")}>
+								<HashIcon className="mr-2 h-4 w-4" />
+								Renumerar en secuencia
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+
+					<Button
+						variant="destructive"
+						size="sm"
+						disabled={pending || hasReservation}
+						title={
+							hasReservation
+								? "No se pueden eliminar espacios con reservas"
+								: undefined
+						}
+						onClick={() => setDialog("delete")}
+					>
+						<Trash2Icon className="mr-1 h-4 w-4" />
+						Eliminar
+					</Button>
+
+					{onCleared && (
+						<Button variant="ghost" size="sm" onClick={onCleared}>
+							<XIcon className="mr-1 h-4 w-4" />
+							Limpiar
+						</Button>
+					)}
+				</div>
+			</div>
+
+			<Dialog
+				open={dialog === "status"}
+				onOpenChange={(o) => !o && setDialog(null)}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Cambiar estado ({count})</DialogTitle>
+					</DialogHeader>
+					{confirmationNote(count)}
+					<div className="grid gap-2">
+						<Label>Estado</Label>
+						<Select
+							value={status}
+							onValueChange={(v) => setStatus(v as StandStatus)}
+						>
+							<SelectTrigger>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{STAND_STATUS_OPTIONS.map((o) => (
+									<SelectItem key={o.value} value={o.value}>
+										{o.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setDialog(null)}>
+							Cancelar
+						</Button>
+						<Button
+							disabled={pending}
+							onClick={() => {
+								onOptimisticStatus?.(selectedIds, status);
+								void runBulk(() =>
+									bulkUpdateStands({
+										festivalId,
+										standIds: selectedIds,
+										patch: { status },
+									}),
+								);
+							}}
+						>
+							{pending ? "Guardando…" : "Guardar"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog
+				open={dialog === "category"}
+				onOpenChange={(o) => !o && setDialog(null)}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Cambiar categoría ({count})</DialogTitle>
+					</DialogHeader>
+					{confirmationNote(count)}
+					<div className="grid gap-2">
+						<Label>Categoría</Label>
+						<Select
+							value={category}
+							onValueChange={(v) => setCategory(v as StandCategory)}
+						>
+							<SelectTrigger>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{CATEGORY_OPTIONS.map((o) => (
+									<SelectItem key={o.value} value={o.value}>
+										{o.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setDialog(null)}>
+							Cancelar
+						</Button>
+						<Button
+							disabled={pending}
+							onClick={() => {
+								onOptimisticCategory?.(selectedIds, category);
+								void runBulk(() =>
+									bulkUpdateStands({
+										festivalId,
+										standIds: selectedIds,
+										patch: { standCategory: category },
+									}),
+								);
+							}}
+						>
+							{pending ? "Guardando…" : "Guardar"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog
+				open={dialog === "price"}
+				onOpenChange={(o) => !o && setDialog(null)}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Establecer precio ({count})</DialogTitle>
+					</DialogHeader>
+					{confirmationNote(count)}
+					<div className="grid gap-2">
+						<Label htmlFor="bulk-price">Precio (BOB)</Label>
+						<Input
+							id="bulk-price"
+							type="number"
+							min={0}
+							step={1}
+							value={price}
+							onChange={(e) =>
+								setPrice(Math.max(0, Number(e.target.value) || 0))
+							}
+						/>
+					</div>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setDialog(null)}>
+							Cancelar
+						</Button>
+						<Button
+							disabled={pending}
+							onClick={() =>
+								void runBulk(() =>
+									bulkUpdateStands({
+										festivalId,
+										standIds: selectedIds,
+										patch: { price },
+									}),
+								)
+							}
+						>
+							{pending ? "Guardando…" : "Guardar"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog
+				open={dialog === "label"}
+				onOpenChange={(o) => !o && setDialog(null)}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Establecer etiqueta ({count})</DialogTitle>
+						<DialogDescription>
+							Reemplaza la etiqueta completa de todos los espacios
+							seleccionados.
+						</DialogDescription>
+					</DialogHeader>
+					{confirmationNote(count)}
+					<div className="grid gap-2">
+						<Label htmlFor="bulk-label">Etiqueta</Label>
+						<Input
+							id="bulk-label"
+							value={label}
+							onChange={(e) => setLabel(e.target.value)}
+							placeholder="p. ej. S"
+						/>
+					</div>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setDialog(null)}>
+							Cancelar
+						</Button>
+						<Button
+							disabled={pending || !label.trim()}
+							onClick={() => {
+								const trimmed = label.trim();
+								void runBulk(
+									() =>
+										bulkUpdateStands({
+											festivalId,
+											standIds: selectedIds,
+											patch: { label: trimmed },
+										}),
+									() => setLabel(""),
+								);
+							}}
+						>
+							{pending ? "Guardando…" : "Guardar"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog
+				open={dialog === "renumber"}
+				onOpenChange={(o) => !o && setDialog(null)}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Renumerar en secuencia ({count})</DialogTitle>
+						<DialogDescription>
+							El primer espacio seleccionado (por número de stand, luego ID)
+							recibirá el número inicial; los siguientes serán consecutivos.
+						</DialogDescription>
+					</DialogHeader>
+					<div className="grid gap-2">
+						<Label htmlFor="renumber-start">Número inicial</Label>
+						<Input
+							id="renumber-start"
+							type="number"
+							min={1}
+							value={renumberStart}
+							onChange={(e) =>
+								setRenumberStart(Math.max(1, Number(e.target.value) || 1))
+							}
+						/>
+					</div>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setDialog(null)}>
+							Cancelar
+						</Button>
+						<Button
+							disabled={pending}
+							onClick={() =>
+								void runBulk(() =>
+									renumberStandsSequentially({
+										festivalId,
+										standIds: selectedIds,
+										startNumber: renumberStart,
+									}),
+								)
+							}
+						>
+							{pending ? "Aplicando…" : "Aplicar"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog
+				open={dialog === "delete"}
+				onOpenChange={(o) => !o && setDialog(null)}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Eliminar {count} espacio(s)</DialogTitle>
+						<DialogDescription>
+							Esta acción no se puede deshacer. No puedes eliminar espacios con
+							reservas.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setDialog(null)}>
+							Cancelar
+						</Button>
+						<Button
+							variant="destructive"
+							disabled={pending || hasReservation}
+							onClick={() => void runBulk(() => deleteStands(selectedIds))}
+						>
+							{pending ? "Eliminando…" : "Eliminar"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}

--- a/app/components/maps/admin/stand-manage/card-list.tsx
+++ b/app/components/maps/admin/stand-manage/card-list.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { EditIcon } from "lucide-react";
+
+import { Badge } from "@/app/components/ui/badge";
+import { Button } from "@/app/components/ui/button";
+import { Checkbox } from "@/app/components/ui/checkbox";
+import { StandStatusBadge } from "@/app/components/stands/status-badge";
+import { cn } from "@/lib/utils";
+
+import {
+	StandCategory,
+	formatPrice,
+	getCategoryLabel,
+	standDisplayLabel,
+} from "@/app/components/maps/admin/stand-manage/shared";
+import { StandRow } from "@/app/components/maps/admin/stand-manage/columns";
+
+type Props = {
+	stands: StandRow[];
+	selectedIds: Set<number>;
+	onToggle: (id: number) => void;
+	onToggleAll: (ids: number[], allOn: boolean) => void;
+	onEdit: (stand: StandRow) => void;
+};
+
+export default function StandManageCardList({
+	stands,
+	selectedIds,
+	onToggle,
+	onToggleAll,
+	onEdit,
+}: Props) {
+	if (stands.length === 0) {
+		return (
+			<div className="rounded-lg border p-6 text-center text-sm text-muted-foreground">
+				Sin resultados.
+			</div>
+		);
+	}
+
+	const allIds = stands.map((s) => s.id);
+	const allSelected = allIds.every((id) => selectedIds.has(id));
+	const someSelected = !allSelected && allIds.some((id) => selectedIds.has(id));
+
+	return (
+		<div className="flex flex-col gap-2">
+			<div className="flex items-center gap-3 px-1 py-2">
+				<Checkbox
+					checked={allSelected ? true : someSelected ? "indeterminate" : false}
+					onCheckedChange={() => onToggleAll(allIds, allSelected)}
+					aria-label="Seleccionar todos"
+				/>
+				<span className="text-xs text-muted-foreground">
+					{stands.length} espacio{stands.length !== 1 ? "s" : ""}
+				</span>
+			</div>
+			<ul className="flex flex-col gap-2">
+				{stands.map((stand) => {
+					const isSelected = selectedIds.has(stand.id);
+					const hasReservation = stand.reservations.length > 0;
+					return (
+						<li
+							key={stand.id}
+							className={cn(
+								"flex items-start gap-3 rounded-lg border bg-background px-3 py-3 transition-colors",
+								isSelected && "bg-muted/50",
+								hasReservation && "border-l-4 border-l-emerald-500",
+							)}
+						>
+							<Checkbox
+								className="mt-1"
+								checked={isSelected}
+								onCheckedChange={() => onToggle(stand.id)}
+								aria-label={`Seleccionar ${standDisplayLabel(stand.label, stand.standNumber)}`}
+							/>
+							<div className="min-w-0 flex-1">
+								<div className="flex flex-wrap items-center gap-2">
+									<span className="text-sm font-semibold">
+										Stand {standDisplayLabel(stand.label, stand.standNumber)}
+									</span>
+									<StandStatusBadge status={stand.status} />
+									{hasReservation && (
+										<Badge variant="secondary" className="text-xs">
+											Con reserva
+										</Badge>
+									)}
+								</div>
+								<div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+									<span>{stand.sectorName}</span>
+									<span>·</span>
+									<span>
+										{getCategoryLabel(stand.standCategory as StandCategory)}
+									</span>
+									<span>·</span>
+									<span className="tabular-nums">
+										{formatPrice(stand.price ?? 0)}
+									</span>
+								</div>
+							</div>
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={() => onEdit(stand)}
+								aria-label={`Editar ${standDisplayLabel(stand.label, stand.standNumber)}`}
+							>
+								<EditIcon className="h-4 w-4" />
+							</Button>
+						</li>
+					);
+				})}
+			</ul>
+		</div>
+	);
+}

--- a/app/components/maps/admin/stand-manage/columns.tsx
+++ b/app/components/maps/admin/stand-manage/columns.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { EditIcon } from "lucide-react";
+
+import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import { Badge } from "@/app/components/ui/badge";
+import { Button } from "@/app/components/ui/button";
+import { Checkbox } from "@/app/components/ui/checkbox";
+import { DataTableColumnHeader } from "@/app/components/ui/data_table/column-header";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/app/components/ui/popover";
+import { StandStatusBadge } from "@/app/components/stands/status-badge";
+import { cn } from "@/lib/utils";
+
+import {
+	CATEGORY_OPTIONS,
+	STAND_STATUS_OPTIONS,
+	StandCategory,
+	StandStatus,
+	formatPrice,
+	getCategoryLabel,
+	standDisplayLabel,
+} from "@/app/components/maps/admin/stand-manage/shared";
+
+export type StandRow = StandWithReservationsWithParticipants & {
+	sectorId: number;
+	sectorName: string;
+};
+
+export const columnTitles = {
+	select: "",
+	label: "Stand",
+	sector: "Sector",
+	status: "Estado",
+	standCategory: "Categoría",
+	price: "Precio",
+	reservation: "Reserva",
+	actions: "",
+};
+
+type ColumnOpts = {
+	onEdit: (stand: StandRow) => void;
+	onQuickStatus: (stand: StandRow, status: StandStatus) => void;
+	pendingQuickStatusId: number | null;
+	isSelected: (id: number) => boolean;
+	onToggle: (id: number) => void;
+	onToggleAll: (ids: number[], allOn: boolean) => void;
+};
+
+function StatusCell({
+	stand,
+	onQuickStatus,
+	isPending,
+}: {
+	stand: StandRow;
+	onQuickStatus: (stand: StandRow, status: StandStatus) => void;
+	isPending: boolean;
+}) {
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					className={cn(
+						"inline-flex items-center rounded-md transition-opacity focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1",
+						isPending && "opacity-50",
+					)}
+					aria-label={`Cambiar estado de ${standDisplayLabel(stand.label, stand.standNumber)}`}
+					disabled={isPending}
+				>
+					<StandStatusBadge status={stand.status} />
+				</button>
+			</PopoverTrigger>
+			<PopoverContent className="w-48 p-1" align="start">
+				<div className="flex flex-col gap-0.5">
+					{STAND_STATUS_OPTIONS.map((opt) => (
+						<button
+							key={opt.value}
+							type="button"
+							onClick={() => onQuickStatus(stand, opt.value)}
+							className={cn(
+								"flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-muted",
+								stand.status === opt.value && "font-semibold",
+							)}
+						>
+							<StandStatusBadge status={opt.value} />
+							{opt.value === stand.status && (
+								<span className="ml-auto text-xs text-muted-foreground">
+									actual
+								</span>
+							)}
+						</button>
+					))}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+export function createColumns({
+	onEdit,
+	onQuickStatus,
+	pendingQuickStatusId,
+	isSelected,
+	onToggle,
+	onToggleAll,
+}: ColumnOpts): ColumnDef<StandRow>[] {
+	return [
+		{
+			id: "select",
+			header: ({ table }) => {
+				const ids = table.getFilteredRowModel().rows.map((r) => r.original.id);
+				const allOn = ids.length > 0 && ids.every((id) => isSelected(id));
+				const someOn = !allOn && ids.some((id) => isSelected(id));
+				return (
+					<Checkbox
+						checked={allOn ? true : someOn ? "indeterminate" : false}
+						onCheckedChange={() => onToggleAll(ids, allOn)}
+						aria-label="Seleccionar todos"
+					/>
+				);
+			},
+			cell: ({ row }) => (
+				<Checkbox
+					checked={isSelected(row.original.id)}
+					onCheckedChange={() => onToggle(row.original.id)}
+					aria-label={`Seleccionar ${standDisplayLabel(row.original.label, row.original.standNumber)}`}
+				/>
+			),
+			enableSorting: false,
+			enableHiding: false,
+		},
+		{
+			accessorKey: "label",
+			id: "label",
+			header: ({ column }) => (
+				<DataTableColumnHeader column={column} title={columnTitles.label} />
+			),
+			accessorFn: (row) => standDisplayLabel(row.label, row.standNumber),
+			cell: ({ row }) => {
+				const hasReservation = row.original.reservations.length > 0;
+				return (
+					<div
+						className={cn(
+							"flex items-center gap-2 pl-2",
+							hasReservation && "border-l-4 border-l-emerald-500 -ml-2 py-0.5",
+						)}
+					>
+						<span className="text-sm font-medium">
+							{standDisplayLabel(row.original.label, row.original.standNumber)}
+						</span>
+					</div>
+				);
+			},
+			sortingFn: (a, b) => {
+				const an = a.original.standNumber;
+				const bn = b.original.standNumber;
+				return an - bn || a.original.id - b.original.id;
+			},
+		},
+		{
+			accessorKey: "sectorName",
+			id: "sector",
+			header: ({ column }) => (
+				<DataTableColumnHeader column={column} title={columnTitles.sector} />
+			),
+			cell: ({ row }) => (
+				<span className="text-sm">{row.original.sectorName}</span>
+			),
+			filterFn: (row, _columnId, filterValue: string[]) => {
+				if (!filterValue?.length) return true;
+				return filterValue.includes(String(row.original.sectorId));
+			},
+		},
+		{
+			accessorKey: "status",
+			id: "status",
+			header: ({ column }) => (
+				<DataTableColumnHeader column={column} title={columnTitles.status} />
+			),
+			cell: ({ row }) => (
+				<StatusCell
+					stand={row.original}
+					onQuickStatus={onQuickStatus}
+					isPending={pendingQuickStatusId === row.original.id}
+				/>
+			),
+			filterFn: (row, _columnId, filterValue: string[]) => {
+				if (!filterValue?.length) return true;
+				return filterValue.includes(row.original.status);
+			},
+		},
+		{
+			accessorKey: "standCategory",
+			id: "standCategory",
+			header: ({ column }) => (
+				<DataTableColumnHeader
+					column={column}
+					title={columnTitles.standCategory}
+				/>
+			),
+			cell: ({ row }) => (
+				<span className="text-sm text-muted-foreground">
+					{getCategoryLabel(row.original.standCategory as StandCategory)}
+				</span>
+			),
+			filterFn: (row, _columnId, filterValue: string[]) => {
+				if (!filterValue?.length) return true;
+				return filterValue.includes(row.original.standCategory);
+			},
+		},
+		{
+			accessorKey: "price",
+			id: "price",
+			header: ({ column }) => (
+				<DataTableColumnHeader column={column} title={columnTitles.price} />
+			),
+			cell: ({ row }) => (
+				<span className="text-sm tabular-nums">
+					{formatPrice(row.original.price ?? 0)}
+				</span>
+			),
+		},
+		{
+			id: "reservation",
+			header: ({ column }) => (
+				<DataTableColumnHeader
+					column={column}
+					title={columnTitles.reservation}
+				/>
+			),
+			accessorFn: (row) => (row.reservations.length > 0 ? "yes" : "no"),
+			cell: ({ row }) => {
+				const hasReservation = row.original.reservations.length > 0;
+				return hasReservation ? (
+					<Badge variant="secondary" className="text-xs">
+						Con reserva
+					</Badge>
+				) : (
+					<span className="text-xs text-muted-foreground">—</span>
+				);
+			},
+			filterFn: (row, _columnId, filterValue: string[]) => {
+				if (!filterValue?.length) return true;
+				const has = row.original.reservations.length > 0 ? "yes" : "no";
+				return filterValue.includes(has);
+			},
+			enableSorting: false,
+		},
+		{
+			id: "actions",
+			header: () => null,
+			cell: ({ row }) => (
+				<div className="flex justify-end">
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => onEdit(row.original)}
+						aria-label={`Editar ${standDisplayLabel(row.original.label, row.original.standNumber)}`}
+					>
+						<EditIcon className="mr-1 h-4 w-4" />
+						Editar
+					</Button>
+				</div>
+			),
+			enableSorting: false,
+			enableHiding: false,
+		},
+	];
+}
+
+export function standFilterOptions() {
+	return {
+		status: STAND_STATUS_OPTIONS.map((o) => ({
+			value: o.value,
+			label: o.label,
+		})),
+		category: CATEGORY_OPTIONS.map((o) => ({
+			value: o.value,
+			label: o.label,
+		})),
+		reservation: [
+			{ value: "yes", label: "Con reserva" },
+			{ value: "no", label: "Sin reserva" },
+		],
+	};
+}

--- a/app/components/maps/admin/stand-manage/edit-form-dialog.tsx
+++ b/app/components/maps/admin/stand-manage/edit-form-dialog.tsx
@@ -91,20 +91,29 @@ export default function StandEditFormDialog({
 
 	async function onSubmit(values: FormOutput) {
 		if (!stand) return;
-		const res = await updateStand({
-			id: stand.id,
-			label: values.label,
-			standNumber: values.standNumber,
-			status: values.status,
-			price: values.price,
-			standCategory: values.standCategory,
-		});
-		if (res.success) {
-			toast.success(res.message);
-			onOpenChange(false);
-			onSaved?.();
-		} else {
-			toast.error(res.message);
+		try {
+			const res = await updateStand({
+				id: stand.id,
+				label: values.label,
+				standNumber: values.standNumber,
+				status: values.status,
+				price: values.price,
+				standCategory: values.standCategory,
+			});
+			if (res.success) {
+				toast.success(res.message);
+				onOpenChange(false);
+				onSaved?.();
+			} else {
+				toast.error(res.message);
+			}
+		} catch (error) {
+			console.error(error);
+			toast.error(
+				error instanceof Error
+					? error.message
+					: "No se pudo actualizar el espacio. Intenta de nuevo.",
+			);
 		}
 	}
 

--- a/app/components/maps/admin/stand-manage/edit-form-dialog.tsx
+++ b/app/components/maps/admin/stand-manage/edit-form-dialog.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import { updateStand } from "@/app/api/stands/actions";
+import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import SelectInput from "@/app/components/form/fields/select";
+import TextInput from "@/app/components/form/fields/text";
+import { Button } from "@/app/components/ui/button";
+import {
+	DrawerDialog,
+	DrawerDialogClose,
+	DrawerDialogContent,
+	DrawerDialogFooter,
+	DrawerDialogHeader,
+	DrawerDialogTitle,
+} from "@/app/components/ui/drawer-dialog";
+import { Form } from "@/app/components/ui/form";
+import { useMediaQuery } from "@/app/hooks/use-media-query";
+
+import {
+	CATEGORY_OPTIONS,
+	STAND_STATUS_OPTIONS,
+	StandCategory,
+	StandStatus,
+} from "@/app/components/maps/admin/stand-manage/shared";
+
+const FormSchema = z.object({
+	label: z.string().trim().min(1, "La etiqueta es requerida"),
+	standNumber: z.coerce.number().int().min(1, "Debe ser mayor a 0"),
+	status: z.enum([
+		"available",
+		"held",
+		"reserved",
+		"confirmed",
+		"disabled",
+	]) as z.ZodType<StandStatus>,
+	price: z.coerce.number().min(0, "No puede ser negativo"),
+	standCategory: z.enum([
+		"none",
+		"illustration",
+		"gastronomy",
+		"entrepreneurship",
+		"new_artist",
+	]) as z.ZodType<StandCategory>,
+});
+
+type FormInput = z.input<typeof FormSchema>;
+type FormOutput = z.output<typeof FormSchema>;
+
+type Props = {
+	stand: StandWithReservationsWithParticipants | null;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onSaved?: () => void;
+};
+
+export default function StandEditFormDialog({
+	stand,
+	open,
+	onOpenChange,
+	onSaved,
+}: Props) {
+	const isDesktop = useMediaQuery("(min-width: 768px)");
+	const form = useForm<FormInput, unknown, FormOutput>({
+		resolver: zodResolver(FormSchema),
+		defaultValues: {
+			label: "",
+			standNumber: "1",
+			status: "available",
+			price: "0",
+			standCategory: "none",
+		},
+	});
+
+	useEffect(() => {
+		if (stand && open) {
+			form.reset({
+				label: stand.label ?? "",
+				standNumber: String(stand.standNumber),
+				status: stand.status as StandStatus,
+				price: String(stand.price ?? 0),
+				standCategory: stand.standCategory as StandCategory,
+			});
+		}
+	}, [stand, open, form]);
+
+	async function onSubmit(values: FormOutput) {
+		if (!stand) return;
+		const res = await updateStand({
+			id: stand.id,
+			label: values.label,
+			standNumber: values.standNumber,
+			status: values.status,
+			price: values.price,
+			standCategory: values.standCategory,
+		});
+		if (res.success) {
+			toast.success(res.message);
+			onOpenChange(false);
+			onSaved?.();
+		} else {
+			toast.error(res.message);
+		}
+	}
+
+	return (
+		<DrawerDialog isDesktop={isDesktop} open={open} onOpenChange={onOpenChange}>
+			<DrawerDialogContent className="sm:max-w-md" isDesktop={isDesktop}>
+				<DrawerDialogHeader isDesktop={isDesktop}>
+					<DrawerDialogTitle isDesktop={isDesktop}>
+						Editar espacio
+					</DrawerDialogTitle>
+				</DrawerDialogHeader>
+
+				<div className={isDesktop ? "" : "px-4 pb-2"}>
+					<Form {...form}>
+						<form
+							onSubmit={form.handleSubmit(onSubmit)}
+							className="grid gap-4 pt-2"
+						>
+							<TextInput label="Etiqueta" name="label" required />
+							<div className="grid gap-4 sm:grid-cols-2">
+								<TextInput
+									label="Número"
+									name="standNumber"
+									type="number"
+									inputMode="numeric"
+									min={1}
+								/>
+								<TextInput
+									label="Precio (Bs.)"
+									name="price"
+									type="number"
+									inputMode="decimal"
+									min={0}
+									step={1}
+								/>
+							</div>
+							<SelectInput
+								formControl={form.control}
+								label="Estado"
+								name="status"
+								options={STAND_STATUS_OPTIONS.map((o) => ({
+									value: o.value,
+									label: o.label,
+								}))}
+							/>
+							<SelectInput
+								formControl={form.control}
+								label="Categoría"
+								name="standCategory"
+								options={CATEGORY_OPTIONS.map((o) => ({
+									value: o.value,
+									label: o.label,
+								}))}
+							/>
+
+							<div className="flex justify-end gap-2 pt-2">
+								{isDesktop && (
+									<Button
+										type="button"
+										variant="outline"
+										onClick={() => onOpenChange(false)}
+									>
+										Cancelar
+									</Button>
+								)}
+								<Button type="submit" disabled={form.formState.isSubmitting}>
+									{form.formState.isSubmitting ? "Guardando…" : "Guardar"}
+								</Button>
+							</div>
+						</form>
+					</Form>
+				</div>
+
+				{!isDesktop && (
+					<DrawerDialogFooter isDesktop={isDesktop} className="pt-2">
+						<DrawerDialogClose isDesktop={isDesktop}>
+							<Button variant="outline">Cancelar</Button>
+						</DrawerDialogClose>
+					</DrawerDialogFooter>
+				)}
+			</DrawerDialogContent>
+		</DrawerDialog>
+	);
+}

--- a/app/components/maps/admin/stand-manage/shared.ts
+++ b/app/components/maps/admin/stand-manage/shared.ts
@@ -1,0 +1,46 @@
+export const STAND_STATUS_OPTIONS = [
+	{ value: "available", label: "Disponible" },
+	{ value: "held", label: "En espera" },
+	{ value: "reserved", label: "Reservado" },
+	{ value: "confirmed", label: "Confirmado" },
+	{ value: "disabled", label: "Deshabilitado" },
+] as const;
+
+export type StandStatus = (typeof STAND_STATUS_OPTIONS)[number]["value"];
+
+export const CATEGORY_OPTIONS = [
+	{ value: "none", label: "Ninguna" },
+	{ value: "illustration", label: "Ilustración" },
+	{ value: "gastronomy", label: "Gastronomía" },
+	{ value: "entrepreneurship", label: "Emprendimiento" },
+	{ value: "new_artist", label: "Artista nuevo" },
+] as const;
+
+export type StandCategory = (typeof CATEGORY_OPTIONS)[number]["value"];
+
+export const RESERVATION_OPTIONS = [
+	{ value: "yes", label: "Con reserva" },
+	{ value: "no", label: "Sin reserva" },
+] as const;
+
+export const CONFIRMATION_THRESHOLD = 20;
+
+export function formatPrice(amount: number) {
+	return new Intl.NumberFormat("es-BO", {
+		style: "currency",
+		currency: "BOB",
+		minimumFractionDigits: 2,
+	}).format(amount);
+}
+
+export function getStatusLabel(status: StandStatus) {
+	return STAND_STATUS_OPTIONS.find((o) => o.value === status)?.label ?? status;
+}
+
+export function getCategoryLabel(category: StandCategory) {
+	return CATEGORY_OPTIONS.find((o) => o.value === category)?.label ?? category;
+}
+
+export function standDisplayLabel(label: string | null, standNumber: number) {
+	return `${label ?? ""}${standNumber}`;
+}

--- a/app/components/maps/admin/stand-position-editor.tsx
+++ b/app/components/maps/admin/stand-position-editor.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	TransformComponent,
@@ -15,6 +16,7 @@ import {
 	AlignVerticalSpaceAround,
 	Download,
 	Grid3x3,
+	ListTree,
 	Magnet,
 	MapPin,
 	Maximize2,
@@ -1428,6 +1430,12 @@ export default function StandPositionEditor({
 					<Upload className="h-4 w-4 mr-1" />
 					Importar
 				</Button>
+				<Button variant="outline" size="sm" asChild>
+					<Link href={`/dashboard/festivals/${festivalId}/stands/manage`}>
+						<ListTree className="h-4 w-4 mr-1" />
+						Gestionar espacios (tabla)
+					</Link>
+				</Button>
 			</div>
 
 			{/* Toggles toolbar */}
@@ -1865,6 +1873,7 @@ export default function StandPositionEditor({
 							>
 								<option value="disabled">Deshabilitado</option>
 								<option value="available">Disponible</option>
+								<option value="held">En espera</option>
 								<option value="reserved">Reservado</option>
 								<option value="confirmed">Confirmado</option>
 							</select>

--- a/app/dashboard/festivals/[id]/stands/manage/page.tsx
+++ b/app/dashboard/festivals/[id]/stands/manage/page.tsx
@@ -26,7 +26,7 @@ export default async function StandManagePage({
 	if (!festival) return notFound();
 
 	return (
-		<div className="container py-6">
+		<div className="container p-4 md:p-6">
 			<StandManageTable
 				festivalId={id}
 				festivalName={festival.name}

--- a/app/dashboard/festivals/[id]/stands/manage/page.tsx
+++ b/app/dashboard/festivals/[id]/stands/manage/page.tsx
@@ -1,0 +1,37 @@
+import { notFound } from "next/navigation";
+import { z } from "zod";
+
+import StandManageTable from "@/app/components/maps/admin/stand-manage-table";
+import { getFestivalById } from "@/app/lib/festivals/helpers";
+import { fetchFestivalSectors } from "@/app/lib/festival_sectors/actions";
+
+const ParamsSchema = z.object({
+	id: z.coerce.number(),
+});
+
+export default async function StandManagePage({
+	params,
+}: {
+	params: Promise<z.infer<typeof ParamsSchema>>;
+}) {
+	const parsed = ParamsSchema.safeParse(await params);
+	if (!parsed.success) return notFound();
+
+	const { id } = parsed.data;
+	const [festival, sectors] = await Promise.all([
+		getFestivalById(id),
+		fetchFestivalSectors(id),
+	]);
+
+	if (!festival) return notFound();
+
+	return (
+		<div className="container py-6">
+			<StandManageTable
+				festivalId={id}
+				festivalName={festival.name}
+				sectors={sectors}
+			/>
+		</div>
+	);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "jsbarcode": "^3.11.6",
         "lucide-react": "0.503.0",
         "luxon": "^3.5.0",
-        "next": "16.2.1",
+        "next": "^16.2.4",
         "next-themes": "^0.4.4",
         "pg": "^8.11.5",
         "playwright": "^1.59.1",
@@ -3686,9 +3686,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.1.tgz",
-      "integrity": "sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
+      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
       "cpu": [
         "arm64"
       ],
@@ -3702,9 +3702,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.1.tgz",
-      "integrity": "sha512-/vrcE6iQSJq3uL3VGVHiXeaKbn8Es10DGTGRJnRZlkNQQk3kaNtAJg8Y6xuAlrx/6INKVjkfi5rY0iEXorZ6uA==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
       "cpu": [
         "x64"
       ],
@@ -3718,11 +3718,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.1.tgz",
-      "integrity": "sha512-uLn+0BK+C31LTVbQ/QU+UaVrV0rRSJQ8RfniQAHPghDdgE+SlroYqcmFnO5iNjNfVWCyKZHYrs3Nl0mUzWxbBw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3734,11 +3737,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.1.tgz",
-      "integrity": "sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3750,11 +3756,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.1.tgz",
-      "integrity": "sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3766,11 +3775,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.1.tgz",
-      "integrity": "sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3782,9 +3794,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.1.tgz",
-      "integrity": "sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
       "cpu": [
         "arm64"
       ],
@@ -3798,9 +3810,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.1.tgz",
-      "integrity": "sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
       "cpu": [
         "x64"
       ],
@@ -14374,12 +14386,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.1.tgz",
-      "integrity": "sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
+      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.1",
+        "@next/env": "16.2.4",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -14393,14 +14405,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.1",
-        "@next/swc-darwin-x64": "16.2.1",
-        "@next/swc-linux-arm64-gnu": "16.2.1",
-        "@next/swc-linux-arm64-musl": "16.2.1",
-        "@next/swc-linux-x64-gnu": "16.2.1",
-        "@next/swc-linux-x64-musl": "16.2.1",
-        "@next/swc-win32-arm64-msvc": "16.2.1",
-        "@next/swc-win32-x64-msvc": "16.2.1",
+        "@next/swc-darwin-arm64": "16.2.4",
+        "@next/swc-darwin-x64": "16.2.4",
+        "@next/swc-linux-arm64-gnu": "16.2.4",
+        "@next/swc-linux-arm64-musl": "16.2.4",
+        "@next/swc-linux-x64-gnu": "16.2.4",
+        "@next/swc-linux-x64-musl": "16.2.4",
+        "@next/swc-win32-arm64-msvc": "16.2.4",
+        "@next/swc-win32-x64-msvc": "16.2.4",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -14435,6 +14447,12 @@
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
+    },
+    "node_modules/next/node_modules/@next/env": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
+      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "license": "MIT"
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "jsbarcode": "^3.11.6",
     "lucide-react": "0.503.0",
     "luxon": "^3.5.0",
-    "next": "16.2.1",
+    "next": "^16.2.4",
     "next-themes": "^0.4.4",
     "pg": "^8.11.5",
     "playwright": "^1.59.1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive Stands Management dashboard: table and mobile card views, per‑sector tabs, filters, reservation counts, and bulk actions bar
  * Bulk operations: update status/category/price/label, sequential renumbering, and bulk delete (confirmation thresholds; delete disabled when reservations exist)
  * Single‑stand edit dialog and in‑table quick status changes with optimistic UI and toasts
  * "Manage Stands" button on festival cards and dedicated manage‑stands page
  * Added "held" stand status option
<!-- end of auto-generated comment: release notes by coderabbit.ai -->