### PR TITLE
refactor(cache): drop cacheComponents and align caching with react.cache

### DIFF
--- a/app/(routes)/portal/page.tsx
+++ b/app/(routes)/portal/page.tsx
@@ -2,11 +2,15 @@ import { CakeIcon, CogIcon } from "lucide-react";
 import { DateTime } from "luxon";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { Suspense } from "react";
 
 import Heading from "@/app/components/atoms/heading";
 import VerificationStatusLabel from "@/app/components/atoms/verification-status-label";
+import {
+	PortalBanners,
+	PortalBannersSkeleton,
+} from "@/app/components/marketing/portal-banners";
 import FestivalActivities from "@/app/components/participant_dashboard/festival-activities";
-import MarketingBannerCarousel from "@/app/components/marketing/marketing-banner-carousel";
 import ParticipationHistoryPreview from "@/app/components/participant_dashboard/participation-history-preview";
 import ReservationCard from "@/app/components/participant_dashboard/reservation-card";
 import RestrictedDashboard from "@/app/components/participant_dashboard/restricted-dashboard";
@@ -14,7 +18,6 @@ import {
 	fetchProfileEnrollmentInFestival,
 	fetchPublishedActiveFestivals,
 } from "@/app/lib/festivals/actions";
-import { fetchMarketingBannersForPortal } from "@/app/lib/marketing_banners/actions";
 import { getCurrentUserProfile } from "@/app/lib/users/helpers";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -35,10 +38,7 @@ export default async function ParticipantDashboardPage() {
 		);
 	}
 
-	const [marketingBanners, carouselFestivals] = await Promise.all([
-		fetchMarketingBannersForPortal(),
-		fetchPublishedActiveFestivals(),
-	]);
+	const carouselFestivals = await fetchPublishedActiveFestivals();
 
 	const activeFestival =
 		carouselFestivals.find((f) => f.status === "active") ?? null;
