### PR TITLE
feat(invoices): enforce payer-only reservation payments and participa…

### DIFF
--- a/app/(routes)/profiles/[profileId]/festivals/[festivalId]/reservations/[reservationId]/payments/page.tsx
+++ b/app/(routes)/profiles/[profileId]/festivals/[festivalId]/reservations/[reservationId]/payments/page.tsx
@@ -34,6 +34,16 @@ export default async function Page(props: {
 	const invoices = await fetchInvoicesByReservation(
 		validatedParams.data.reservationId,
 	);
+
+	const isInvoiceOwner = invoices.some(
+		(invoice) => invoice.userId === profile.id,
+	);
+	if (!isInvoiceOwner) {
+		redirect(
+			`/profiles/${validatedParams.data.profileId}/festivals/${validatedParams.data.festivalId}/invoices`,
+		);
+	}
+
 	const pendingInvoices = invoices?.filter(
 		(invoice) => invoice.status === "pending",
 	);
@@ -69,7 +79,9 @@ export default async function Page(props: {
 					return (
 						<div key={invoice.id} className="container p-4 md:p-6">
 							<h1 className="text-3xl font-bold mb-8">
-								{invoice.amount === 0 ? "Confirma tu Reserva" : "Completa tu Pago"}
+								{invoice.amount === 0
+									? "Confirma tu Reserva"
+									: "Completa tu Pago"}
 							</h1>
 							<div className="grid grid-cols-1 md:grid-cols-2 gap-8">
 								<div className="flex flex-col gap-6">

--- a/app/(routes)/profiles/[profileId]/festivals/[festivalId]/reservations/[reservationId]/payments/page.tsx
+++ b/app/(routes)/profiles/[profileId]/festivals/[festivalId]/reservations/[reservationId]/payments/page.tsx
@@ -34,21 +34,21 @@ export default async function Page(props: {
 	const invoices = await fetchInvoicesByReservation(
 		validatedParams.data.reservationId,
 	);
-
-	const isInvoiceOwner = invoices.some(
+	const ownerInvoices = invoices.filter(
 		(invoice) => invoice.userId === profile.id,
 	);
-	if (!isInvoiceOwner) {
+
+	if (ownerInvoices.length === 0) {
 		redirect(
 			`/profiles/${validatedParams.data.profileId}/festivals/${validatedParams.data.festivalId}/invoices`,
 		);
 	}
 
-	const pendingInvoices = invoices?.filter(
+	const pendingInvoices = ownerInvoices.filter(
 		(invoice) => invoice.status === "pending",
 	);
 
-	if (pendingInvoices?.length === 0) {
+	if (pendingInvoices.length === 0) {
 		return (
 			<>
 				<StepIndicator
@@ -74,7 +74,7 @@ export default async function Page(props: {
 				backLabel="Ver mi reserva"
 				backHref="/my_profile"
 			/>
-			{invoices?.map((invoice) => {
+			{ownerInvoices.map((invoice) => {
 				if (invoice && invoice.status === "pending") {
 					return (
 						<div key={invoice.id} className="container p-4 md:p-6">

--- a/app/components/payments/invoice-card.tsx
+++ b/app/components/payments/invoice-card.tsx
@@ -12,10 +12,12 @@ import Link from "next/link";
 
 import Heading from "@/app/components/atoms/heading";
 import { Badge } from "@/app/components/ui/badge";
+import { Banner } from "@/app/components/ui/banner";
 import { Button } from "@/app/components/ui/button";
 import { Card, CardContent } from "@/app/components/ui/card";
 import {
 	InvoiceWithPayments,
+	InvoiceWithPaymentsAndOwner,
 	ReservationWithStandAndInvoicesAndFestival,
 } from "@/app/data/invoices/definitions";
 import { formatDate } from "@/app/lib/formatters";
@@ -23,7 +25,7 @@ import { cn } from "@/app/lib/utils";
 
 const PAYMENT_DUE_DAYS = 5;
 
-export type InvoiceWithReservation = InvoiceWithPayments & {
+export type InvoiceWithReservation = InvoiceWithPaymentsAndOwner & {
 	reservation: ReservationWithStandAndInvoicesAndFestival;
 };
 
@@ -39,6 +41,7 @@ export default function InvoiceCard({ invoice, profileId, festivalId }: Props) {
 	const dueDate = createdAt.plus({ days: PAYMENT_DUE_DAYS });
 	const isPending = invoice.status === "pending";
 	const isOverdue = isPending && DateTime.now() > dueDate;
+	const isOwner = invoice.userId === profileId;
 	const standLabel = `${invoice.reservation.stand.label ?? ""}${invoice.reservation.stand.standNumber}`;
 	const sectorName = invoice.reservation.stand.festivalSector?.name;
 
@@ -88,19 +91,37 @@ export default function InvoiceCard({ invoice, profileId, festivalId }: Props) {
 					)}
 				</div>
 
-				{isPending && (
-					<Button asChild variant="default" size="sm" className="w-full">
-						<Link
-							href={`/profiles/${profileId}/festivals/${festivalId}/reservations/${invoice.reservation.id}/payments`}
-						>
-							{invoice.amount === 0 ? "Confirmar reserva" : "Completar pago"}
-							<ArrowRightIcon className="w-3.5 h-3.5 shrink-0 ml-1" />
-						</Link>
-					</Button>
-				)}
+				{isPending &&
+					(isOwner ? (
+						<Button asChild variant="default" size="sm" className="w-full">
+							<Link
+								href={`/profiles/${profileId}/festivals/${festivalId}/reservations/${invoice.reservation.id}/payments`}
+							>
+								{invoice.amount === 0 ? "Confirmar reserva" : "Completar pago"}
+								<ArrowRightIcon className="w-3.5 h-3.5 shrink-0 ml-1" />
+							</Link>
+						</Button>
+					) : (
+						<Banner variant="info">
+							Contactá al titular de la reserva
+							{getOwnerDisplayName(invoice.user)
+								? `, ${getOwnerDisplayName(invoice.user)},`
+								: ""}{" "}
+							para completar este pago.
+						</Banner>
+					))}
 			</CardContent>
 		</Card>
 	);
+}
+
+function getOwnerDisplayName(
+	user: InvoiceWithPaymentsAndOwner["user"] | null | undefined,
+): string | null {
+	if (!user) return null;
+	if (user.displayName) return user.displayName;
+	const fullName = [user.firstName, user.lastName].filter(Boolean).join(" ");
+	return fullName || null;
 }
 
 function getInvoiceStatusConfig(status: InvoiceWithPayments["status"]) {

--- a/app/data/invoices/actions.ts
+++ b/app/data/invoices/actions.ts
@@ -303,6 +303,7 @@ export async function fetchReservationsWithInvoicesByProfileAndFestival(
 				invoices: {
 					with: {
 						payments: true,
+						user: true,
 					},
 				},
 			},

--- a/app/data/invoices/definitions.ts
+++ b/app/data/invoices/definitions.ts
@@ -15,12 +15,15 @@ export type InvoiceBase = typeof invoices.$inferSelect;
 export type InvoiceWithPayments = InvoiceBase & {
 	payments: (typeof payments.$inferSelect)[];
 };
+export type InvoiceWithPaymentsAndOwner = InvoiceWithPayments & {
+	user: typeof users.$inferSelect;
+};
 export type ReservationWithStandAndInvoicesAndFestival =
 	typeof standReservations.$inferSelect & {
 		stand: StandBase & {
 			festivalSector: typeof festivalSectors.$inferSelect | null;
 		};
-		invoices: InvoiceWithPayments[];
+		invoices: InvoiceWithPaymentsAndOwner[];
 		festival: FestivalWithDates;
 	};
 export type InvoiceWithPaymentsAndStand = InvoiceWithPayments & {


### PR DESCRIPTION
…nt UX

Redirect users who do not own an invoice on that reservation to the festival invoices hub. Eager-load invoice owners in festival queries; add InvoiceWithPaymentsAndOwner for typing. On InvoiceCard, keep the pay CTA for owners only and show an info banner prompting others to contact the holder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payment pages now restrict invoices to those owned by the current profile and redirect to the reservation’s invoices page if none are owned.

* **New Features**
  * Pending invoices show owner-aware actions: owners see a payment/confirmation button, non-owners see an informational prompt with the reservation holder’s name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->