@@ -112,11 +112,9 @@ export default async function ParticipantDashboardPage() {
 				<Separator className="mt-4" />
 			</div>
 
-			{marketingBanners.length > 0 && (
-				<div className="w-full mt-4">
-					<MarketingBannerCarousel banners={marketingBanners} />
-				</div>
-			)}
+			<Suspense fallback={<PortalBannersSkeleton />}>
+				<PortalBanners />
+			</Suspense>
 
 			<div className="flex flex-col gap-6 mt-4">
 				{showMiParticipacionBlock && (

--- a/app/components/marketing/portal-banners.tsx
+++ b/app/components/marketing/portal-banners.tsx
@@ -1,0 +1,23 @@
+import MarketingBannerCarousel from "@/app/components/marketing/marketing-banner-carousel";
+import { Skeleton } from "@/app/components/ui/skeleton";
+import { fetchMarketingBannersForPortal } from "@/app/lib/marketing_banners/actions";
+
+export async function PortalBanners() {
+	const banners = await fetchMarketingBannersForPortal();
+
+	if (banners.length === 0) return null;
+
+	return (
+		<div className="w-full mt-4">
+			<MarketingBannerCarousel banners={banners} />
+		</div>
+	);
+}
+
+export function PortalBannersSkeleton() {
+	return (
+		<div className="w-full mt-4">
+			<Skeleton className="aspect-3/2 max-h-[240px] w-full rounded-lg md:aspect-3/1 md:max-h-[280px] lg:aspect-4/1 lg:max-h-[320px]" />
+		</div>
+	);
+}

--- a/app/lib/festival_exports/actions.ts
+++ b/app/lib/festival_exports/actions.ts
@@ -2,473 +2,471 @@
 
 import { db } from "@/db";
 import {
-  festivals,
-  festivalDates,
-  festivalSectors,
-  mapElements,
-  stands,
+	festivals,
+	festivalDates,
+	festivalSectors,
+	mapElements,
+	stands,
 } from "@/db/schema";
 import { eq } from "drizzle-orm";
-import { revalidatePath, updateTag } from "next/cache";
+import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import {
-  FestivalExport,
-  FestivalInfoTemplate,
-  ExportFestivalDataOptions,
-  ImportFestivalDataOptions,
+	FestivalExport,
+	FestivalInfoTemplate,
+	ExportFestivalDataOptions,
+	ImportFestivalDataOptions,
 } from "./definitions";
 import {
-  exportFestivalDataOptionsSchema,
-  festivalExportSchema,
-  importFestivalDataOptionsSchema,
+	exportFestivalDataOptionsSchema,
+	festivalExportSchema,
+	importFestivalDataOptionsSchema,
 } from "./schemas";
 import {
-  MapElementTemplate,
-  MapTemplate,
-  SectorTemplate,
-  StandTemplate,
+	MapElementTemplate,
+	MapTemplate,
+	SectorTemplate,
+	StandTemplate,
 } from "@/app/lib/map_templates/definitions";
 import { importTemplateToFestival } from "@/app/lib/map_templates/actions";
 
 export async function exportFestivalData(
-  festivalId: number,
-  options: ExportFestivalDataOptions,
+	festivalId: number,
+	options: ExportFestivalDataOptions,
 ): Promise<{ success: boolean; data?: FestivalExport; message: string }> {
-  try {
-    const parsedOptions = exportFestivalDataOptionsSchema.parse(options);
+	try {
+		const parsedOptions = exportFestivalDataOptionsSchema.parse(options);
 
-    const festival = await db.query.festivals.findFirst({
-      where: eq(festivals.id, festivalId),
-      with: {
-        festivalDates: true,
-        festivalSectors: {
-          with: {
-            stands: true,
-            mapElements: true,
-          },
-          orderBy: festivalSectors.orderInFestival,
-        },
-      },
-    });
+		const festival = await db.query.festivals.findFirst({
+			where: eq(festivals.id, festivalId),
+			with: {
+				festivalDates: true,
+				festivalSectors: {
+					with: {
+						stands: true,
+						mapElements: true,
+					},
+					orderBy: festivalSectors.orderInFestival,
+				},
+			},
+		});
 
-    if (!festival) {
-      return { success: false, message: "Festival no encontrado" };
-    }
+		if (!festival) {
+			return { success: false, message: "Festival no encontrado" };
+		}
 
-    // Build festival info template
-    let festivalInfo: FestivalInfoTemplate | undefined;
-    if (parsedOptions.includeBasicInfo) {
-      festivalInfo = {
-        name: festival.name,
-        description: festival.description,
-        address: festival.address,
-        locationLabel: festival.locationLabel,
-        locationUrl: festival.locationUrl,
-        festivalType: festival.festivalType,
-        mapsVersion: festival.mapsVersion,
-        publicRegistration: festival.publicRegistration,
-        eventDayRegistration: festival.eventDayRegistration,
-        festivalCode: festival.festivalCode,
-        dates: festival.festivalDates.map((d) => ({
-          startDate: d.startDate.toISOString(),
-          endDate: d.endDate.toISOString(),
-        })),
-      };
-    }
+		// Build festival info template
+		let festivalInfo: FestivalInfoTemplate | undefined;
+		if (parsedOptions.includeBasicInfo) {
+			festivalInfo = {
+				name: festival.name,
+				description: festival.description,
+				address: festival.address,
+				locationLabel: festival.locationLabel,
+				locationUrl: festival.locationUrl,
+				festivalType: festival.festivalType,
+				mapsVersion: festival.mapsVersion,
+				publicRegistration: festival.publicRegistration,
+				eventDayRegistration: festival.eventDayRegistration,
+				festivalCode: festival.festivalCode,
+				dates: festival.festivalDates.map((d) => ({
+					startDate: d.startDate.toISOString(),
+					endDate: d.endDate.toISOString(),
+				})),
+			};
+		}
 
-    // Build sectors template
-    let sectorTemplates: SectorTemplate[] | undefined;
-    if (parsedOptions.includeSectors) {
-      const filteredSectors = parsedOptions.sectorIds
-        ? festival.festivalSectors.filter((s) =>
-            parsedOptions.sectorIds!.includes(s.id),
-          )
-        : festival.festivalSectors;
+		// Build sectors template
+		let sectorTemplates: SectorTemplate[] | undefined;
+		if (parsedOptions.includeSectors) {
+			const filteredSectors = parsedOptions.sectorIds
+				? festival.festivalSectors.filter((s) =>
+						parsedOptions.sectorIds!.includes(s.id),
+					)
+				: festival.festivalSectors;
 
-      if (filteredSectors.length === 0) {
-        return { success: false, message: "No se encontraron sectores" };
-      }
+			if (filteredSectors.length === 0) {
+				return { success: false, message: "No se encontraron sectores" };
+			}
 
-      sectorTemplates = filteredSectors.map((sector) => ({
-        name: sector.name,
-        description: sector.description,
-        orderInFestival: sector.orderInFestival,
-        mapBounds: {
-          originX: sector.mapOriginX,
-          originY: sector.mapOriginY,
-          width: sector.mapWidth,
-          height: sector.mapHeight,
-        },
-        stands: sector.stands.map(
-          (stand): StandTemplate => ({
-            label: stand.label,
-            standNumber: stand.standNumber,
-            standCategory: stand.standCategory,
-            zone: stand.zone,
-            orientation: stand.orientation,
-            width: stand.width,
-            height: stand.height,
-            positionLeft: stand.positionLeft ?? 0,
-            positionTop: stand.positionTop ?? 0,
-            price: stand.price,
-          }),
-        ),
-        elements:
-          sector.mapElements.length > 0
-            ? sector.mapElements.map(
-                (el): MapElementTemplate => ({
-                  type: el.type,
-                  label: el.label,
-                  labelPosition: el.labelPosition,
-                  labelFontSize: el.labelFontSize,
-                  showIcon: el.showIcon,
-                  labelFontWeight: el.labelFontWeight,
-                  rotation: el.rotation ?? 0,
-                  positionLeft: el.positionLeft,
-                  positionTop: el.positionTop,
-                  width: el.width,
-                  height: el.height,
-                }),
-              )
-            : undefined,
-      }));
-    }
+			sectorTemplates = filteredSectors.map((sector) => ({
+				name: sector.name,
+				description: sector.description,
+				orderInFestival: sector.orderInFestival,
+				mapBounds: {
+					originX: sector.mapOriginX,
+					originY: sector.mapOriginY,
+					width: sector.mapWidth,
+					height: sector.mapHeight,
+				},
+				stands: sector.stands.map(
+					(stand): StandTemplate => ({
+						label: stand.label,
+						standNumber: stand.standNumber,
+						standCategory: stand.standCategory,
+						zone: stand.zone,
+						orientation: stand.orientation,
+						width: stand.width,
+						height: stand.height,
+						positionLeft: stand.positionLeft ?? 0,
+						positionTop: stand.positionTop ?? 0,
+						price: stand.price,
+					}),
+				),
+				elements:
+					sector.mapElements.length > 0
+						? sector.mapElements.map(
+								(el): MapElementTemplate => ({
+									type: el.type,
+									label: el.label,
+									labelPosition: el.labelPosition,
+									labelFontSize: el.labelFontSize,
+									showIcon: el.showIcon,
+									labelFontWeight: el.labelFontWeight,
+									rotation: el.rotation ?? 0,
+									positionLeft: el.positionLeft,
+									positionTop: el.positionTop,
+									width: el.width,
+									height: el.height,
+								}),
+							)
+						: undefined,
+			}));
+		}
 
-    const exportData: FestivalExport = {
-      version: "2.0",
-      metadata: {
-        name: `${festival.name} - Exportacion`,
-        createdAt: new Date().toISOString(),
-        createdFrom: {
-          festivalId: festival.id,
-          festivalName: festival.name,
-        },
-        exportOptions: {
-          includeBasicInfo: parsedOptions.includeBasicInfo,
-          includeSectors: parsedOptions.includeSectors,
-        },
-      },
-      festival: festivalInfo,
-      sectors: sectorTemplates,
-    };
+		const exportData: FestivalExport = {
+			version: "2.0",
+			metadata: {
+				name: `${festival.name} - Exportacion`,
+				createdAt: new Date().toISOString(),
+				createdFrom: {
+					festivalId: festival.id,
+					festivalName: festival.name,
+				},
+				exportOptions: {
+					includeBasicInfo: parsedOptions.includeBasicInfo,
+					includeSectors: parsedOptions.includeSectors,
+				},
+			},
+			festival: festivalInfo,
+			sectors: sectorTemplates,
+		};
 
-    return {
-      success: true,
-      data: exportData,
-      message: "Datos exportados correctamente",
-    };
-  } catch (error) {
-    console.error("Error exporting festival data", error);
-    return { success: false, message: "Error al exportar los datos" };
-  }
+		return {
+			success: true,
+			data: exportData,
+			message: "Datos exportados correctamente",
+		};
+	} catch (error) {
+		console.error("Error exporting festival data", error);
+		return { success: false, message: "Error al exportar los datos" };
+	}
 }
 
 export async function importFestivalData(
-  festivalId: number,
-  exportData: FestivalExport,
-  options: ImportFestivalDataOptions,
+	festivalId: number,
+	exportData: FestivalExport,
+	options: ImportFestivalDataOptions,
 ): Promise<{
-  success: boolean;
-  message: string;
-  details?: {
-    basicInfoUpdated: boolean;
-    sectorsCreated: number;
-    standsCreated: number;
-    datesCreated: number;
-  };
+	success: boolean;
+	message: string;
+	details?: {
+		basicInfoUpdated: boolean;
+		sectorsCreated: number;
+		standsCreated: number;
+		datesCreated: number;
+	};
 }> {
-  try {
-    const parsedData = festivalExportSchema.parse(exportData);
-    const parsedOptions = importFestivalDataOptionsSchema.parse(options);
+	try {
+		const parsedData = festivalExportSchema.parse(exportData);
+		const parsedOptions = importFestivalDataOptionsSchema.parse(options);
 
-    // Validate we have the data we need
-    if (parsedOptions.importBasicInfo && !parsedData.festival) {
-      return {
-        success: false,
-        message:
-          "El archivo no contiene informacion basica del festival",
-      };
-    }
+		// Validate we have the data we need
+		if (parsedOptions.importBasicInfo && !parsedData.festival) {
+			return {
+				success: false,
+				message: "El archivo no contiene informacion basica del festival",
+			};
+		}
 
-    if (parsedOptions.importSectors && !parsedData.sectors) {
-      return {
-        success: false,
-        message: "El archivo no contiene datos de sectores",
-      };
-    }
+		if (parsedOptions.importSectors && !parsedData.sectors) {
+			return {
+				success: false,
+				message: "El archivo no contiene datos de sectores",
+			};
+		}
 
-    let basicInfoUpdated = false;
-    let sectorsCreated = 0;
-    let standsCreated = 0;
-    let datesCreated = 0;
+		let basicInfoUpdated = false;
+		let sectorsCreated = 0;
+		let standsCreated = 0;
+		let datesCreated = 0;
 
-    // Import basic info
-    if (parsedOptions.importBasicInfo && parsedData.festival) {
-      const festivalInfo = parsedData.festival;
+		// Import basic info
+		if (parsedOptions.importBasicInfo && parsedData.festival) {
+			const festivalInfo = parsedData.festival;
 
-      try {
-        await db.transaction(async (tx) => {
-          // Update festival basic fields
-          await tx
-            .update(festivals)
-            .set({
-              name: parsedOptions.nameOverride || festivalInfo.name,
-              description: festivalInfo.description,
-              address: festivalInfo.address,
-              locationLabel: festivalInfo.locationLabel,
-              locationUrl: festivalInfo.locationUrl,
-              festivalType: festivalInfo.festivalType,
-              mapsVersion: festivalInfo.mapsVersion,
-              publicRegistration: festivalInfo.publicRegistration,
-              eventDayRegistration: festivalInfo.eventDayRegistration,
-              festivalCode: festivalInfo.festivalCode,
-              updatedAt: new Date(),
-            })
-            .where(eq(festivals.id, festivalId));
+			try {
+				await db.transaction(async (tx) => {
+					// Update festival basic fields
+					await tx
+						.update(festivals)
+						.set({
+							name: parsedOptions.nameOverride || festivalInfo.name,
+							description: festivalInfo.description,
+							address: festivalInfo.address,
+							locationLabel: festivalInfo.locationLabel,
+							locationUrl: festivalInfo.locationUrl,
+							festivalType: festivalInfo.festivalType,
+							mapsVersion: festivalInfo.mapsVersion,
+							publicRegistration: festivalInfo.publicRegistration,
+							eventDayRegistration: festivalInfo.eventDayRegistration,
+							festivalCode: festivalInfo.festivalCode,
+							updatedAt: new Date(),
+						})
+						.where(eq(festivals.id, festivalId));
 
-          // Replace dates: delete existing, insert new
-          await tx
-            .delete(festivalDates)
-            .where(eq(festivalDates.festivalId, festivalId));
+					// Replace dates: delete existing, insert new
+					await tx
+						.delete(festivalDates)
+						.where(eq(festivalDates.festivalId, festivalId));
 
-          if (festivalInfo.dates.length > 0) {
-            await tx.insert(festivalDates).values(
-              festivalInfo.dates.map((d) => ({
-                festivalId,
-                startDate: new Date(d.startDate),
-                endDate: new Date(d.endDate),
-                updatedAt: new Date(),
-                createdAt: new Date(),
-              })),
-            );
-          }
+					if (festivalInfo.dates.length > 0) {
+						await tx.insert(festivalDates).values(
+							festivalInfo.dates.map((d) => ({
+								festivalId,
+								startDate: new Date(d.startDate),
+								endDate: new Date(d.endDate),
+								updatedAt: new Date(),
+								createdAt: new Date(),
+							})),
+						);
+					}
 
-          datesCreated = festivalInfo.dates.length;
-        });
+					datesCreated = festivalInfo.dates.length;
+				});
 
-        basicInfoUpdated = true;
-      } catch (error: unknown) {
-        // Check for unique name constraint violation
-        if (
-          error instanceof Error &&
-          error.message.includes("unique") &&
-          error.message.includes("name")
-        ) {
-          return {
-            success: false,
-            message:
-              "Ya existe un festival con ese nombre. Cambia el nombre en el archivo e intenta de nuevo.",
-          };
-        }
-        throw error;
-      }
-    }
+				basicInfoUpdated = true;
+			} catch (error: unknown) {
+				// Check for unique name constraint violation
+				if (
+					error instanceof Error &&
+					error.message.includes("unique") &&
+					error.message.includes("name")
+				) {
+					return {
+						success: false,
+						message:
+							"Ya existe un festival con ese nombre. Cambia el nombre en el archivo e intenta de nuevo.",
+					};
+				}
+				throw error;
+			}
+		}
 
-    // Import sectors/stands using existing importTemplateToFestival
-    if (parsedOptions.importSectors && parsedData.sectors) {
-      const hasElements = parsedData.sectors.some((s) => s.elements);
-      const mapTemplate: MapTemplate = {
-        version: hasElements ? "1.1" : "1.0",
-        metadata: {
-          name: parsedData.metadata.name,
-          createdAt: parsedData.metadata.createdAt,
-          createdFrom: parsedData.metadata.createdFrom,
-        },
-        sectors: parsedData.sectors,
-      };
+		// Import sectors/stands using existing importTemplateToFestival
+		if (parsedOptions.importSectors && parsedData.sectors) {
+			const hasElements = parsedData.sectors.some((s) => s.elements);
+			const mapTemplate: MapTemplate = {
+				version: hasElements ? "1.1" : "1.0",
+				metadata: {
+					name: parsedData.metadata.name,
+					createdAt: parsedData.metadata.createdAt,
+					createdFrom: parsedData.metadata.createdFrom,
+				},
+				sectors: parsedData.sectors,
+			};
 
-      const result = await importTemplateToFestival(festivalId, mapTemplate, {
-        mode: parsedOptions.sectorImportMode,
-      });
+			const result = await importTemplateToFestival(festivalId, mapTemplate, {
+				mode: parsedOptions.sectorImportMode,
+			});
 
-      if (!result.success) {
-        return {
-          success: false,
-          message: result.message,
-          details: {
-            basicInfoUpdated,
-            sectorsCreated: 0,
-            standsCreated: 0,
-            datesCreated,
-          },
-        };
-      }
+			if (!result.success) {
+				return {
+					success: false,
+					message: result.message,
+					details: {
+						basicInfoUpdated,
+						sectorsCreated: 0,
+						standsCreated: 0,
+						datesCreated,
+					},
+				};
+			}
 
-      sectorsCreated = parsedData.sectors.length;
-      standsCreated = result.createdStands ?? 0;
-    }
+			sectorsCreated = parsedData.sectors.length;
+			standsCreated = result.createdStands ?? 0;
+		}
 
-    revalidatePath("/dashboard/festivals");
-    revalidatePath("/", "layout");
-    updateTag("active-festival");
+		revalidatePath("/dashboard/festivals");
+		revalidatePath("/", "layout");
 
-    return {
-      success: true,
-      message: "Datos importados correctamente",
-      details: {
-        basicInfoUpdated,
-        sectorsCreated,
-        standsCreated,
-        datesCreated,
-      },
-    };
-  } catch (error) {
-    console.error("Error importing festival data", error);
-    if (error instanceof z.ZodError) {
-      return {
-        success: false,
-        message: "Estructura de datos invalida",
-      };
-    }
-    return { success: false, message: "Error al importar los datos" };
-  }
+		return {
+			success: true,
+			message: "Datos importados correctamente",
+			details: {
+				basicInfoUpdated,
+				sectorsCreated,
+				standsCreated,
+				datesCreated,
+			},
+		};
+	} catch (error) {
+		console.error("Error importing festival data", error);
+		if (error instanceof z.ZodError) {
+			return {
+				success: false,
+				message: "Estructura de datos invalida",
+			};
+		}
+		return { success: false, message: "Error al importar los datos" };
+	}
 }
 
 export async function createFestivalFromImport(
-  exportData: FestivalExport,
-  nameOverride?: string,
+	exportData: FestivalExport,
+	nameOverride?: string,
 ): Promise<{
-  success: boolean;
-  message: string;
-  festivalId?: number;
+	success: boolean;
+	message: string;
+	festivalId?: number;
 }> {
-  try {
-    const parsedData = festivalExportSchema.parse(exportData);
+	try {
+		const parsedData = festivalExportSchema.parse(exportData);
 
-    const festivalInfo = parsedData.festival;
+		const festivalInfo = parsedData.festival;
 
-    const result = await db.transaction(async (tx) => {
-      // Create festival
-      const [newFestival] = await tx
-        .insert(festivals)
-        .values({
-          name: nameOverride || (festivalInfo?.name ?? parsedData.metadata.name),
-          description: festivalInfo?.description ?? null,
-          address: festivalInfo?.address ?? null,
-          locationLabel: festivalInfo?.locationLabel ?? null,
-          locationUrl: festivalInfo?.locationUrl ?? null,
-          status: "draft",
-          mapsVersion: festivalInfo?.mapsVersion ?? "v1",
-          publicRegistration: festivalInfo?.publicRegistration ?? false,
-          eventDayRegistration: festivalInfo?.eventDayRegistration ?? false,
-          festivalType: festivalInfo?.festivalType ?? "glitter",
-          festivalCode: festivalInfo?.festivalCode ?? null,
-          reservationsStartDate: new Date(),
-          updatedAt: new Date(),
-          createdAt: new Date(),
-        })
-        .returning();
+		const result = await db.transaction(async (tx) => {
+			// Create festival
+			const [newFestival] = await tx
+				.insert(festivals)
+				.values({
+					name:
+						nameOverride || (festivalInfo?.name ?? parsedData.metadata.name),
+					description: festivalInfo?.description ?? null,
+					address: festivalInfo?.address ?? null,
+					locationLabel: festivalInfo?.locationLabel ?? null,
+					locationUrl: festivalInfo?.locationUrl ?? null,
+					status: "draft",
+					mapsVersion: festivalInfo?.mapsVersion ?? "v1",
+					publicRegistration: festivalInfo?.publicRegistration ?? false,
+					eventDayRegistration: festivalInfo?.eventDayRegistration ?? false,
+					festivalType: festivalInfo?.festivalType ?? "glitter",
+					festivalCode: festivalInfo?.festivalCode ?? null,
+					reservationsStartDate: new Date(),
+					updatedAt: new Date(),
+					createdAt: new Date(),
+				})
+				.returning();
 
-      // Insert dates
-      if (festivalInfo?.dates && festivalInfo.dates.length > 0) {
-        await tx.insert(festivalDates).values(
-          festivalInfo.dates.map((d) => ({
-            festivalId: newFestival.id,
-            startDate: new Date(d.startDate),
-            endDate: new Date(d.endDate),
-            updatedAt: new Date(),
-            createdAt: new Date(),
-          })),
-        );
-      }
+			// Insert dates
+			if (festivalInfo?.dates && festivalInfo.dates.length > 0) {
+				await tx.insert(festivalDates).values(
+					festivalInfo.dates.map((d) => ({
+						festivalId: newFestival.id,
+						startDate: new Date(d.startDate),
+						endDate: new Date(d.endDate),
+						updatedAt: new Date(),
+						createdAt: new Date(),
+					})),
+				);
+			}
 
-      // Create sectors with stands and elements
-      if (parsedData.sectors && parsedData.sectors.length > 0) {
-        for (const sectorTemplate of parsedData.sectors) {
-          const [newSector] = await tx
-            .insert(festivalSectors)
-            .values({
-              festivalId: newFestival.id,
-              name: sectorTemplate.name,
-              description: sectorTemplate.description,
-              orderInFestival: sectorTemplate.orderInFestival,
-              mapOriginX: sectorTemplate.mapBounds.originX,
-              mapOriginY: sectorTemplate.mapBounds.originY,
-              mapWidth: sectorTemplate.mapBounds.width,
-              mapHeight: sectorTemplate.mapBounds.height,
-            })
-            .returning();
+			// Create sectors with stands and elements
+			if (parsedData.sectors && parsedData.sectors.length > 0) {
+				for (const sectorTemplate of parsedData.sectors) {
+					const [newSector] = await tx
+						.insert(festivalSectors)
+						.values({
+							festivalId: newFestival.id,
+							name: sectorTemplate.name,
+							description: sectorTemplate.description,
+							orderInFestival: sectorTemplate.orderInFestival,
+							mapOriginX: sectorTemplate.mapBounds.originX,
+							mapOriginY: sectorTemplate.mapBounds.originY,
+							mapWidth: sectorTemplate.mapBounds.width,
+							mapHeight: sectorTemplate.mapBounds.height,
+						})
+						.returning();
 
-          // Create stands
-          if (sectorTemplate.stands.length > 0) {
-            await tx.insert(stands).values(
-              sectorTemplate.stands.map((stand) => ({
-                label: stand.label,
-                standNumber: stand.standNumber,
-                standCategory: stand.standCategory,
-                zone: stand.zone,
-                orientation: stand.orientation,
-                width: stand.width,
-                height: stand.height,
-                positionLeft: stand.positionLeft,
-                positionTop: stand.positionTop,
-                price: stand.price,
-                status: "available" as const,
-                festivalId: newFestival.id,
-                festivalSectorId: newSector.id,
-              })),
-            );
-          }
+					// Create stands
+					if (sectorTemplate.stands.length > 0) {
+						await tx.insert(stands).values(
+							sectorTemplate.stands.map((stand) => ({
+								label: stand.label,
+								standNumber: stand.standNumber,
+								standCategory: stand.standCategory,
+								zone: stand.zone,
+								orientation: stand.orientation,
+								width: stand.width,
+								height: stand.height,
+								positionLeft: stand.positionLeft,
+								positionTop: stand.positionTop,
+								price: stand.price,
+								status: "available" as const,
+								festivalId: newFestival.id,
+								festivalSectorId: newSector.id,
+							})),
+						);
+					}
 
-          // Create map elements
-          const templateElements = sectorTemplate.elements ?? [];
-          if (templateElements.length > 0) {
-            await tx.insert(mapElements).values(
-              templateElements.map((el) => ({
-                type: el.type,
-                label: el.label,
-                labelPosition: el.labelPosition ?? "bottom",
-                labelFontSize: el.labelFontSize ?? 2,
-                showIcon: el.showIcon ?? true,
-                labelFontWeight: el.labelFontWeight ?? 500,
-                rotation: el.rotation ?? 0,
-                positionLeft: el.positionLeft,
-                positionTop: el.positionTop,
-                width: el.width,
-                height: el.height,
-                festivalSectorId: newSector.id,
-              })),
-            );
-          }
-        }
-      }
+					// Create map elements
+					const templateElements = sectorTemplate.elements ?? [];
+					if (templateElements.length > 0) {
+						await tx.insert(mapElements).values(
+							templateElements.map((el) => ({
+								type: el.type,
+								label: el.label,
+								labelPosition: el.labelPosition ?? "bottom",
+								labelFontSize: el.labelFontSize ?? 2,
+								showIcon: el.showIcon ?? true,
+								labelFontWeight: el.labelFontWeight ?? 500,
+								rotation: el.rotation ?? 0,
+								positionLeft: el.positionLeft,
+								positionTop: el.positionTop,
+								width: el.width,
+								height: el.height,
+								festivalSectorId: newSector.id,
+							})),
+						);
+					}
+				}
+			}
 
-      return newFestival;
-    });
+			return newFestival;
+		});
 
-    revalidatePath("/dashboard/festivals");
-    updateTag("active-festival");
+		revalidatePath("/dashboard/festivals");
 
-    return {
-      success: true,
-      message: "Festival creado correctamente desde importacion",
-      festivalId: result.id,
-    };
-  } catch (error: unknown) {
-    console.error("Error creating festival from import", error);
+		return {
+			success: true,
+			message: "Festival creado correctamente desde importacion",
+			festivalId: result.id,
+		};
+	} catch (error: unknown) {
+		console.error("Error creating festival from import", error);
 
-    if (
-      error instanceof Error &&
-      error.message.includes("unique") &&
-      error.message.includes("name")
-    ) {
-      return {
-        success: false,
-        message:
-          "Ya existe un festival con ese nombre. Cambia el nombre en el archivo e intenta de nuevo.",
-      };
-    }
+		if (
+			error instanceof Error &&
+			error.message.includes("unique") &&
+			error.message.includes("name")
+		) {
+			return {
+				success: false,
+				message:
+					"Ya existe un festival con ese nombre. Cambia el nombre en el archivo e intenta de nuevo.",
+			};
+		}
 
-    if (error instanceof z.ZodError) {
-      return {
-        success: false,
-        message: "Estructura de datos invalida",
-      };
-    }
+		if (error instanceof z.ZodError) {
+			return {
+				success: false,
+				message: "Estructura de datos invalida",
+			};
+		}
 
-    return {
-      success: false,
-      message: "Error al crear el festival desde importacion",
-    };
-  }
+		return {
+			success: false,
+			message: "Error al crear el festival desde importacion",
+		};
+	}
 }

--- a/app/lib/festivals/actions.ts
+++ b/app/lib/festivals/actions.ts
@@ -34,7 +34,7 @@ import {
 	or,
 	sql,
 } from "drizzle-orm";
-import { cacheLife, cacheTag, revalidatePath, updateTag } from "next/cache";
+import { revalidatePath } from "next/cache";
 import {
 	FestivalActivityWithDetailsAndParticipants,
 	FestivalBase,
@@ -132,7 +132,6 @@ export async function createFestival(
 		});
 
 		revalidatePath("/dashboard/festivals");
-		updateTag("active-festival");
 		return {
 			success: true,
 			message: "Festival creado exitosamente!",
@@ -159,7 +158,6 @@ export async function deleteFestival(festivalId: number) {
 		};
 	}
 	revalidatePath("/dashboard/festivals");
-	updateTag("active-festival");
 	return {
 		success: true,
 		message: "Festival eliminado correctamente!",
@@ -342,7 +340,6 @@ export async function updateFestival(
 		});
 
 		revalidatePath("/dashboard/festivals");
-		updateTag("active-festival");
 		return {
 			success: true,
 			message: "Festival actualizado correctamente.",
@@ -398,10 +395,6 @@ export async function fetchFestivalActivityForReview(
 export async function fetchPublishedActiveFestivals(): Promise<
 	FestivalWithDates[]
 > {
-	"use cache";
-	cacheLife("minutes");
-	cacheTag("active-festival");
-
 	try {
 		return (await db.query.festivals.findMany({
 			where: or(
@@ -476,10 +469,6 @@ export async function fetchFestivalWithDatesAndSectors(
 }
 
 export async function fetchActiveFestivalWithDates(): Promise<FestivalWithDates | null> {
-	"use cache";
-	cacheLife("hours");
-	cacheTag("active-festival");
-
 	try {
 		const festival = await db.query.festivals.findFirst({
 			where: eq(festivals.status, "active"),
@@ -643,7 +632,6 @@ export async function updateFestivalStatusTemp(festival: FestivalBase) {
 	}
 
 	revalidatePath("/dashboard/festivals");
-	updateTag("active-festival");
 	return { success: true, message: "Festival actualizado con éxito" };
 }
 
@@ -741,7 +729,6 @@ export async function updateFestivalStatus(festival: FestivalBase) {
 	}
 
 	revalidatePath("/dashboard/festivals");
-	updateTag("active-festival");
 	return { success: true, message: "Festival actualizado con éxito" };
 }
 
@@ -776,7 +763,6 @@ export async function updateFestivalRegistration(
 	}
 
 	revalidatePath("/dashboard/festivals");
-	updateTag("active-festival");
 	return { success: true, message: "Festival actualizado con éxito" };
 }
 

--- a/app/lib/festivals/helpers.ts
+++ b/app/lib/festivals/helpers.ts
@@ -9,13 +9,11 @@ export const getActiveFestival = cache(async () => {
 	return await fetchFestival({});
 });
 
-// react.cache() is not needed here because fetchActiveFestivalWithDates uses
-// "use cache", which already deduplicates across requests. If "use cache" is
-// ever removed from that function, wrap this in react.cache() again for
-// per-request memoization.
-export async function getActiveFestivalBase(): Promise<FestivalWithDates | null> {
-	return await fetchActiveFestivalWithDates();
-}
+export const getActiveFestivalBase = cache(
+	async (): Promise<FestivalWithDates | null> => {
+		return await fetchActiveFestivalWithDates();
+	},
+);
 
 export const getFestivalById = cache(
 	async (festivalId: number): Promise<FullFestival | undefined | null> => {

--- a/app/lib/marketing_banners/actions.ts
+++ b/app/lib/marketing_banners/actions.ts
@@ -4,15 +4,13 @@ import { getCurrentUserProfile } from "@/app/lib/users/helpers";
 import { db } from "@/db";
 import { marketingBanners } from "@/db/schema";
 import { and, asc, eq, inArray, max, or } from "drizzle-orm";
-import { cacheLife, cacheTag, revalidatePath, updateTag } from "next/cache";
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import type {
 	MarketingBannerAudience,
 	MarketingBannerRow,
 } from "./definitions";
 import { assertValidHref } from "./validate-href";
-
-const CACHE_TAG = "marketing-banners";
 
 function canManageBanners(
 	role: string | null | undefined,
@@ -21,7 +19,6 @@ function canManageBanners(
 }
 
 function invalidateBanners() {
-	updateTag(CACHE_TAG);
 	revalidatePath("/", "page");
 	revalidatePath("/portal", "page");
 	revalidatePath("/dashboard/banners", "layout");
@@ -30,10 +27,6 @@ function invalidateBanners() {
 export async function fetchMarketingBannersForLanding(
 	isAuthenticated: boolean,
 ): Promise<MarketingBannerRow[]> {
-	"use cache";
-	cacheLife("minutes");
-	cacheTag(CACHE_TAG);
-
 	try {
 		if (isAuthenticated) {
 			return await db
@@ -69,10 +62,6 @@ export async function fetchMarketingBannersForLanding(
 export async function fetchMarketingBannersForPortal(): Promise<
 	MarketingBannerRow[]
 > {
-	"use cache";
-	cacheLife("minutes");
-	cacheTag(CACHE_TAG);
-
 	try {
 		return await db
 			.select()

--- a/app/lib/subcategories/actions.ts
+++ b/app/lib/subcategories/actions.ts
@@ -7,24 +7,17 @@ import {
 import { db } from "@/db";
 import { subcategories } from "@/db/schema";
 import { eq } from "drizzle-orm";
-import { cacheLife, cacheTag, revalidatePath, updateTag } from "next/cache";
+import { revalidatePath } from "next/cache";
+import { cache } from "react";
 
-// react.cache() is not needed here because "use cache" already deduplicates
-// across requests. If "use cache" is ever removed, wrap this in react.cache()
-// for per-request memoization (subcategories are fetched in multiple places
-// on the same page).
-export async function fetchSubcategories(): Promise<Subcategory[]> {
-	"use cache";
-	cacheLife("hours");
-	cacheTag("subcategories");
-
+export const fetchSubcategories = cache(async (): Promise<Subcategory[]> => {
 	try {
 		return await db.query.subcategories.findMany();
 	} catch (error) {
 		console.error("Error fetching subcategories", error);
 		return [];
 	}
-}
+});
 
 export async function createSubcategory(subcategory: NewSubcategory) {
 	try {
@@ -42,7 +35,6 @@ export async function createSubcategory(subcategory: NewSubcategory) {
 	}
 
 	revalidatePath("/dashboard/subcategories");
-	updateTag("subcategories");
 	return {
 		success: true,
 		message: "Subcategoría creada correctamente",
@@ -61,7 +53,6 @@ export async function deleteSubcategory(subcategoryId: number) {
 	}
 
 	revalidatePath("/dashboard/subcategories");
-	updateTag("subcategories");
 	return {
 		success: true,
 		message: "Subcategoría eliminada correctamente",

--- a/next.config.ts
+++ b/next.config.ts
@@ -19,7 +19,6 @@ const nextConfig: NextConfig = {
 		];
 	},
 	skipTrailingSlashRedirect: true,
-	cacheComponents: true,
 	reactCompiler: true,
 	images: {
 		remotePatterns: [


### PR DESCRIPTION
- Remove cacheComponents from next.config and strip "use cache", cacheLife, cacheTag, and updateTag from festival, banner, export, and subcategory server code
- Memoize fetchSubcategories and getActiveFestivalBase with react.cache after removing request-level "use cache"
- Load portal marketing banners in PortalBanners under Suspense with a skeleton so the dashboard shell can stream
- Normalize festival_exports/actions formatting (tabs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal caching mechanisms for improved system performance.
  * Enhanced portal banner loading experience with skeleton loading placeholders during data fetch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->