### PR TITLE
feat(reservations): add external participant support across booking a…

### DIFF
--- a/app/api/reservations/actions.ts
+++ b/app/api/reservations/actions.ts
@@ -44,6 +44,11 @@ export async function fetchReservations(options: {
             },
           },
         },
+        externalParticipants: {
+          with: {
+            externalParticipant: true,
+          },
+        },
         stand: true,
         festival: {
           with: {

--- a/app/api/reservations/definitions.ts
+++ b/app/api/reservations/definitions.ts
@@ -9,7 +9,9 @@ import { InvoiceWithPayments } from "@/app/data/invoices/definitions";
 import { FestivalWithDates } from "@/app/lib/festivals/definitions";
 import { Collaborator } from "@/app/lib/reservations/definitions";
 import {
+  externalParticipants,
   reservationParticipants,
+  reservationExternalParticipants,
   scheduledTasks,
   standReservations,
 } from "@/db/schema";
@@ -23,10 +25,16 @@ export type ReservationWithStand = ReservationBase & {
 export type Participant = typeof reservationParticipants.$inferSelect & {
   user: ProfileWithSocials;
 };
+export type ExternalParticipant = typeof externalParticipants.$inferSelect;
+export type ReservationExternalParticipant =
+  typeof reservationExternalParticipants.$inferSelect & {
+    externalParticipant: ExternalParticipant;
+  };
 
 export type ReservationWithParticipantsAndUsers =
   typeof standReservations.$inferSelect & {
     participants: Participant[];
+    externalParticipants?: ReservationExternalParticipant[];
   };
 
 export type ReservationWithParticipantsAndUsersAndStand =
@@ -59,6 +67,7 @@ export type FullReservation = ReservationBase & {
       profileSubcategories: ProfileSubcategoryWithSubcategory[];
     };
   })[];
+  externalParticipants?: ReservationExternalParticipant[];
   stand: StandBase;
   festival: FestivalWithDates;
   invoices: InvoiceWithPayments[];

--- a/app/api/uploadthing/core.ts
+++ b/app/api/uploadthing/core.ts
@@ -191,6 +191,28 @@ export const ourFileRouter = {
     .onUploadComplete(({ file }) => ({
       imageUrl: (file as { url: string }).url,
     })),
+  externalParticipantImage: f({
+    image: { maxFileSize: "4MB", maxFileCount: 1 },
+  })
+    .middleware(async () => {
+      const user = await currentUser();
+      if (!user) throw new UploadThingError("Debes iniciar sesión");
+
+      const profile = await fetchUserProfile(user.id);
+      if (
+        !profile ||
+        (profile.role !== "admin" && profile.role !== "festival_admin")
+      ) {
+        throw new UploadThingError(
+          "No tienes permisos para subir imágenes de participantes externos",
+        );
+      }
+
+      return { userId: user.id };
+    })
+    .onUploadComplete(({ file }) => ({
+      imageUrl: (file as { url: string }).url,
+    })),
   productImage: f({ image: { maxFileSize: "4MB", maxFileCount: 10 } })
     .middleware(async ({ req }) => {
       const user = await currentUser();

--- a/app/components/maps/admin/admin-overview-map.tsx
+++ b/app/components/maps/admin/admin-overview-map.tsx
@@ -22,6 +22,7 @@ import AdminOverviewMapTooltip from "@/app/components/maps/admin/admin-overview-
 import { Tabs, TabsList, TabsTrigger } from "@/app/components/ui/tabs";
 import { Switch } from "@/app/components/ui/switch";
 import { useMediaQuery } from "@/app/hooks/use-media-query";
+import { hasExternalParticipants } from "@/app/components/maps/map-participants";
 
 type AdminOverviewMapProps = {
   sectors: FestivalSectorWithStandsWithReservationsWithParticipants[];
@@ -70,6 +71,12 @@ const LEGEND_ITEMS = [
     border: "hsl(262, 77%, 35%)",
     label: "Confirmado",
     countKey: "confirmado" as const,
+  },
+  {
+    color: "rgba(13, 148, 136, 0.82)",
+    border: "rgba(17, 94, 89, 0.9)",
+    label: "Externo",
+    countKey: "externo" as const,
   },
 ];
 
@@ -171,6 +178,7 @@ export default function AdminOverviewMap({
       atrasado: 0,
       pagadoPorConfirmar: 0,
       confirmado: 0,
+      externo: 0,
     };
     for (const stand of sector?.stands ?? []) {
       if (stand.status === "disabled") {
@@ -183,6 +191,10 @@ export default function AdminOverviewMap({
       }
       if (stand.status === "held") {
         counts.enEspera++;
+        continue;
+      }
+      if (hasExternalParticipants(stand)) {
+        counts.externo++;
         continue;
       }
       if (getIsOverdue(stand.id)) {
@@ -361,6 +373,7 @@ export default function AdminOverviewMap({
                       stand.status,
                       getReservationStatus(stand.id),
                       getIsOverdue(stand.id),
+                      hasExternalParticipants(stand),
                     )}
                     onClick={handleStandClick}
                     onTouchTap={handleTouchTap}

--- a/app/components/maps/festival-nav/festival-nav-map-canvas.tsx
+++ b/app/components/maps/festival-nav/festival-nav-map-canvas.tsx
@@ -10,6 +10,7 @@ import {
   STAND_SIZE,
   StandColors,
   computeCanvasBounds,
+  getExternalParticipantStandColors,
   getPublicStandColors,
   getStandPosition,
 } from "@/app/components/maps/map-utils";
@@ -17,6 +18,7 @@ import MapCanvas from "@/app/components/maps/map-canvas";
 import MapStand from "@/app/components/maps/map-stand";
 import MapElement from "@/app/components/maps/map-element";
 import MapTransformWrapper from "@/app/components/maps/map-transform-wrapper";
+import { hasExternalParticipants } from "@/app/components/maps/map-participants";
 
 type FestivalNavMapCanvasProps = {
   stands: StandWithReservationsWithParticipants[];
@@ -60,6 +62,8 @@ function getNavStandColors(
   stickerHuntUserIdSet: Set<number>,
 ): StandColors {
   if (!isOccupied(stand)) return getPublicStandColors(stand.status);
+  if (hasExternalParticipants(stand))
+    return getExternalParticipantStandColors();
 
   const hasCoupon = hasActivityParticipant(stand, couponBookUserIdSet);
   const hasPassport = hasActivityParticipant(stand, passportUserIdSet);

--- a/app/components/maps/festival-nav/festival-nav-stand-drawer.tsx
+++ b/app/components/maps/festival-nav/festival-nav-stand-drawer.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { BookOpen, Search, Stamp } from "lucide-react";
 
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import { getStandMapParticipants } from "@/app/components/maps/map-participants";
 import { Avatar, AvatarImage } from "@/app/components/ui/avatar";
 import { Badge } from "@/app/components/ui/badge";
 import {
@@ -65,11 +66,7 @@ export default function FestivalNavStandDrawer({
     setActiveTab(0);
   }, [stand?.id]);
 
-  const participants = stand
-    ? stand.reservations
-        .filter((r) => r.status !== "rejected")
-        .flatMap((r) => r.participants)
-    : [];
+  const participants = stand ? getStandMapParticipants(stand) : [];
 
   const clampedTab = Math.min(activeTab, Math.max(0, participants.length - 1));
 
@@ -81,18 +78,18 @@ export default function FestivalNavStandDrawer({
   const products = stand.standSubcategories.map((sc) => sc.subcategory.label);
 
   const couponProof =
-    currentParticipant != null
-      ? (couponBookProofs[currentParticipant.user.id]?.[0] ?? null)
+    currentParticipant?.kind === "user" && currentParticipant.userId != null
+      ? (couponBookProofs[currentParticipant.userId]?.[0] ?? null)
       : null;
 
   const isInPassport =
-    currentParticipant != null
-      ? passportUserIdSet.has(currentParticipant.user.id)
+    currentParticipant?.kind === "user" && currentParticipant.userId != null
+      ? passportUserIdSet.has(currentParticipant.userId)
       : false;
 
   const isInStickerHunt =
-    currentParticipant != null
-      ? stickerHuntUserIdSet.has(currentParticipant.user.id)
+    currentParticipant?.kind === "user" && currentParticipant.userId != null
+      ? stickerHuntUserIdSet.has(currentParticipant.userId)
       : false;
 
   return (
@@ -141,12 +138,12 @@ export default function FestivalNavStandDrawer({
                     >
                       <Avatar className="w-6 h-6">
                         <AvatarImage
-                          src={p.user.imageUrl ?? undefined}
-                          alt={p.user.displayName ?? "Participante"}
+                          src={p.imageUrl ?? undefined}
+                          alt={p.displayName}
                         />
                       </Avatar>
                       <span className="text-xs font-medium truncate max-w-[100px]">
-                        {p.user.displayName ?? "Participante"}
+                        {p.displayName}
                       </span>
                     </button>
                   ))}
@@ -159,19 +156,25 @@ export default function FestivalNavStandDrawer({
                   <div className="flex items-center gap-3">
                     <Avatar className="w-14 h-14 border-2 border-primary shrink-0">
                       <AvatarImage
-                        src={currentParticipant.user.imageUrl ?? undefined}
-                        alt={
-                          currentParticipant.user.displayName ?? "Participante"
-                        }
+                        src={currentParticipant.imageUrl ?? undefined}
+                        alt={currentParticipant.displayName}
                       />
                     </Avatar>
                     <div className="flex-1 min-w-0">
                       <h3 className="text-lg font-bold truncate">
-                        {currentParticipant.user.displayName ?? "Participante"}
+                        {currentParticipant.displayName}
                       </h3>
                       <p className="text-sm text-muted-foreground">
                         Stand #{standLabel} · {sectorName}
                       </p>
+                      {currentParticipant.kind === "external" && (
+                        <Badge
+                          variant="outline"
+                          className="mt-2 rounded-full border-teal-600 text-teal-700"
+                        >
+                          {currentParticipant.categoryLabel}
+                        </Badge>
+                      )}
                     </div>
                   </div>
 
@@ -247,13 +250,13 @@ export default function FestivalNavStandDrawer({
                   )}
 
                   {/* Social links */}
-                  {currentParticipant.user.userSocials.length > 0 && (
+                  {currentParticipant.userSocials.length > 0 && (
                     <div>
                       <p className="text-xs text-muted-foreground mb-2">
                         Contacto
                       </p>
                       <div className="space-y-2">
-                        {currentParticipant.user.userSocials.map((social) => (
+                        {currentParticipant.userSocials.map((social) => (
                           <a
                             key={social.id}
                             href={`${socialsUrls[social.type]}${social.username}`}
@@ -272,6 +275,26 @@ export default function FestivalNavStandDrawer({
                               icon={socialsIcons[social.type]}
                             />
                             @{social.username}
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {currentParticipant.links.length > 0 && (
+                    <div>
+                      <p className="text-xs text-muted-foreground mb-2">
+                        Contacto
+                      </p>
+                      <div className="space-y-2">
+                        {currentParticipant.links.map((link) => (
+                          <a
+                            key={link.href}
+                            href={link.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-2 text-sm hover:underline font-medium text-teal-700"
+                          >
+                            {link.label}
                           </a>
                         ))}
                       </div>

--- a/app/components/maps/map-legend.tsx
+++ b/app/components/maps/map-legend.tsx
@@ -16,6 +16,10 @@ const legendItems = [
     color: "bg-gray-300/50 border-gray-400/60",
   },
   {
+    label: "Externo",
+    color: "bg-teal-600/80 border-teal-800/90",
+  },
+  {
     label: "No disponible",
     color: "bg-gray-200/35 border-gray-300/40",
   },

--- a/app/components/maps/map-participants.ts
+++ b/app/components/maps/map-participants.ts
@@ -3,20 +3,30 @@ import {
   ExternalParticipant,
 } from "@/app/api/reservations/definitions";
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
-import { UserSocial } from "@/app/api/users/definitions";
+import { UserCategory, UserSocial } from "@/app/api/users/definitions";
 import { getExternalParticipantCategoryLabel } from "@/app/lib/external_participants/definitions";
 import { socialsUrls } from "@/app/lib/users/utils";
 
-export type MapParticipant = {
+type BaseMapParticipant = {
   id: string;
-  kind: "user" | "external";
   displayName: string;
   imageUrl: string | null;
-  categoryLabel: string;
-  userId?: number;
   userSocials: UserSocial[];
   links: { label: string; href: string }[];
 };
+
+export type UserMapParticipant = BaseMapParticipant & {
+  kind: "user";
+  categoryLabel: UserCategory;
+  userId: number;
+};
+
+export type ExternalMapParticipant = BaseMapParticipant & {
+  kind: "external";
+  categoryLabel: string;
+};
+
+export type MapParticipant = UserMapParticipant | ExternalMapParticipant;
 
 export function getActiveStandReservations(
   stand: StandWithReservationsWithParticipants,

--- a/app/components/maps/map-participants.ts
+++ b/app/components/maps/map-participants.ts
@@ -5,7 +5,6 @@ import {
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
 import { UserCategory, UserSocial } from "@/app/api/users/definitions";
 import { getExternalParticipantCategoryLabel } from "@/app/lib/external_participants/definitions";
-import { socialsUrls } from "@/app/lib/users/utils";
 
 type BaseMapParticipant = {
   id: string;
@@ -54,12 +53,7 @@ export function getStandMapParticipants(
       categoryLabel: participant.user.category,
       userId: participant.user.id,
       userSocials: participant.user.userSocials ?? [],
-      links: (participant.user.userSocials ?? [])
-        .filter((social) => !!social.username && social.type in socialsUrls)
-        .map((social) => ({
-          label: `@${social.username}`,
-          href: `${socialsUrls[social.type]}${social.username}`,
-        })),
+      links: [],
     }));
 
     const externalParticipants =

--- a/app/components/maps/map-participants.ts
+++ b/app/components/maps/map-participants.ts
@@ -1,0 +1,88 @@
+import {
+  ReservationWithParticipantsAndUsers,
+  ExternalParticipant,
+} from "@/app/api/reservations/definitions";
+import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import { UserSocial } from "@/app/api/users/definitions";
+import { getExternalParticipantCategoryLabel } from "@/app/lib/external_participants/definitions";
+import { socialsUrls } from "@/app/lib/users/utils";
+
+export type MapParticipant = {
+  id: string;
+  kind: "user" | "external";
+  displayName: string;
+  imageUrl: string | null;
+  categoryLabel: string;
+  userId?: number;
+  userSocials: UserSocial[];
+  links: { label: string; href: string }[];
+};
+
+export function getActiveStandReservations(
+  stand: StandWithReservationsWithParticipants,
+): ReservationWithParticipantsAndUsers[] {
+  return stand.reservations?.filter((r) => r.status !== "rejected") ?? [];
+}
+
+export function hasExternalParticipants(
+  stand: StandWithReservationsWithParticipants,
+) {
+  return getActiveStandReservations(stand).some(
+    (reservation) => (reservation.externalParticipants?.length ?? 0) > 0,
+  );
+}
+
+export function getStandMapParticipants(
+  stand: StandWithReservationsWithParticipants,
+): MapParticipant[] {
+  return getActiveStandReservations(stand).flatMap((reservation) => {
+    const userParticipants = reservation.participants.map((participant) => ({
+      id: `user-${participant.id}`,
+      kind: "user" as const,
+      displayName: participant.user.displayName ?? "Participante",
+      imageUrl: participant.user.imageUrl,
+      categoryLabel: participant.user.category,
+      userId: participant.user.id,
+      userSocials: participant.user.userSocials ?? [],
+      links: participant.user.userSocials
+        .filter((social) => !!social.username)
+        .map((social) => ({
+          label: `@${social.username}`,
+          href: `${socialsUrls[social.type]}${social.username}`,
+        })),
+    }));
+
+    const externalParticipants =
+      reservation.externalParticipants?.map(({ externalParticipant }) =>
+        mapExternalParticipant(externalParticipant),
+      ) ?? [];
+
+    return [...userParticipants, ...externalParticipants];
+  });
+}
+
+function mapExternalParticipant(
+  participant: ExternalParticipant,
+): MapParticipant {
+  const links = [
+    participant.websiteUrl
+      ? { label: "Sitio web", href: participant.websiteUrl }
+      : null,
+    participant.instagramUrl
+      ? { label: "Instagram", href: participant.instagramUrl }
+      : null,
+    participant.contactEmail
+      ? { label: "Correo", href: `mailto:${participant.contactEmail}` }
+      : null,
+  ].filter((link): link is { label: string; href: string } => link !== null);
+
+  return {
+    id: `external-${participant.id}`,
+    kind: "external",
+    displayName: participant.displayName,
+    imageUrl: participant.imageUrl,
+    categoryLabel: getExternalParticipantCategoryLabel(participant),
+    userSocials: [],
+    links,
+  };
+}

--- a/app/components/maps/map-participants.ts
+++ b/app/components/maps/map-participants.ts
@@ -54,8 +54,8 @@ export function getStandMapParticipants(
       categoryLabel: participant.user.category,
       userId: participant.user.id,
       userSocials: participant.user.userSocials ?? [],
-      links: participant.user.userSocials
-        .filter((social) => !!social.username)
+      links: (participant.user.userSocials ?? [])
+        .filter((social) => !!social.username && social.type in socialsUrls)
         .map((social) => ({
           label: `@${social.username}`,
           href: `${socialsUrls[social.type]}${social.username}`,

--- a/app/components/maps/map-utils.ts
+++ b/app/components/maps/map-utils.ts
@@ -168,6 +168,7 @@ export function getAdminOverviewColors(
   standStatus: string,
   reservationStatus?: string | null,
   isOverdue?: boolean,
+  isExternalParticipant?: boolean,
 ): StandColors {
   if (standStatus === "disabled") {
     return {
@@ -193,6 +194,7 @@ export function getAdminOverviewColors(
       text: "#92400E",
     };
   }
+  if (isExternalParticipant) return getExternalParticipantStandColors();
   // For all other stand states, color is driven by reservation status
   if (reservationStatus === "verification_payment") {
     return {
@@ -258,5 +260,14 @@ export function getPublicStandColors(status: string): StandColors {
     hoverFill: "rgba(109, 40, 217, 0.95)", // violet-700 hover
     stroke: "rgba(91, 33, 182, 0.8)", // violet-800
     text: "#ffffff", // white
+  };
+}
+
+export function getExternalParticipantStandColors(): StandColors {
+  return {
+    fill: "rgba(13, 148, 136, 0.82)",
+    hoverFill: "rgba(15, 118, 110, 0.92)",
+    stroke: "rgba(17, 94, 89, 0.9)",
+    text: "#ffffff",
   };
 }

--- a/app/components/maps/public/public-map-drawer.tsx
+++ b/app/components/maps/public/public-map-drawer.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import { getStandMapParticipants } from "@/app/components/maps/map-participants";
 import { Avatar, AvatarImage } from "@/app/components/ui/avatar";
 import { Badge } from "@/app/components/ui/badge";
 import { socialsUrls, socialsIcons } from "@/app/lib/users/utils";
@@ -37,11 +38,7 @@ export default function PublicMapStandCard({
 }: PublicMapStandCardProps) {
 	const [activeTab, setActiveTab] = useState(0);
 
-	const participants = stand
-		? (stand.reservations ?? [])
-				.filter((r) => r.status !== "rejected")
-				.flatMap((r) => r.participants)
-		: [];
+	const participants = stand ? getStandMapParticipants(stand) : [];
 
 	const clampedTab = Math.min(activeTab, Math.max(0, participants.length - 1));
 
@@ -49,7 +46,6 @@ export default function PublicMapStandCard({
 	if (participants.length === 0) return null;
 
 	const currentParticipant = participants[clampedTab] ?? participants[0];
-	const { user } = currentParticipant;
 	const standLabel = `${stand.label}${stand.standNumber}`;
 	const categoryLabel = getCategoryLabel(stand.standCategory);
 	const products = stand.standSubcategories.map((sc) => sc.subcategory.label);
@@ -91,12 +87,12 @@ export default function PublicMapStandCard({
 								>
 									<Avatar className="w-6 h-6">
 										<AvatarImage
-											src={p.user.imageUrl ?? undefined}
-											alt={p.user.displayName ?? "Participante"}
+											src={p.imageUrl ?? undefined}
+											alt={p.displayName}
 										/>
 									</Avatar>
 									<span className="text-xs font-medium text-foreground truncate max-w-[100px]">
-										{p.user.displayName ?? "Participante"}
+										{p.displayName}
 									</span>
 								</button>
 							))}
@@ -107,24 +103,34 @@ export default function PublicMapStandCard({
 					<div className="flex items-center gap-3">
 						<Avatar className="w-16 h-16 border-2 border-primary shrink-0">
 							<AvatarImage
-								src={user.imageUrl ?? undefined}
-								alt={user.displayName ?? "Participante"}
+								src={currentParticipant.imageUrl ?? undefined}
+								alt={currentParticipant.displayName}
 							/>
 						</Avatar>
 						<div className="flex-1 min-w-0">
 							<h3 className="text-xl font-bold text-foreground mb-0.5 truncate">
-								{user.displayName ?? "Participante"}
+								{currentParticipant.displayName}
 							</h3>
 							<p className="text-sm text-muted-foreground">
 								Stand #{standLabel}
 								{sectorName ? ` • ${sectorName}` : ""}
 							</p>
+							{currentParticipant.kind === "external" && (
+								<Badge
+									variant="outline"
+									className="mt-2 rounded-full border-teal-600 text-teal-700"
+								>
+									{currentParticipant.categoryLabel}
+								</Badge>
+							)}
 						</div>
 					</div>
 				</div>
 
 				{/* Body */}
-				{(products.length > 0 || user.userSocials.length > 0) && (
+				{(products.length > 0 ||
+					currentParticipant.userSocials.length > 0 ||
+					currentParticipant.links.length > 0) && (
 					<div className="p-4 space-y-3">
 						{/* Products */}
 						{products.length > 0 && (
@@ -145,11 +151,11 @@ export default function PublicMapStandCard({
 						)}
 
 						{/* Social links */}
-						{user.userSocials.length > 0 && (
+						{currentParticipant.userSocials.length > 0 && (
 							<div>
 								<p className="text-xs text-muted-foreground mb-2">Contacto</p>
 								<div className="space-y-2">
-									{user.userSocials.map((social) => (
+									{currentParticipant.userSocials.map((social) => (
 										<a
 											key={social.id}
 											href={`${socialsUrls[social.type]}${social.username}`}
@@ -166,6 +172,24 @@ export default function PublicMapStandCard({
 												icon={socialsIcons[social.type]}
 											/>
 											@{social.username}
+										</a>
+									))}
+								</div>
+							</div>
+						)}
+						{currentParticipant.links.length > 0 && (
+							<div>
+								<p className="text-xs text-muted-foreground mb-2">Contacto</p>
+								<div className="space-y-2">
+									{currentParticipant.links.map((link) => (
+										<a
+											key={link.href}
+											href={link.href}
+											target="_blank"
+											rel="noopener noreferrer"
+											className="flex items-center gap-2 text-sm hover:underline font-medium text-teal-700"
+										>
+											{link.label}
 										</a>
 									))}
 								</div>

--- a/app/components/maps/public/public-map-legend.tsx
+++ b/app/components/maps/public/public-map-legend.tsx
@@ -7,6 +7,10 @@ const legendItems = [
 		label: "Ocupado",
 		color: "bg-violet-700/70 border-violet-800/80",
 	},
+	{
+		label: "Externo",
+		color: "bg-teal-600/80 border-teal-800/90",
+	},
 ];
 
 export default function PublicMapLegend() {

--- a/app/components/maps/public/public-map-tooltip.tsx
+++ b/app/components/maps/public/public-map-tooltip.tsx
@@ -10,7 +10,6 @@ import {
 import { createPortal } from "react-dom";
 
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
-import { UserCategory } from "@/app/api/users/definitions";
 import { getStandMapParticipants } from "@/app/components/maps/map-participants";
 import { Avatar, AvatarImage } from "@/app/components/ui/avatar";
 import { Badge } from "@/app/components/ui/badge";
@@ -109,9 +108,9 @@ export default function PublicMapTooltip({
 									<p className="text-sm font-semibold leading-tight">
 										{p.displayName}
 									</p>
-									{p.kind === "user" && p.userId ? (
+									{p.kind === "user" ? (
 										<CategoryBadge
-											category={p.categoryLabel as UserCategory}
+											category={p.categoryLabel}
 											className="text-[10px]"
 										/>
 									) : (

--- a/app/components/maps/public/public-map-tooltip.tsx
+++ b/app/components/maps/public/public-map-tooltip.tsx
@@ -10,6 +10,8 @@ import {
 import { createPortal } from "react-dom";
 
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import { UserCategory } from "@/app/api/users/definitions";
+import { getStandMapParticipants } from "@/app/components/maps/map-participants";
 import { Avatar, AvatarImage } from "@/app/components/ui/avatar";
 import { Badge } from "@/app/components/ui/badge";
 import CategoryBadge from "@/app/components/category-badge";
@@ -21,14 +23,6 @@ type PublicMapTooltipProps = {
 
 const GAP = 8;
 
-function getParticipants(stand: StandWithReservationsWithParticipants) {
-	return (
-		stand.reservations
-			?.filter((r) => r.status !== "rejected")
-			.flatMap((r) => r.participants) ?? []
-	);
-}
-
 export default function PublicMapTooltip({
 	stand,
 	anchorRect,
@@ -39,7 +33,7 @@ export default function PublicMapTooltip({
 		left: 0,
 	});
 
-	const participants = getParticipants(stand);
+	const participants = getStandMapParticipants(stand);
 	const standLabel = `${stand.label}${stand.standNumber}`;
 	const countLabel =
 		participants.length === 1
@@ -107,18 +101,27 @@ export default function PublicMapTooltip({
 							<div key={i} className="flex items-center gap-2">
 								<Avatar className="w-8 h-8 shrink-0">
 									<AvatarImage
-										src={p.user.imageUrl ?? undefined}
-										alt={p.user.displayName ?? "Participante"}
+										src={p.imageUrl ?? undefined}
+										alt={p.displayName}
 									/>
 								</Avatar>
 								<div>
 									<p className="text-sm font-semibold leading-tight">
-										{p.user.displayName ?? "Participante"}
+										{p.displayName}
 									</p>
-									<CategoryBadge
-										category={p.user.category}
-										className="text-[10px]"
-									/>
+									{p.kind === "user" && p.userId ? (
+										<CategoryBadge
+											category={p.categoryLabel as UserCategory}
+											className="text-[10px]"
+										/>
+									) : (
+										<Badge
+											variant="outline"
+											className="mt-1 rounded-full border-teal-600 text-[10px] text-teal-700"
+										>
+											{p.categoryLabel}
+										</Badge>
+									)}
 								</div>
 							</div>
 						))}

--- a/app/components/maps/public/public-map.tsx
+++ b/app/components/maps/public/public-map.tsx
@@ -6,9 +6,11 @@ import { StandWithReservationsWithParticipants } from "@/app/api/stands/definiti
 import { MapElementBase } from "@/app/lib/map_elements/definitions";
 import {
 	computeCanvasBounds,
+	getExternalParticipantStandColors,
 	getPublicStandColors,
 } from "@/app/components/maps/map-utils";
 import { usePublicMapCard } from "@/app/components/maps/public/public-map-card-provider";
+import { hasExternalParticipants } from "@/app/components/maps/map-participants";
 
 import MapCanvas from "@/app/components/maps/map-canvas";
 import MapStand from "@/app/components/maps/map-stand";
@@ -84,11 +86,15 @@ export default function PublicMap({
 						{visibleStands.map((stand) => (
 							<MapStand
 								key={stand.id}
-								stand={stand}
-								canBeReserved={false}
-								selected={stand.id === selectedStandId}
-								colors={getPublicStandColors(stand.status)}
-								onHoverChange={handleHoverChange}
+										stand={stand}
+										canBeReserved={false}
+										selected={stand.id === selectedStandId}
+										colors={
+											hasExternalParticipants(stand)
+												? getExternalParticipantStandColors()
+												: getPublicStandColors(stand.status)
+										}
+										onHoverChange={handleHoverChange}
 								onTouchTap={handleStandSelect}
 								onClick={handleStandSelect}
 							/>

--- a/app/components/maps/user/user-map.tsx
+++ b/app/components/maps/user/user-map.tsx
@@ -14,7 +14,11 @@ import MapElement from "@/app/components/maps/map-element";
 import MapToolbar from "@/app/components/maps/map-toolbar";
 import MapLegend from "@/app/components/maps/map-legend";
 import MapTransformWrapper from "@/app/components/maps/map-transform-wrapper";
-import { computeCanvasBounds } from "@/app/components/maps/map-utils";
+import {
+  computeCanvasBounds,
+  getExternalParticipantStandColors,
+} from "@/app/components/maps/map-utils";
+import { hasExternalParticipants } from "@/app/components/maps/map-participants";
 
 type UserMapProps = {
   stands: StandWithReservationsWithParticipants[];
@@ -78,6 +82,11 @@ export default function UserMap({
                     stand={stand}
                     canBeReserved={standCanBeReserved}
                     selected={stand.id === selectedStandId}
+                    colors={
+                      hasExternalParticipants(stand)
+                        ? getExternalParticipantStandColors()
+                        : undefined
+                    }
                     onClick={onStandClick}
                     onTouchTap={onStandTouchTap}
                   />

--- a/app/components/reservations/columns.tsx
+++ b/app/components/reservations/columns.tsx
@@ -178,7 +178,12 @@ export const columns: ColumnDef<FullReservation>[] = [
       </div>
     ),
     filterFn: (row, _columnId, filterCategories) => {
-      if (filterCategories.length === 0) return true;
+      if (
+        !filterCategories ||
+        !Array.isArray(filterCategories) ||
+        filterCategories.length === 0
+      )
+        return true;
       const userCategories = row.original.participants.map(
         (participant) => participant.user.category,
       );

--- a/app/components/reservations/columns.tsx
+++ b/app/components/reservations/columns.tsx
@@ -14,10 +14,12 @@ import { ActionsCell } from "@/app/components/reservations/cells/actions";
 import PaymentStatus from "@/app/components/reservations/cells/payment-status";
 import { ReservationStatus } from "@/app/components/reservations/cells/status";
 import { Avatar, AvatarImage } from "@/app/components/ui/avatar";
+import { Badge } from "@/app/components/ui/badge";
 import { Checkbox } from "@/app/components/ui/checkbox";
 import { DataTableColumnHeader } from "@/app/components/ui/data_table/column-header";
 import ProfileQuickViewInfo from "@/app/components/users/profile-quick-view-info";
 import { RESERVATION_EXPIRATION_HOURS } from "@/app/lib/constants";
+import { getExternalParticipantCategoryLabel } from "@/app/lib/external_participants/definitions";
 import { formatDate, formatDateWithTime } from "@/app/lib/formatters";
 import {
   DisplayPaymentStatus,
@@ -34,7 +36,7 @@ export const columnTitles = {
   paymentStatus: "Estado del Pago",
   expiration: "Vencimiento",
   collaborators: "Colaboradores",
-  festivalSector: "Sector",
+  participantCategory: "Categoría",
 };
 
 export const columns: ColumnDef<FullReservation>[] = [
@@ -76,52 +78,118 @@ export const columns: ColumnDef<FullReservation>[] = [
   {
     id: "artists",
     accessorFn: (row) =>
-      row.participants.map((p) => p.user.displayName).join(", "),
+      [
+        ...row.participants.map((p) => p.user.displayName),
+        ...(row.externalParticipants?.map(
+          ({ externalParticipant }) => externalParticipant.displayName,
+        ) ?? []),
+      ].join(", "),
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title={columnTitles.artists} />
     ),
-    cell: ({ row }) =>
-      row.original.participants.map(({ user: profile }) => (
-        <TooltipProvider key={profile.id}>
-          <Tooltip>
-            <TooltipTrigger>
-              <Avatar className="w-8 h-8">
-                <AvatarImage
-                  src={
-                    profile?.imageUrl ||
-                    "/img/placeholders/avatar-placeholder.png"
-                  }
-                  alt={profile.displayName || "avatar"}
+    cell: ({ row }) => (
+      <div className="flex flex-wrap gap-1">
+        {row.original.participants.map(({ user: profile }) => (
+          <TooltipProvider key={profile.id}>
+            <Tooltip>
+              <TooltipTrigger>
+                <Avatar className="w-8 h-8">
+                  <AvatarImage
+                    src={
+                      profile?.imageUrl ||
+                      "/img/placeholders/avatar-placeholder.png"
+                    }
+                    alt={profile.displayName || "avatar"}
+                  />
+                </Avatar>
+              </TooltipTrigger>
+              <TooltipContent>
+                <ProfileQuickViewInfo
+                  className="p-4"
+                  profile={profile}
+                  truncateEmail
                 />
-              </Avatar>
-            </TooltipTrigger>
-            <TooltipContent>
-              <ProfileQuickViewInfo
-                className="p-4"
-                profile={profile}
-                truncateEmail
-              />
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      )),
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ))}
+        {row.original.externalParticipants?.map(({ externalParticipant }) => (
+          <TooltipProvider key={`external-${externalParticipant.id}`}>
+            <Tooltip>
+              <TooltipTrigger>
+                <Avatar className="w-8 h-8">
+                  <AvatarImage
+                    src={
+                      externalParticipant.imageUrl ||
+                      "/img/placeholders/avatar-placeholder.png"
+                    }
+                    alt={externalParticipant.displayName || "avatar"}
+                  />
+                </Avatar>
+              </TooltipTrigger>
+              <TooltipContent>
+                <div className="flex flex-col gap-1 p-2">
+                  <span className="font-medium">
+                    {externalParticipant.displayName}
+                  </span>
+                  <span className="text-sm text-muted-foreground">
+                    {getExternalParticipantCategoryLabel(externalParticipant)}
+                  </span>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ))}
+      </div>
+    ),
   },
   {
-    id: "festivalSector",
-    accessorFn: (row) => row.stand.standCategory,
+    id: "participantCategory",
+    accessorFn: (row) =>
+      [
+        ...row.participants.map((p) => p.user.category),
+        ...(row.externalParticipants?.map(({ externalParticipant }) =>
+          getExternalParticipantCategoryLabel(externalParticipant),
+        ) ?? []),
+      ].join(", "),
     header: ({ column }) => (
       <DataTableColumnHeader
         column={column}
-        title={columnTitles.festivalSector}
+        title={columnTitles.participantCategory}
       />
     ),
     cell: ({ row }) => (
-      <CategoryBadge category={row.original.stand.standCategory} />
+      <div className="flex flex-wrap gap-1">
+        {row.original.participants.map((participant) => (
+          <CategoryBadge
+            key={`participant-category-${participant.id}`}
+            category={participant.user.category}
+          />
+        ))}
+        {row.original.externalParticipants?.map(({ externalParticipant }) => (
+          <Badge
+            key={`external-category-${externalParticipant.id}`}
+            variant="outline"
+            className="border-teal-600 text-teal-700 font-bold uppercase"
+          >
+            {getExternalParticipantCategoryLabel(externalParticipant)}
+          </Badge>
+        ))}
+      </div>
     ),
-    filterFn: (row, columnId, filterCategories) => {
+    filterFn: (row, _columnId, filterCategories) => {
       if (filterCategories.length === 0) return true;
-      const category = row.getValue(columnId);
-      return filterCategories.includes(category);
+      const userCategories = row.original.participants.map(
+        (participant) => participant.user.category,
+      );
+      const externalParticipantTypes =
+        row.original.externalParticipants?.map(
+          ({ externalParticipant }) => externalParticipant.type,
+        ) ?? [];
+
+      return [...userCategories, ...externalParticipantTypes].some(
+        (category) => filterCategories.includes(category),
+      );
     },
   },
   {

--- a/app/components/reservations/reservations-table.tsx
+++ b/app/components/reservations/reservations-table.tsx
@@ -1,5 +1,6 @@
 import { FullReservation } from "@/app/api/reservations/definitions";
 import { DataTable } from "@/app/components/ui/data_table/data-table";
+import { externalParticipantTypeOptions } from "@/app/lib/external_participants/definitions";
 import { DisplayPaymentStatus } from "@/app/lib/payments/helpers";
 import { userCategoryOptions } from "@/app/lib/utils";
 import { columns, columnTitles } from "./columns";
@@ -53,9 +54,9 @@ export default function ReservationsTable({
           ],
         },
         {
-          label: "Sector",
-          columnId: "festivalSector",
-          options: [...userCategoryOptions],
+          label: "Categoría",
+          columnId: "participantCategory",
+          options: [...userCategoryOptions, ...externalParticipantTypeOptions],
         },
       ]}
     />

--- a/app/components/reservations/table.tsx
+++ b/app/components/reservations/table.tsx
@@ -1,8 +1,11 @@
 import { fetchReservations } from "@/app/api/reservations/actions";
 import ReservationStatusBadge from "@/app/components/atoms/reservation-status-badge";
+import CategoryBadge from "@/app/components/category-badge";
 import ProfileCell from "@/app/components/common/table/profile-cell";
 import { ActionsCell } from "@/app/components/reservations/cells/actions";
 import PaymentStatus from "@/app/components/reservations/cells/payment-status";
+import { Avatar, AvatarImage } from "@/app/components/ui/avatar";
+import { Badge } from "@/app/components/ui/badge";
 import {
   Table,
   TableBody,
@@ -12,6 +15,7 @@ import {
   TableRow,
 } from "@/app/components/ui/table";
 import { HeaderCell } from "@/app/components/users/header-cell";
+import { getExternalParticipantCategoryLabel } from "@/app/lib/external_participants/definitions";
 import { formatDate } from "@/app/lib/formatters";
 import { DateTime } from "luxon";
 
@@ -30,6 +34,7 @@ export default async function ReservationsTable(props: ReservationsTableProps) {
         <TableRow>
           <HeaderCell value="number" label="#" />
           <HeaderCell value="profile" label="Perfil" />
+          <HeaderCell value="category" label="Categoría" />
           <HeaderCell value="status" label="Estado de la Reserva" />
           <HeaderCell value="stand" label="Espacio" />
           <HeaderCell value="festivalName" label="Festival" />
@@ -51,6 +56,66 @@ export default async function ReservationsTable(props: ReservationsTableProps) {
                       profile={participant.user}
                     />
                   ))}
+                  {reservation.externalParticipants?.map(
+                    ({ externalParticipant }) => (
+                      <div
+                        key={`external-${externalParticipant.id}`}
+                        className="flex gap-2 items-center"
+                      >
+                        <Avatar className="w-8 h-8">
+                          <AvatarImage
+                            src={
+                              externalParticipant.imageUrl ||
+                              "/img/placeholders/avatar-placeholder.png"
+                            }
+                            alt={
+                              externalParticipant.displayName
+                                ? `Imagen de ${externalParticipant.displayName}`
+                                : "Imagen de participante externo"
+                            }
+                          />
+                        </Avatar>
+                        <div className="flex flex-col">
+                          <span>
+                            <span className="text-muted-foreground mr-1">
+                              #{externalParticipant.id}
+                            </span>
+                            <span className="font-semibold mr-1">
+                              {externalParticipant.displayName}
+                            </span>
+                          </span>
+                          {externalParticipant.contactEmail && (
+                            <span className="text-muted-foreground text-sm">
+                              {externalParticipant.contactEmail}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    ),
+                  )}
+                </div>
+              </TableCell>
+              <TableCell>
+                <div className="flex flex-wrap gap-1">
+                  {reservation.participants.map((participant) => (
+                    <CategoryBadge
+                      key={`participant-category-${participant.id}`}
+                      category={participant.user.category}
+                    />
+                  ))}
+                  {reservation.externalParticipants?.map(
+                    ({ externalParticipant }) => (
+                      <Badge
+                        key={`external-category-${externalParticipant.id}`}
+                        variant="outline"
+                        className="border-teal-600 text-teal-700 font-bold uppercase"
+                      >
+                        {getExternalParticipantCategoryLabel(
+                          externalParticipant,
+                        )}
+                      </Badge>
+                    ),
+                  )}
                 </div>
               </TableCell>
               <TableCell>
@@ -76,7 +141,7 @@ export default async function ReservationsTable(props: ReservationsTableProps) {
           ))
         ) : (
           <TableRow>
-            <TableCell colSpan={8} className="h-24 text-center">
+            <TableCell colSpan={9} className="h-24 text-center">
               Sin resultados
             </TableCell>
           </TableRow>

--- a/app/components/stands/stand-artists.tsx
+++ b/app/components/stands/stand-artists.tsx
@@ -2,18 +2,30 @@ import { Avatar, AvatarImage } from "@/app/components/ui/avatar";
 import { RedirectButton } from "@/app/components/redirect-button";
 import { ProfileType } from "@/app/api/users/definitions";
 import ProfileAvatarGroup from "@/app/components/common/profile-avatar-group";
-import { StandBase } from "@/app/api/stands/definitions";
+import {
+  StandBase,
+  StandWithReservationsWithParticipants,
+} from "@/app/api/stands/definitions";
+import { getStandMapParticipants } from "@/app/components/maps/map-participants";
+import { Badge } from "@/app/components/ui/badge";
 
 type Props = {
   festivalId: number;
   participants?: ProfileType[];
-  stand: StandBase;
+  stand: StandBase | StandWithReservationsWithParticipants;
 };
 
 const StandArtists = ({ festivalId, participants, stand }: Props) => {
   let cardBody;
   let label;
-  if (!participants?.length) {
+  const externalParticipants =
+    "reservations" in stand
+      ? getStandMapParticipants(stand).filter(
+          (participant) => participant.kind === "external",
+        )
+      : [];
+
+  if (!participants?.length && externalParticipants.length === 0) {
     cardBody = (
       <Avatar>
         <AvatarImage src="/img/profile-avatar.png" alt="Espacio Disponible" />
@@ -51,6 +63,36 @@ const StandArtists = ({ festivalId, participants, stand }: Props) => {
         </span>
       );
     }
+  }
+
+  if (!participants?.length && externalParticipants.length > 0) {
+    cardBody = (
+      <div className="flex -space-x-2">
+        {externalParticipants.slice(0, 2).map((participant) => (
+          <Avatar key={participant.id} className="border-2 border-background">
+            <AvatarImage
+              src={participant.imageUrl ?? "/img/profile-avatar.png"}
+              alt={participant.displayName}
+            />
+          </Avatar>
+        ))}
+      </div>
+    );
+    label = (
+      <span className="flex flex-col items-center gap-1">
+        <span>
+          {externalParticipants
+            .map((participant) => participant.displayName)
+            .join(" & ")}
+        </span>
+        <Badge
+          variant="outline"
+          className="rounded-full border-teal-600 text-teal-700"
+        >
+          {externalParticipants[0].categoryLabel}
+        </Badge>
+      </span>
+    );
   }
 
   return (

--- a/app/dashboard/festivals/[id]/reservations/new/form.tsx
+++ b/app/dashboard/festivals/[id]/reservations/new/form.tsx
@@ -446,9 +446,11 @@ export default function CreateReservationForm({
                         onClientUploadComplete={(res) => {
                           const uploadedUrl =
                             res?.[0]?.serverData?.imageUrl ?? res?.[0]?.url;
-                          if (uploadedUrl) {
+                          if (uploadedUrl && typeof uploadedUrl === "string") {
                             field.onChange(uploadedUrl);
                             toast.success("Imagen subida");
+                          } else {
+                            toast.error("Respuesta de carga inválida");
                           }
                         }}
                         onUploadError={() => {

--- a/app/dashboard/festivals/[id]/reservations/new/form.tsx
+++ b/app/dashboard/festivals/[id]/reservations/new/form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useForm } from "react-hook-form";
+import { useForm, UseFormReturn } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { toast } from "sonner";
@@ -58,6 +58,34 @@ type Props = {
   sectors: FestivalSectorWithStandsWithReservationsWithParticipants[];
   externalParticipants: ExternalParticipant[];
 };
+
+function TextField({
+  form,
+  name,
+  label,
+  placeholder,
+}: {
+  form: UseFormReturn<FormValues>;
+  name: keyof FormValues;
+  label: string;
+  placeholder?: string;
+}) {
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>{label}</FormLabel>
+          <FormControl>
+            <Input placeholder={placeholder} {...field} />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
 
 export default function CreateReservationForm({
   festivalId,
@@ -282,6 +310,7 @@ export default function CreateReservationForm({
             ) : (
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <TextField
+                  form={form}
                   name="displayName"
                   label="Nombre"
                   placeholder="Nombre de la institución"
@@ -294,22 +323,26 @@ export default function CreateReservationForm({
                   options={externalParticipantTypeOptions}
                 />
                 <TextField
+                  form={form}
                   name="customCategoryLabel"
                   label="Etiqueta de categoría"
                   placeholder="Ej. Refugio animal"
                 />
                 <ExternalParticipantImageField imageUrl={externalImageUrl} />
                 <TextField
+                  form={form}
                   name="websiteUrl"
                   label="Sitio web"
                   placeholder="https://..."
                 />
                 <TextField
+                  form={form}
                   name="instagramUrl"
                   label="Instagram"
                   placeholder="https://instagram.com/..."
                 />
                 <TextField
+                  form={form}
                   name="contactEmail"
                   label="Correo de contacto"
                   placeholder="contacto@..."
@@ -360,32 +393,6 @@ export default function CreateReservationForm({
       </form>
     </Form>
   );
-
-  function TextField({
-    name,
-    label,
-    placeholder,
-  }: {
-    name: keyof FormValues;
-    label: string;
-    placeholder?: string;
-  }) {
-    return (
-      <FormField
-        control={form.control}
-        name={name}
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>{label}</FormLabel>
-            <FormControl>
-              <Input placeholder={placeholder} {...field} />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-    );
-  }
 
   function ExternalParticipantImageField({ imageUrl }: { imageUrl?: string }) {
     return (

--- a/app/dashboard/festivals/[id]/reservations/new/form.tsx
+++ b/app/dashboard/festivals/[id]/reservations/new/form.tsx
@@ -5,7 +5,8 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { toast } from "sonner";
-import { Building2Icon, UserIcon } from "lucide-react";
+import { Building2Icon, Loader2Icon, UserIcon } from "lucide-react";
+import { twMerge } from "tailwind-merge";
 
 import { BaseProfile } from "@/app/api/users/definitions";
 import ComboboxInput from "@/app/components/form/fields/combobox";
@@ -22,6 +23,7 @@ import {
 import { Input } from "@/app/components/ui/input";
 import { Tabs, TabsList, TabsTrigger } from "@/app/components/ui/tabs";
 import { Textarea } from "@/app/components/ui/textarea";
+import { UploadButton } from "@/app/vendors/uploadthing";
 import {
   ExternalParticipant,
   externalParticipantTypeOptions,
@@ -29,6 +31,7 @@ import {
 import { FestivalSectorWithStandsWithReservationsWithParticipants } from "@/app/lib/festival_sectors/definitions";
 import { createAdminReservation } from "@/app/lib/reservations/admin-actions";
 import { createExternalParticipantReservation } from "@/app/lib/external_participants/actions";
+import { deleteFile } from "@/app/lib/uploadthing/actions";
 
 const FormSchema = z.object({
   mode: z.enum(["user", "external"]),
@@ -114,6 +117,7 @@ export default function CreateReservationForm({
 
   const mode = form.watch("mode");
   const externalMode = form.watch("externalMode");
+  const externalImageUrl = form.watch("imageUrl");
 
   async function onSubmit(data: FormValues) {
     if (data.mode === "user") {
@@ -294,11 +298,7 @@ export default function CreateReservationForm({
                   label="Etiqueta de categoría"
                   placeholder="Ej. Refugio animal"
                 />
-                <TextField
-                  name="imageUrl"
-                  label="Imagen o logo"
-                  placeholder="https://..."
-                />
+                <ExternalParticipantImageField imageUrl={externalImageUrl} />
                 <TextField
                   name="websiteUrl"
                   label="Sitio web"
@@ -379,6 +379,106 @@ export default function CreateReservationForm({
             <FormLabel>{label}</FormLabel>
             <FormControl>
               <Input placeholder={placeholder} {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    );
+  }
+
+  function ExternalParticipantImageField({ imageUrl }: { imageUrl?: string }) {
+    return (
+      <FormField
+        control={form.control}
+        name="imageUrl"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Imagen o logo</FormLabel>
+            <FormControl>
+              <div className="grid gap-3">
+                <div className="flex items-center gap-3 rounded-md border border-dashed p-3">
+                  <div className="flex size-16 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted">
+                    {imageUrl ? (
+                      <img
+                        src={imageUrl}
+                        alt="Vista previa"
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <Building2Icon className="size-7 text-muted-foreground" />
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <UploadButton
+                        config={{ cn: twMerge }}
+                        endpoint="externalParticipantImage"
+                        content={{
+                          button({ ready, isUploading, uploadProgress }) {
+                            if (isUploading && uploadProgress === 100) {
+                              return (
+                                <Loader2Icon className="size-4 animate-spin text-primary-500" />
+                              );
+                            }
+                            if (isUploading)
+                              return <span>{uploadProgress}%</span>;
+                            if (ready) return <span>Subir imagen</span>;
+                            return "Cargando...";
+                          },
+                          allowedContent({ ready, isUploading }) {
+                            if (!ready) return null;
+                            if (isUploading) return "Subiendo imagen...";
+                            return "Imagen hasta 4MB";
+                          },
+                        }}
+                        appearance={{
+                          button: ({ ready, isUploading }) => {
+                            if (!ready) {
+                              return "bg-transparent text-xs text-muted-foreground border";
+                            }
+                            if (isUploading) {
+                              return "bg-transparent text-xs text-muted-foreground border after:bg-primary-700/60";
+                            }
+                            return "bg-transparent text-xs text-foreground border hover:text-primary-500 hover:border-primary-500";
+                          },
+                        }}
+                        onClientUploadComplete={(res) => {
+                          const uploadedUrl =
+                            res?.[0]?.serverData?.imageUrl ?? res?.[0]?.url;
+                          if (uploadedUrl) {
+                            field.onChange(uploadedUrl);
+                            toast.success("Imagen subida");
+                          }
+                        }}
+                        onUploadError={() => {
+                          toast.error("Error al subir la imagen");
+                        }}
+                      />
+                      {imageUrl && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={async () => {
+                            const result = await deleteFile(imageUrl);
+                            if (result.success) {
+                              field.onChange("");
+                              toast.success("Imagen eliminada");
+                            } else {
+                              toast.error(
+                                result.error || "Error al eliminar la imagen",
+                              );
+                            }
+                          }}
+                        >
+                          Quitar
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
             </FormControl>
             <FormMessage />
           </FormItem>

--- a/app/dashboard/festivals/[id]/reservations/new/form.tsx
+++ b/app/dashboard/festivals/[id]/reservations/new/form.tsx
@@ -5,17 +5,46 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { toast } from "sonner";
+import { Building2Icon, UserIcon } from "lucide-react";
+
 import { BaseProfile } from "@/app/api/users/definitions";
+import ComboboxInput from "@/app/components/form/fields/combobox";
+import SelectInput from "@/app/components/form/fields/select";
+import { Button } from "@/app/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/app/components/ui/form";
+import { Input } from "@/app/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/app/components/ui/tabs";
+import { Textarea } from "@/app/components/ui/textarea";
+import {
+  ExternalParticipant,
+  externalParticipantTypeOptions,
+} from "@/app/lib/external_participants/definitions";
 import { FestivalSectorWithStandsWithReservationsWithParticipants } from "@/app/lib/festival_sectors/definitions";
 import { createAdminReservation } from "@/app/lib/reservations/admin-actions";
-import ComboboxInput from "@/app/components/form/fields/combobox";
-import { Button } from "@/app/components/ui/button";
-import { Form } from "@/app/components/ui/form";
+import { createExternalParticipantReservation } from "@/app/lib/external_participants/actions";
 
 const FormSchema = z.object({
-  userId: z.string().min(1, "Seleccioná un usuario"),
+  mode: z.enum(["user", "external"]),
+  externalMode: z.enum(["existing", "new"]),
+  userId: z.string().optional(),
   standId: z.string().min(1, "Seleccioná un espacio"),
   partnerId: z.string().optional(),
+  externalParticipantId: z.string().optional(),
+  displayName: z.string().optional(),
+  type: z.string().optional(),
+  customCategoryLabel: z.string().optional(),
+  description: z.string().optional(),
+  imageUrl: z.string().optional(),
+  websiteUrl: z.string().optional(),
+  instagramUrl: z.string().optional(),
+  contactEmail: z.string().optional(),
 });
 
 type FormValues = z.infer<typeof FormSchema>;
@@ -24,12 +53,14 @@ type Props = {
   festivalId: number;
   users: BaseProfile[];
   sectors: FestivalSectorWithStandsWithReservationsWithParticipants[];
+  externalParticipants: ExternalParticipant[];
 };
 
 export default function CreateReservationForm({
   festivalId,
   users,
   sectors,
+  externalParticipants,
 }: Props) {
   const router = useRouter();
 
@@ -45,17 +76,113 @@ export default function CreateReservationForm({
     })),
   );
 
+  const externalStandOptions = sectors.flatMap((sector) =>
+    sector.stands
+      .filter((stand) => stand.status === "available")
+      .map((stand) => ({
+        value: String(stand.id),
+        label: `${stand.label ?? ""}${stand.standNumber} — ${sector.name}`,
+      })),
+  );
+
+  const externalParticipantOptions = externalParticipants.map(
+    (participant) => ({
+      value: String(participant.id),
+      label: participant.displayName,
+    }),
+  );
+
   const form = useForm<FormValues>({
     resolver: zodResolver(FormSchema),
-    defaultValues: { userId: "", standId: "", partnerId: "" },
+    defaultValues: {
+      mode: "user",
+      externalMode: externalParticipantOptions.length > 0 ? "existing" : "new",
+      userId: "",
+      standId: "",
+      partnerId: "",
+      externalParticipantId: "",
+      displayName: "",
+      type: "institution",
+      customCategoryLabel: "",
+      description: "",
+      imageUrl: "",
+      websiteUrl: "",
+      instagramUrl: "",
+      contactEmail: "",
+    },
   });
 
+  const mode = form.watch("mode");
+  const externalMode = form.watch("externalMode");
+
   async function onSubmit(data: FormValues) {
-    const result = await createAdminReservation({
+    if (data.mode === "user") {
+      if (!data.userId) {
+        form.setError("userId", { message: "Seleccioná un usuario" });
+        return;
+      }
+
+      const result = await createAdminReservation({
+        festivalId,
+        userId: Number(data.userId),
+        standId: Number(data.standId),
+        partnerId: data.partnerId ? Number(data.partnerId) : undefined,
+      });
+
+      if (result.success) {
+        toast.success(result.message);
+        router.push(`/dashboard/festivals/${festivalId}/reservations`);
+      } else {
+        toast.error(result.message);
+      }
+      return;
+    }
+
+    if (data.externalMode === "existing") {
+      if (!data.externalParticipantId) {
+        form.setError("externalParticipantId", {
+          message: "Seleccioná un participante externo",
+        });
+        return;
+      }
+
+      const result = await createExternalParticipantReservation({
+        festivalId,
+        standId: Number(data.standId),
+        externalParticipantId: Number(data.externalParticipantId),
+      });
+
+      if (result.success) {
+        toast.success(result.message);
+        router.push(`/dashboard/festivals/${festivalId}/reservations`);
+      } else {
+        toast.error(result.message);
+      }
+      return;
+    }
+
+    if (!data.displayName?.trim()) {
+      form.setError("displayName", { message: "El nombre es requerido" });
+      return;
+    }
+    if (!data.type) {
+      form.setError("type", { message: "Seleccioná un tipo" });
+      return;
+    }
+
+    const result = await createExternalParticipantReservation({
       festivalId,
-      userId: Number(data.userId),
       standId: Number(data.standId),
-      partnerId: data.partnerId ? Number(data.partnerId) : undefined,
+      externalParticipant: {
+        displayName: data.displayName,
+        type: data.type as ExternalParticipant["type"],
+        customCategoryLabel: data.customCategoryLabel,
+        description: data.description,
+        imageUrl: data.imageUrl,
+        websiteUrl: data.websiteUrl,
+        instagramUrl: data.instagramUrl,
+        contactEmail: data.contactEmail,
+      },
     });
 
     if (result.success) {
@@ -72,27 +199,150 @@ export default function CreateReservationForm({
         onSubmit={form.handleSubmit(onSubmit)}
         className="flex flex-col gap-6"
       >
-        <ComboboxInput
-          form={form}
-          name="userId"
-          label="Usuario"
-          placeholder="Seleccionar usuario"
-          options={userOptions}
+        <FormField
+          control={form.control}
+          name="mode"
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <Tabs value={field.value} onValueChange={field.onChange}>
+                  <TabsList className="grid w-full grid-cols-2">
+                    <TabsTrigger value="user" className="gap-2">
+                      <UserIcon className="size-4" />
+                      Usuario
+                    </TabsTrigger>
+                    <TabsTrigger value="external" className="gap-2">
+                      <Building2Icon className="size-4" />
+                      Participante externo
+                    </TabsTrigger>
+                  </TabsList>
+                </Tabs>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
         />
-        <ComboboxInput
-          form={form}
-          name="standId"
-          label="Espacio"
-          placeholder="Seleccionar espacio"
-          options={standOptions}
-        />
-        <ComboboxInput
-          form={form}
-          name="partnerId"
-          label="Acompañante (opcional)"
-          placeholder="Seleccionar acompañante"
-          options={userOptions}
-        />
+
+        {mode === "user" ? (
+          <>
+            <ComboboxInput
+              form={form}
+              name="userId"
+              label="Usuario"
+              placeholder="Seleccionar usuario"
+              options={userOptions}
+            />
+            <ComboboxInput
+              form={form}
+              name="standId"
+              label="Espacio"
+              placeholder="Seleccionar espacio"
+              options={standOptions}
+            />
+            <ComboboxInput
+              form={form}
+              name="partnerId"
+              label="Acompañante (opcional)"
+              placeholder="Seleccionar acompañante"
+              options={userOptions}
+            />
+          </>
+        ) : (
+          <>
+            <FormField
+              control={form.control}
+              name="externalMode"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <Tabs value={field.value} onValueChange={field.onChange}>
+                      <TabsList className="grid w-full grid-cols-2">
+                        <TabsTrigger value="existing">Existente</TabsTrigger>
+                        <TabsTrigger value="new">Nuevo</TabsTrigger>
+                      </TabsList>
+                    </Tabs>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {externalMode === "existing" ? (
+              <ComboboxInput
+                form={form}
+                name="externalParticipantId"
+                label="Participante externo"
+                placeholder="Seleccionar participante"
+                options={externalParticipantOptions}
+              />
+            ) : (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <TextField
+                  name="displayName"
+                  label="Nombre"
+                  placeholder="Nombre de la institución"
+                />
+                <SelectInput
+                  formControl={form.control}
+                  name="type"
+                  label="Tipo"
+                  placeholder="Seleccionar tipo"
+                  options={externalParticipantTypeOptions}
+                />
+                <TextField
+                  name="customCategoryLabel"
+                  label="Etiqueta de categoría"
+                  placeholder="Ej. Refugio animal"
+                />
+                <TextField
+                  name="imageUrl"
+                  label="Imagen o logo"
+                  placeholder="https://..."
+                />
+                <TextField
+                  name="websiteUrl"
+                  label="Sitio web"
+                  placeholder="https://..."
+                />
+                <TextField
+                  name="instagramUrl"
+                  label="Instagram"
+                  placeholder="https://instagram.com/..."
+                />
+                <TextField
+                  name="contactEmail"
+                  label="Correo de contacto"
+                  placeholder="contacto@..."
+                />
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem className="md:col-span-2">
+                      <FormLabel>Descripción</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="Breve descripción para referencia interna o pública"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            )}
+
+            <ComboboxInput
+              form={form}
+              name="standId"
+              label="Espacio disponible"
+              placeholder="Seleccionar espacio"
+              options={externalStandOptions}
+            />
+          </>
+        )}
+
         <div className="flex gap-3">
           <Button
             type="button"
@@ -110,4 +360,30 @@ export default function CreateReservationForm({
       </form>
     </Form>
   );
+
+  function TextField({
+    name,
+    label,
+    placeholder,
+  }: {
+    name: keyof FormValues;
+    label: string;
+    placeholder?: string;
+  }) {
+    return (
+      <FormField
+        control={form.control}
+        name={name}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{label}</FormLabel>
+            <FormControl>
+              <Input placeholder={placeholder} {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    );
+  }
 }

--- a/app/dashboard/festivals/[id]/reservations/new/page.tsx
+++ b/app/dashboard/festivals/[id]/reservations/new/page.tsx
@@ -21,8 +21,10 @@ export default async function NewReservationPage({
   ]);
 
   return (
-    <div className="container max-w-2xl py-8">
-      <h1 className="text-2xl font-bold mb-6">Agregar reserva</h1>
+    <div className="container p-4 md:p-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">Agregar reserva</h1>
+      </div>
       <CreateReservationForm
         festivalId={id}
         users={enrolledUsers}

--- a/app/dashboard/festivals/[id]/reservations/new/page.tsx
+++ b/app/dashboard/festivals/[id]/reservations/new/page.tsx
@@ -1,5 +1,6 @@
 import { fetchAllFestivalEnrolledUsers } from "@/app/lib/festivals/actions";
 import { fetchFestivalSectors } from "@/app/lib/festival_sectors/actions";
+import { fetchExternalParticipants } from "@/app/lib/external_participants/actions";
 import CreateReservationForm from "./form";
 import { z } from "zod";
 
@@ -13,18 +14,20 @@ export default async function NewReservationPage({
   params: Promise<z.infer<typeof ParamsSchema>>;
 }) {
   const { id } = ParamsSchema.parse(await params);
-  const [enrolledUsers, sectors] = await Promise.all([
+  const [enrolledUsers, sectors, externalParticipants] = await Promise.all([
     fetchAllFestivalEnrolledUsers(id),
     fetchFestivalSectors(id),
+    fetchExternalParticipants(),
   ]);
 
   return (
-    <div className="container max-w-lg py-8">
+    <div className="container max-w-2xl py-8">
       <h1 className="text-2xl font-bold mb-6">Agregar reserva</h1>
       <CreateReservationForm
         festivalId={id}
         users={enrolledUsers}
         sectors={sectors}
+        externalParticipants={externalParticipants}
       />
     </div>
   );

--- a/app/dashboard/festivals/[id]/reservations/page.tsx
+++ b/app/dashboard/festivals/[id]/reservations/page.tsx
@@ -18,7 +18,7 @@ export default async function FestivalReservationsPage({
   const reservations = await fetchReservationsByFestivalId(id);
 
   return (
-    <div className="container">
+    <div className="container p-4 md:p-6">
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-2xl font-bold">Reservas del festival</h1>
         <Button asChild size="sm">

--- a/app/lib/external_participants/actions.ts
+++ b/app/lib/external_participants/actions.ts
@@ -1,0 +1,198 @@
+"use server";
+
+import { db } from "@/db";
+import {
+  externalParticipantTypeEnum,
+  externalParticipants,
+  reservationExternalParticipants,
+  standReservations,
+  stands,
+} from "@/db/schema";
+import { getCurrentUserProfile } from "@/app/lib/users/helpers";
+import { and, eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+const ExternalParticipantInputSchema = z.object({
+  displayName: z.string().trim().min(2, "El nombre es requerido"),
+  type: z.enum(externalParticipantTypeEnum.enumValues),
+  customCategoryLabel: z.string().trim().optional(),
+  description: z.string().trim().optional(),
+  imageUrl: z.string().trim().optional(),
+  websiteUrl: z.string().trim().optional(),
+  instagramUrl: z.string().trim().optional(),
+  contactEmail: z
+    .email("Ingresá un correo válido")
+    .optional()
+    .or(z.literal("")),
+});
+
+const AssignmentSchema = z.object({
+  festivalId: z.coerce.number().int().positive(),
+  standId: z.coerce.number().int().positive(),
+  externalParticipantId: z.coerce.number().int().positive().optional(),
+  externalParticipant: ExternalParticipantInputSchema.optional(),
+});
+
+function emptyToNull(value?: string) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export async function fetchExternalParticipants() {
+  try {
+    return await db.query.externalParticipants.findMany({
+      orderBy: (externalParticipants, { asc }) => [
+        asc(externalParticipants.displayName),
+      ],
+    });
+  } catch (error) {
+    console.error("Error fetching external participants", error);
+    return [];
+  }
+}
+
+export async function createExternalParticipantReservation(
+  input: z.infer<typeof AssignmentSchema>,
+): Promise<{ success: boolean; message: string; reservationId?: number }> {
+  const currentProfile = await getCurrentUserProfile();
+  if (
+    !currentProfile ||
+    (currentProfile.role !== "admin" &&
+      currentProfile.role !== "festival_admin")
+  ) {
+    return {
+      success: false,
+      message: "No tienes permisos para realizar esta acción",
+    };
+  }
+
+  const parsed = AssignmentSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: "Datos inválidos",
+    };
+  }
+
+  const { festivalId, standId, externalParticipantId, externalParticipant } =
+    parsed.data;
+
+  if (!externalParticipantId && !externalParticipant) {
+    return {
+      success: false,
+      message: "Seleccioná o creá un participante externo",
+    };
+  }
+
+  try {
+    const reservationId = await db.transaction(async (tx) => {
+      const [lockedStand] = await tx
+        .select()
+        .from(stands)
+        .where(and(eq(stands.id, standId), eq(stands.festivalId, festivalId)))
+        .limit(1)
+        .for("update");
+
+      if (!lockedStand) {
+        throw new Error("STAND_NOT_FOUND");
+      }
+
+      if (lockedStand.status !== "available") {
+        throw new Error("STAND_NOT_AVAILABLE");
+      }
+
+      let participantId = externalParticipantId;
+
+      if (participantId) {
+        const existing = await tx.query.externalParticipants.findFirst({
+          where: eq(externalParticipants.id, participantId),
+        });
+        if (!existing) {
+          throw new Error("EXTERNAL_PARTICIPANT_NOT_FOUND");
+        }
+      } else if (externalParticipant) {
+        const [created] = await tx
+          .insert(externalParticipants)
+          .values({
+            displayName: externalParticipant.displayName,
+            type: externalParticipant.type,
+            customCategoryLabel: emptyToNull(
+              externalParticipant.customCategoryLabel,
+            ),
+            description: emptyToNull(externalParticipant.description),
+            imageUrl: emptyToNull(externalParticipant.imageUrl),
+            websiteUrl: emptyToNull(externalParticipant.websiteUrl),
+            instagramUrl: emptyToNull(externalParticipant.instagramUrl),
+            contactEmail: emptyToNull(externalParticipant.contactEmail),
+            createdByUserId: currentProfile.id,
+          })
+          .returning({ id: externalParticipants.id });
+
+        participantId = created.id;
+      }
+
+      if (!participantId) {
+        throw new Error("EXTERNAL_PARTICIPANT_REQUIRED");
+      }
+
+      const [reservation] = await tx
+        .insert(standReservations)
+        .values({
+          festivalId,
+          standId,
+          status: "accepted",
+          source: "admin_assignment",
+        })
+        .returning({ id: standReservations.id });
+
+      await tx.insert(reservationExternalParticipants).values({
+        externalParticipantId: participantId,
+        reservationId: reservation.id,
+      });
+
+      await tx
+        .update(stands)
+        .set({ status: "confirmed", updatedAt: new Date() })
+        .where(eq(stands.id, standId));
+
+      return reservation.id;
+    });
+
+    revalidatePath("/dashboard/festivals");
+    revalidatePath("/dashboard/reservations");
+    revalidatePath(`/dashboard/festivals/${festivalId}`);
+    revalidatePath(`/dashboard/festivals/${festivalId}/reservations`);
+    revalidatePath("/", "layout");
+
+    return {
+      success: true,
+      message: "Reserva externa creada",
+      reservationId,
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === "STAND_NOT_FOUND") {
+        return { success: false, message: "El espacio no existe" };
+      }
+      if (error.message === "STAND_NOT_AVAILABLE") {
+        return {
+          success: false,
+          message: "El espacio no está disponible",
+        };
+      }
+      if (error.message === "EXTERNAL_PARTICIPANT_NOT_FOUND") {
+        return {
+          success: false,
+          message: "El participante externo no existe",
+        };
+      }
+    }
+
+    console.error("Error creating external participant reservation", error);
+    return {
+      success: false,
+      message: "Ups! No pudimos crear la reserva externa",
+    };
+  }
+}

--- a/app/lib/external_participants/actions.ts
+++ b/app/lib/external_participants/actions.ts
@@ -13,12 +13,34 @@ import { and, eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 
+function isAcceptedExternalParticipantImageUrl(value?: string) {
+  if (!value) return true;
+
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      (url.hostname === "utfs.io" ||
+        url.hostname === "ufs.sh" ||
+        url.hostname.endsWith(".ufs.sh"))
+    );
+  } catch {
+    return false;
+  }
+}
+
 const ExternalParticipantInputSchema = z.object({
   displayName: z.string().trim().min(2, "El nombre es requerido"),
   type: z.enum(externalParticipantTypeEnum.enumValues),
   customCategoryLabel: z.string().trim().optional(),
   description: z.string().trim().optional(),
-  imageUrl: z.string().trim().optional(),
+  imageUrl: z
+    .string()
+    .trim()
+    .optional()
+    .refine(isAcceptedExternalParticipantImageUrl, {
+      message: "La imagen debe subirse desde el formulario",
+    }),
   websiteUrl: z.string().trim().optional(),
   instagramUrl: z.string().trim().optional(),
   contactEmail: z

--- a/app/lib/external_participants/actions.ts
+++ b/app/lib/external_participants/actions.ts
@@ -41,8 +41,8 @@ const ExternalParticipantInputSchema = z.object({
     .refine(isAcceptedExternalParticipantImageUrl, {
       message: "La imagen debe subirse desde el formulario",
     }),
-  websiteUrl: z.string().trim().optional(),
-  instagramUrl: z.string().trim().optional(),
+  websiteUrl: z.url().optional(),
+  instagramUrl: z.url().optional(),
   contactEmail: z
     .email("Ingresá un correo válido")
     .optional()

--- a/app/lib/external_participants/actions.ts
+++ b/app/lib/external_participants/actions.ts
@@ -41,8 +41,8 @@ const ExternalParticipantInputSchema = z.object({
     .refine(isAcceptedExternalParticipantImageUrl, {
       message: "La imagen debe subirse desde el formulario",
     }),
-  websiteUrl: z.url().optional(),
-  instagramUrl: z.url().optional(),
+  websiteUrl: z.url().optional().or(z.literal("")),
+  instagramUrl: z.url().optional().or(z.literal("")),
   contactEmail: z
     .email("Ingresá un correo válido")
     .optional()

--- a/app/lib/external_participants/definitions.ts
+++ b/app/lib/external_participants/definitions.ts
@@ -1,0 +1,31 @@
+import { externalParticipants } from "@/db/schema";
+
+export type ExternalParticipant = typeof externalParticipants.$inferSelect;
+export type NewExternalParticipant = typeof externalParticipants.$inferInsert;
+export type ExternalParticipantType = ExternalParticipant["type"];
+
+export const externalParticipantTypeLabels: Record<
+  ExternalParticipantType,
+  string
+> = {
+  institution: "Institución",
+  social_organization: "Organización social",
+  sponsor: "Auspiciante",
+  partner: "Aliado",
+  public_entity: "Entidad pública",
+  invited_brand: "Marca invitada",
+  other: "Otro",
+};
+
+export const externalParticipantTypeOptions = Object.entries(
+  externalParticipantTypeLabels,
+).map(([value, label]) => ({ value, label }));
+
+export function getExternalParticipantCategoryLabel(
+  participant: Pick<ExternalParticipant, "type" | "customCategoryLabel">,
+) {
+  return (
+    participant.customCategoryLabel?.trim() ||
+    externalParticipantTypeLabels[participant.type]
+  );
+}

--- a/app/lib/festival_sectors/actions.ts
+++ b/app/lib/festival_sectors/actions.ts
@@ -46,6 +46,11 @@ export async function fetchFestivalSectors(
                     },
                   },
                 },
+                externalParticipants: {
+                  with: {
+                    externalParticipant: true,
+                  },
+                },
               },
             },
             standSubcategories: {
@@ -182,6 +187,11 @@ export async function fetchFestivalSectorsByUserCategory(
                           userSocials: true,
                         },
                       },
+                    },
+                  },
+                  externalParticipants: {
+                    with: {
+                      externalParticipant: true,
                     },
                   },
                 },
@@ -379,7 +389,14 @@ export async function fetchSectorWithStandsAndReservations(sectorId: number) {
         stands: {
           with: {
             reservations: {
-              with: { participants: { with: { user: true } } },
+              with: {
+                participants: { with: { user: true } },
+                externalParticipants: {
+                  with: {
+                    externalParticipant: true,
+                  },
+                },
+              },
             },
           },
         },

--- a/app/lib/reservations/actions.ts
+++ b/app/lib/reservations/actions.ts
@@ -129,47 +129,6 @@ export async function fetchReservationsByFestivalId(
             },
           },
         },
-        collaborators: {
-          with: {
-            collaborator: true,
-          },
-        },
-        invoices: {
-          with: {
-            payments: true,
-          },
-        },
-        scheduledTasks: true,
-      },
-    });
-  } catch (error) {
-    console.error(error);
-    return [];
-  }
-  try {
-    return await db.query.standReservations.findMany({
-      where: eq(standReservations.festivalId, festivalId),
-      with: {
-        stand: true,
-        festival: {
-          with: {
-            festivalDates: true,
-          },
-        },
-        participants: {
-          with: {
-            user: {
-              with: {
-                userSocials: true,
-                profileSubcategories: {
-                  with: {
-                    subcategory: true,
-                  },
-                },
-              },
-            },
-          },
-        },
         externalParticipants: {
           with: {
             externalParticipant: true,
@@ -202,26 +161,6 @@ export async function fetchReservationsByFestivalId(
 export async function fetchPublicReservationsByFestivalId(
   festivalId: number,
 ): Promise<ReservationWithParticipantsAndUsersAndStand[]> {
-  try {
-    return await db.query.standReservations.findMany({
-      where: eq(standReservations.festivalId, festivalId),
-      with: {
-        stand: true,
-        participants: {
-          with: {
-            user: {
-              with: {
-                userSocials: true,
-              },
-            },
-          },
-        },
-      },
-    });
-  } catch (error) {
-    console.error(error);
-    return [];
-  }
   try {
     return await db.query.standReservations.findMany({
       where: eq(standReservations.festivalId, festivalId),

--- a/app/lib/reservations/actions.ts
+++ b/app/lib/reservations/actions.ts
@@ -146,6 +146,52 @@ export async function fetchReservationsByFestivalId(
     console.error(error);
     return [];
   }
+  try {
+    return await db.query.standReservations.findMany({
+      where: eq(standReservations.festivalId, festivalId),
+      with: {
+        stand: true,
+        festival: {
+          with: {
+            festivalDates: true,
+          },
+        },
+        participants: {
+          with: {
+            user: {
+              with: {
+                userSocials: true,
+                profileSubcategories: {
+                  with: {
+                    subcategory: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+        externalParticipants: {
+          with: {
+            externalParticipant: true,
+          },
+        },
+        collaborators: {
+          with: {
+            collaborator: true,
+          },
+        },
+        invoices: {
+          with: {
+            payments: true,
+          },
+        },
+        scheduledTasks: true,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
 }
 
 /**
@@ -168,6 +214,31 @@ export async function fetchPublicReservationsByFestivalId(
                 userSocials: true,
               },
             },
+          },
+        },
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+  try {
+    return await db.query.standReservations.findMany({
+      where: eq(standReservations.festivalId, festivalId),
+      with: {
+        stand: true,
+        participants: {
+          with: {
+            user: {
+              with: {
+                userSocials: true,
+              },
+            },
+          },
+        },
+        externalParticipants: {
+          with: {
+            externalParticipant: true,
           },
         },
       },

--- a/app/lib/uploadthing/actions.ts
+++ b/app/lib/uploadthing/actions.ts
@@ -25,6 +25,8 @@ export async function deleteFile(url: string) {
     const key = getUploadThingFileKey(url);
     if (key) {
       await utapi.deleteFiles(key);
+    } else {
+      console.warn("Could not extract UploadThing file key from URL:", url);
     }
     return { success: true };
   } catch (error) {

--- a/app/lib/uploadthing/actions.ts
+++ b/app/lib/uploadthing/actions.ts
@@ -27,6 +27,7 @@ export async function deleteFile(url: string) {
       await utapi.deleteFiles(key);
     } else {
       console.warn("Could not extract UploadThing file key from URL:", url);
+      return { success: false, error: "No se pudo identificar el archivo" };
     }
     return { success: true };
   } catch (error) {

--- a/app/lib/uploadthing/actions.ts
+++ b/app/lib/uploadthing/actions.ts
@@ -2,10 +2,28 @@
 
 import { utapi } from "@/app/server/uploadthing";
 
+function getUploadThingFileKey(url: string) {
+  try {
+    const parsedUrl = new URL(url);
+    if (
+      parsedUrl.hostname === "utfs.io" ||
+      parsedUrl.hostname === "ufs.sh" ||
+      parsedUrl.hostname.endsWith(".ufs.sh")
+    ) {
+      const fileKey = parsedUrl.pathname.split("/f/")[1];
+      return fileKey || null;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
 export async function deleteFile(url: string) {
   try {
-    if (url.includes("utfs")) {
-      const [_, key] = url.split("/f/");
+    const key = getUploadThingFileKey(url);
+    if (key) {
       await utapi.deleteFiles(key);
     }
     return { success: true };

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -98,6 +98,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   userRequests: many(userRequests),
   userSocials: many(userSocials),
   participations: many(reservationParticipants),
+  createdExternalParticipants: many(externalParticipants),
   scheduledTasks: many(scheduledTasks),
   invoices: many(invoices),
   profileTags: many(profileTags),
@@ -353,6 +354,19 @@ export const reservationStatusEnum = pgEnum("reservation_status", [
   "accepted",
   "rejected",
 ]);
+export const reservationSourceEnum = pgEnum("reservation_source", [
+  "user_reservation",
+  "admin_assignment",
+]);
+export const externalParticipantTypeEnum = pgEnum("external_participant_type", [
+  "institution",
+  "social_organization",
+  "sponsor",
+  "partner",
+  "public_entity",
+  "invited_brand",
+  "other",
+]);
 
 export const requestTypeEnum = pgEnum("user_request_type", [
   "festival_participation",
@@ -539,6 +553,7 @@ export const standReservations = pgTable("stand_reservations", {
     .references(() => stands.id),
   festivalId: integer("festival_id").notNull(),
   status: reservationStatusEnum("status").default("pending").notNull(),
+  source: reservationSourceEnum("source").default("user_reservation").notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
@@ -554,6 +569,7 @@ export const standReservationsRelations = relations(
       references: [festivals.id],
     }),
     participants: many(reservationParticipants),
+    externalParticipants: many(reservationExternalParticipants),
     invoices: many(invoices),
     scheduledTasks: many(scheduledTasks),
     collaborators: many(reservationCollaborators),
@@ -582,6 +598,75 @@ export const participationsRelations = relations(
     }),
     reservation: one(standReservations, {
       fields: [reservationParticipants.reservationId],
+      references: [standReservations.id],
+    }),
+  }),
+);
+
+export const externalParticipants = pgTable(
+  "external_participants",
+  {
+    id: serial("id").primaryKey(),
+    displayName: text("display_name").notNull(),
+    type: externalParticipantTypeEnum("type").notNull(),
+    customCategoryLabel: text("custom_category_label"),
+    description: text("description"),
+    imageUrl: text("image_url"),
+    websiteUrl: text("website_url"),
+    instagramUrl: text("instagram_url"),
+    contactEmail: text("contact_email"),
+    createdByUserId: integer("created_by_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (externalParticipants) => [
+    index("external_participants_display_name_idx").on(
+      externalParticipants.displayName,
+    ),
+  ],
+);
+export const externalParticipantsRelations = relations(
+  externalParticipants,
+  ({ one, many }) => ({
+    createdByUser: one(users, {
+      fields: [externalParticipants.createdByUserId],
+      references: [users.id],
+    }),
+    reservations: many(reservationExternalParticipants),
+  }),
+);
+
+export const reservationExternalParticipants = pgTable(
+  "reservation_external_participants",
+  {
+    id: serial("id").primaryKey(),
+    externalParticipantId: integer("external_participant_id")
+      .notNull()
+      .references(() => externalParticipants.id, { onDelete: "cascade" }),
+    reservationId: integer("reservation_id")
+      .notNull()
+      .references(() => standReservations.id, { onDelete: "cascade" }),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (reservationExternalParticipants) => [
+    unique("reservation_external_participants_unique").on(
+      reservationExternalParticipants.externalParticipantId,
+      reservationExternalParticipants.reservationId,
+    ),
+  ],
+);
+export const reservationExternalParticipantsRelations = relations(
+  reservationExternalParticipants,
+  ({ one }) => ({
+    externalParticipant: one(externalParticipants, {
+      fields: [reservationExternalParticipants.externalParticipantId],
+      references: [externalParticipants.id],
+    }),
+    reservation: one(standReservations, {
+      fields: [reservationExternalParticipants.reservationId],
       references: [standReservations.id],
     }),
   }),

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -652,6 +652,9 @@ export const reservationExternalParticipants = pgTable(
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
   (reservationExternalParticipants) => [
+    index("reservation_external_participants_reservation_id_idx").on(
+      reservationExternalParticipants.reservationId,
+    ),
     unique("reservation_external_participants_unique").on(
       reservationExternalParticipants.externalParticipantId,
       reservationExternalParticipants.reservationId,

--- a/drizzle/0177_grey_speedball.sql
+++ b/drizzle/0177_grey_speedball.sql
@@ -1,0 +1,30 @@
+CREATE TYPE "public"."external_participant_type" AS ENUM('institution', 'social_organization', 'sponsor', 'partner', 'public_entity', 'invited_brand', 'other');--> statement-breakpoint
+CREATE TYPE "public"."reservation_source" AS ENUM('user_reservation', 'admin_assignment');--> statement-breakpoint
+CREATE TABLE "external_participants" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"display_name" text NOT NULL,
+	"type" "external_participant_type" NOT NULL,
+	"custom_category_label" text,
+	"description" text,
+	"image_url" text,
+	"website_url" text,
+	"instagram_url" text,
+	"contact_email" text,
+	"created_by_user_id" integer,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "reservation_external_participants" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"external_participant_id" integer NOT NULL,
+	"reservation_id" integer NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "reservation_external_participants_unique" UNIQUE("external_participant_id","reservation_id")
+);
+--> statement-breakpoint
+ALTER TABLE "external_participants" ADD CONSTRAINT "external_participants_created_by_user_id_users_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reservation_external_participants" ADD CONSTRAINT "reservation_external_participants_external_participant_id_external_participants_id_fk" FOREIGN KEY ("external_participant_id") REFERENCES "public"."external_participants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reservation_external_participants" ADD CONSTRAINT "reservation_external_participants_reservation_id_stand_reservations_id_fk" FOREIGN KEY ("reservation_id") REFERENCES "public"."stand_reservations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "external_participants_display_name_idx" ON "external_participants" USING btree ("display_name");

--- a/drizzle/0178_ordinary_nekra.sql
+++ b/drizzle/0178_ordinary_nekra.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "stand_reservations" ADD COLUMN "source" "reservation_source" DEFAULT 'user_reservation' NOT NULL;

--- a/drizzle/0179_gray_white_queen.sql
+++ b/drizzle/0179_gray_white_queen.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "reservation_external_participants_reservation_id_idx" ON "reservation_external_participants" USING btree ("reservation_id");

--- a/drizzle/meta/0177_snapshot.json
+++ b/drizzle/meta/0177_snapshot.json
@@ -1,0 +1,5388 @@
+{
+  "id": "cac6c990-2d6f-489b-8507-bb13cd5fe205",
+  "prevId": "e60a5b27-0498-411b-9ee0-a272e36c8722",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "badges_festival_id_festivals_id_fk": {
+          "name": "badges_festival_id_festivals_id_fk",
+          "tableFrom": "badges",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cart_items": {
+      "name": "cart_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cart_items_cart_id_idx": {
+          "name": "cart_items_cart_id_idx",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cart_items_product_id_idx": {
+          "name": "cart_items_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cart_items_cart_id_carts_id_fk": {
+          "name": "cart_items_cart_id_carts_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "carts",
+          "columnsFrom": [
+            "cart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cart_items_product_id_products_id_fk": {
+          "name": "cart_items_product_id_products_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cart_items_cart_product_unique": {
+          "name": "cart_items_cart_product_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cart_id",
+            "product_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cart_items_quantity_positive": {
+          "name": "cart_items_quantity_positive",
+          "value": "\"cart_items\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.carts": {
+      "name": "carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "carts_user_id_users_id_fk": {
+          "name": "carts_user_id_users_id_fk",
+          "tableFrom": "carts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "carts_user_id_unique": {
+          "name": "carts_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collaborators": {
+      "name": "collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identification_number": {
+          "name": "identification_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collaborators_attendance_logs": {
+      "name": "collaborators_attendance_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reservation_collaborator_id": {
+          "name": "reservation_collaborator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_date_id": {
+          "name": "festival_date_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collaborators_attendance_logs_reservation_collaborator_id_reservation_collaborators_id_fk": {
+          "name": "collaborators_attendance_logs_reservation_collaborator_id_reservation_collaborators_id_fk",
+          "tableFrom": "collaborators_attendance_logs",
+          "tableTo": "reservation_collaborators",
+          "columnsFrom": [
+            "reservation_collaborator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collaborators_attendance_logs_festival_date_id_festival_dates_id_fk": {
+          "name": "collaborators_attendance_logs_festival_date_id_festival_dates_id_fk",
+          "tableFrom": "collaborators_attendance_logs",
+          "tableTo": "festival_dates",
+          "columnsFrom": [
+            "festival_date_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discount_codes": {
+      "name": "discount_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_unit": {
+          "name": "discount_unit",
+          "type": "discount_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_uses": {
+          "name": "current_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discount_codes_festival_id_festivals_id_fk": {
+          "name": "discount_codes_festival_id_festivals_id_fk",
+          "tableFrom": "discount_codes",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "discount_codes_user_id_users_id_fk": {
+          "name": "discount_codes_user_id_users_id_fk",
+          "tableFrom": "discount_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discount_codes_code_unique": {
+          "name": "discount_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_participants": {
+      "name": "external_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "external_participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_category_label": {
+          "name": "custom_category_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_participants_display_name_idx": {
+          "name": "external_participants_display_name_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_participants_created_by_user_id_users_id_fk": {
+          "name": "external_participants_created_by_user_id_users_id_fk",
+          "tableFrom": "external_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activities": {
+      "name": "festival_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_start_date": {
+          "name": "registration_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_end_date": {
+          "name": "registration_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promotional_art_url": {
+          "name": "promotional_art_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitors_description": {
+          "name": "visitors_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "festival_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stamp_passport'"
+        },
+        "activity_prize_url": {
+          "name": "activity_prize_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allows_voting": {
+          "name": "allows_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "voting_start_date": {
+          "name": "voting_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voting_end_date": {
+          "name": "voting_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_type": {
+          "name": "proof_type",
+          "type": "proof_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_upload_limit_date": {
+          "name": "proof_upload_limit_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "access_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "waitlist_window_minutes": {
+          "name": "waitlist_window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activities_festival_id_festivals_id_fk": {
+          "name": "festival_activities_festival_id_festivals_id_fk",
+          "tableFrom": "festival_activities",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proof_upload_limit_required": {
+          "name": "proof_upload_limit_required",
+          "value": "(\"festival_activities\".\"proof_type\" IS NULL) OR (\"festival_activities\".\"proof_upload_limit_date\" IS NOT NULL)"
+        },
+        "festival_activities_waitlist_window_minutes_positive": {
+          "name": "festival_activities_waitlist_window_minutes_positive",
+          "value": "\"festival_activities\".\"waitlist_window_minutes\" IS NULL OR \"festival_activities\".\"waitlist_window_minutes\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_details": {
+      "name": "festival_activity_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coupon_book_header_image_url": {
+          "name": "coupon_book_header_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participation_limit": {
+          "name": "participation_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_details_activity_id_festival_activities_id_fk": {
+          "name": "festival_activity_details_activity_id_festival_activities_id_fk",
+          "tableFrom": "festival_activity_details",
+          "tableTo": "festival_activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_participant_proofs": {
+      "name": "festival_activity_participant_proofs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participation_id": {
+          "name": "participation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promo_highlight": {
+          "name": "promo_highlight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_description": {
+          "name": "promo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_conditions": {
+          "name": "promo_conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_status": {
+          "name": "proof_status",
+          "type": "proof_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "admin_feedback": {
+          "name": "admin_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_participant_proofs_participation_id_festival_activity_participants_id_fk": {
+          "name": "festival_activity_participant_proofs_participation_id_festival_activity_participants_id_fk",
+          "tableFrom": "festival_activity_participant_proofs",
+          "tableTo": "festival_activity_participants",
+          "columnsFrom": [
+            "participation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_participants": {
+      "name": "festival_activity_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "details_id": {
+          "name": "details_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removal_reason": {
+          "name": "removal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_participants_details_id_festival_activity_details_id_fk": {
+          "name": "festival_activity_participants_details_id_festival_activity_details_id_fk",
+          "tableFrom": "festival_activity_participants",
+          "tableTo": "festival_activity_details",
+          "columnsFrom": [
+            "details_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_participants_user_id_users_id_fk": {
+          "name": "festival_activity_participants_user_id_users_id_fk",
+          "tableFrom": "festival_activity_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "festival_activity_participants_details_id_user_id_unique": {
+          "name": "festival_activity_participants_details_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "details_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_votes": {
+      "name": "festival_activity_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_variant_id": {
+          "name": "activity_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votable_type": {
+          "name": "votable_type",
+          "type": "votable_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_votes_voter_id_users_id_fk": {
+          "name": "festival_activity_votes_voter_id_users_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_votes_activity_variant_id_festival_activity_details_id_fk": {
+          "name": "festival_activity_votes_activity_variant_id_festival_activity_details_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "festival_activity_details",
+          "columnsFrom": [
+            "activity_variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_votes_stand_id_stands_id_fk": {
+          "name": "festival_activity_votes_stand_id_stands_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_votes_participant_id_festival_activity_participants_id_fk": {
+          "name": "festival_activity_votes_participant_id_festival_activity_participants_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "festival_activity_participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_voter_activity": {
+          "name": "unique_voter_activity",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_id",
+            "activity_variant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_waitlist": {
+      "name": "festival_activity_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notified_for_detail_id": {
+          "name": "notified_for_detail_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_waitlist_activity_id_festival_activities_id_fk": {
+          "name": "festival_activity_waitlist_activity_id_festival_activities_id_fk",
+          "tableFrom": "festival_activity_waitlist",
+          "tableTo": "festival_activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_waitlist_user_id_users_id_fk": {
+          "name": "festival_activity_waitlist_user_id_users_id_fk",
+          "tableFrom": "festival_activity_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_waitlist_notified_for_detail_id_festival_activity_details_id_fk": {
+          "name": "festival_activity_waitlist_notified_for_detail_id_festival_activity_details_id_fk",
+          "tableFrom": "festival_activity_waitlist",
+          "tableTo": "festival_activity_details",
+          "columnsFrom": [
+            "notified_for_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "festival_activity_waitlist_activity_id_user_id_unique": {
+          "name": "festival_activity_waitlist_activity_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "activity_id",
+            "user_id"
+          ]
+        },
+        "festival_activity_waitlist_activity_id_position_unique": {
+          "name": "festival_activity_waitlist_activity_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "activity_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "festival_activity_waitlist_position_check": {
+          "name": "festival_activity_waitlist_position_check",
+          "value": "\"festival_activity_waitlist\".\"position\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.festival_dates": {
+      "name": "festival_dates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "festival_dates_festival_id_idx": {
+          "name": "festival_dates_festival_id_idx",
+          "columns": [
+            {
+              "expression": "festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "festival_dates_festival_id_festivals_id_fk": {
+          "name": "festival_dates_festival_id_festivals_id_fk",
+          "tableFrom": "festival_dates",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_sectors": {
+      "name": "festival_sectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_url": {
+          "name": "map_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_in_festival": {
+          "name": "order_in_festival",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mascot_url": {
+          "name": "mascot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_origin_x": {
+          "name": "map_origin_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_origin_y": {
+          "name": "map_origin_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_width": {
+          "name": "map_width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_height": {
+          "name": "map_height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "festival_sector_name_idx": {
+          "name": "festival_sector_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "festival_sectors_festival_id_festivals_id_fk": {
+          "name": "festival_sectors_festival_id_festivals_id_fk",
+          "tableFrom": "festival_sectors",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festivals": {
+      "name": "festivals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label": {
+          "name": "location_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_url": {
+          "name": "location_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "festival_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maps_version": {
+          "name": "maps_version",
+          "type": "festival_map_version",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        },
+        "public_registration": {
+          "name": "public_registration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_day_registration": {
+          "name": "event_day_registration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "keep_store_open": {
+          "name": "keep_store_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reservations_start_date": {
+          "name": "reservations_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "general_map_url": {
+          "name": "general_map_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mascot_url": {
+          "name": "mascot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_type": {
+          "name": "festival_type",
+          "type": "festival_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'glitter'"
+        },
+        "illustration_payment_qr_code_url": {
+          "name": "illustration_payment_qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gastronomy_payment_qr_code_url": {
+          "name": "gastronomy_payment_qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrepreneurship_payment_qr_code_url": {
+          "name": "entrepreneurship_payment_qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "illustration_stand_url": {
+          "name": "illustration_stand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gastronomy_stand_url": {
+          "name": "gastronomy_stand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrepreneurship_stand_url": {
+          "name": "entrepreneurship_stand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_code": {
+          "name": "festival_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_banner_url": {
+          "name": "festival_banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms_and_conditions_url": {
+          "name": "terms_and_conditions_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_url": {
+          "name": "poster_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "festivals_name_unique": {
+          "name": "festivals_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.infraction_types": {
+      "name": "infraction_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "infraction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'low'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "infraction_types_code_unique": {
+          "name": "infraction_types_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.infractions": {
+      "name": "infractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handled": {
+          "name": "handled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_gave_notice": {
+          "name": "user_gave_notice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gave_notice_at": {
+          "name": "gave_notice_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "infractions_user_id_users_id_fk": {
+          "name": "infractions_user_id_users_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "infractions_type_id_infraction_types_id_fk": {
+          "name": "infractions_type_id_infraction_types_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "infraction_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "infractions_festival_id_festivals_id_fk": {
+          "name": "infractions_festival_id_festivals_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "original_amount": {
+          "name": "original_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_code_id": {
+          "name": "discount_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_user_id_users_id_fk": {
+          "name": "invoices_user_id_users_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_reservation_id_stand_reservations_id_fk": {
+          "name": "invoices_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_discount_code_id_discount_codes_id_fk": {
+          "name": "invoices_discount_code_id_discount_codes_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "discount_codes",
+          "columnsFrom": [
+            "discount_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.live_acts": {
+      "name": "live_acts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "act_name": {
+          "name": "act_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "live_act_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_link": {
+          "name": "resource_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "live_act_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "admin_notes": {
+          "name": "admin_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_elements": {
+      "name": "map_elements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "map_element_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_position": {
+          "name": "label_position",
+          "type": "map_element_label_position",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bottom'"
+        },
+        "label_font_size": {
+          "name": "label_font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "label_font_weight": {
+          "name": "label_font_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "show_icon": {
+          "name": "show_icon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "position_left": {
+          "name": "position_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "position_top": {
+          "name": "position_top",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "width": {
+          "name": "width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "height": {
+          "name": "height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "festival_sector_id": {
+          "name": "festival_sector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "map_elements_sector_idx": {
+          "name": "map_elements_sector_idx",
+          "columns": [
+            {
+              "expression": "festival_sector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_elements_festival_sector_id_festival_sectors_id_fk": {
+          "name": "map_elements_festival_sector_id_festival_sectors_id_fk",
+          "tableFrom": "map_elements",
+          "tableTo": "festival_sectors",
+          "columnsFrom": [
+            "festival_sector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_templates": {
+      "name": "map_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_data": {
+          "name": "template_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_festival_id": {
+          "name": "created_from_festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "map_templates_created_by_user_id_users_id_fk": {
+          "name": "map_templates_created_by_user_id_users_id_fk",
+          "tableFrom": "map_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "map_templates_created_from_festival_id_festivals_id_fk": {
+          "name": "map_templates_created_from_festival_id_festivals_id_fk",
+          "tableFrom": "map_templates",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "created_from_festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketing_banners": {
+      "name": "marketing_banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url_tablet": {
+          "name": "image_url_tablet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url_mobile": {
+          "name": "image_url_mobile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "marketing_banner_audience",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "open_in_new_tab": {
+          "name": "open_in_new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "marketing_banners_sort_order_idx": {
+          "name": "marketing_banners_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "marketing_banners_is_visible_idx": {
+          "name": "marketing_banners_is_visible_idx",
+          "columns": [
+            {
+              "expression": "is_visible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_items": {
+      "name": "order_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_at_purchase": {
+          "name": "price_at_purchase",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_items_order_id_idx": {
+          "name": "order_items_order_id_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_items_product_id_idx": {
+          "name": "order_items_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_phone": {
+          "name": "guest_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_order_token": {
+          "name": "guest_order_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_voucher_url": {
+          "name": "payment_voucher_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voucher_submitted_at": {
+          "name": "voucher_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_due_date": {
+          "name": "payment_due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + interval '2 days'"
+        },
+        "payment_reminder1_sent_at": {
+          "name": "payment_reminder1_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder2_sent_at": {
+          "name": "payment_reminder2_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder3_sent_at": {
+          "name": "payment_reminder3_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder1_claimed_at": {
+          "name": "payment_reminder1_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder2_claimed_at": {
+          "name": "payment_reminder2_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder3_claimed_at": {
+          "name": "payment_reminder3_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "orders_user_id_users_id_fk": {
+          "name": "orders_user_id_users_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orders_guest_order_token_unique": {
+          "name": "orders_guest_order_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "guest_order_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "orders_identity_check": {
+          "name": "orders_identity_check",
+          "value": "(\n\t\t\t\t(\"orders\".\"user_id\" IS NOT NULL AND \"orders\".\"guest_name\" IS NULL AND \"orders\".\"guest_email\" IS NULL AND \"orders\".\"guest_phone\" IS NULL AND \"orders\".\"guest_order_token\" IS NULL)\n\t\t\t\tOR\n\t\t\t\t(\"orders\".\"user_id\" IS NULL AND length(trim(\"orders\".\"guest_name\")) > 0 AND length(trim(\"orders\".\"guest_email\")) > 0 AND length(trim(\"orders\".\"guest_phone\")) > 0 AND length(trim(\"orders\".\"guest_order_token\")) > 0)\n\t\t\t)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.participant_products": {
+      "name": "participant_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participation_id": {
+          "name": "participation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_status": {
+          "name": "submission_status",
+          "type": "submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "submission_feedback": {
+          "name": "submission_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_products_user_id_users_id_fk": {
+          "name": "participant_products_user_id_users_id_fk",
+          "tableFrom": "participant_products",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participant_products_participation_id_participations_id_fk": {
+          "name": "participant_products_participation_id_participations_id_fk",
+          "tableFrom": "participant_products",
+          "tableTo": "participations",
+          "columnsFrom": [
+            "participation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voucher_url": {
+          "name": "voucher_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_images": {
+      "name": "product_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_status": {
+          "name": "upload_status",
+          "type": "product_image_upload_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_images_product_id_idx": {
+          "name": "product_images_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pre_order": {
+          "name": "is_pre_order",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "available_date": {
+          "name": "available_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "discount_unit": {
+          "name": "discount_unit",
+          "type": "discount_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "product_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_subcategories": {
+      "name": "profile_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subcategory_id": {
+          "name": "subcategory_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_subcategories_profile_id_users_id_fk": {
+          "name": "profile_subcategories_profile_id_users_id_fk",
+          "tableFrom": "profile_subcategories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_subcategories_subcategory_id_subcategories_id_fk": {
+          "name": "profile_subcategories_subcategory_id_subcategories_id_fk",
+          "tableFrom": "profile_subcategories",
+          "tableTo": "subcategories",
+          "columnsFrom": [
+            "subcategory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_tags": {
+      "name": "profile_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_tags_profile_id_users_id_fk": {
+          "name": "profile_tags_profile_id_users_id_fk",
+          "tableFrom": "profile_tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_tags_tag_id_tags_id_fk": {
+          "name": "profile_tags_tag_id_tags_id_fk",
+          "tableFrom": "profile_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qr_codes": {
+      "name": "qr_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qr_code_url": {
+          "name": "qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reservation_collaborators": {
+      "name": "reservation_collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collaborator_id": {
+          "name": "collaborator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reservation_collaborators_reservation_id_stand_reservations_id_fk": {
+          "name": "reservation_collaborators_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "reservation_collaborators",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reservation_collaborators_collaborator_id_collaborators_id_fk": {
+          "name": "reservation_collaborators_collaborator_id_collaborators_id_fk",
+          "tableFrom": "reservation_collaborators",
+          "tableTo": "collaborators",
+          "columnsFrom": [
+            "collaborator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reservation_external_participants": {
+      "name": "reservation_external_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_participant_id": {
+          "name": "external_participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reservation_external_participants_external_participant_id_external_participants_id_fk": {
+          "name": "reservation_external_participants_external_participant_id_external_participants_id_fk",
+          "tableFrom": "reservation_external_participants",
+          "tableTo": "external_participants",
+          "columnsFrom": [
+            "external_participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reservation_external_participants_reservation_id_stand_reservations_id_fk": {
+          "name": "reservation_external_participants_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "reservation_external_participants",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reservation_external_participants_unique": {
+          "name": "reservation_external_participants_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_participant_id",
+            "reservation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participations": {
+      "name": "participations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_stamp": {
+          "name": "has_stamp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participations_user_id_users_id_fk": {
+          "name": "participations_user_id_users_id_fk",
+          "tableFrom": "participations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participations_reservation_id_stand_reservations_id_fk": {
+          "name": "participations_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "participations",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sanctions": {
+      "name": "sanctions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infraction_id": {
+          "name": "infraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "sanction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_unit": {
+          "name": "duration_unit",
+          "type": "duration_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'indefinitely'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sanctions_user_id_users_id_fk": {
+          "name": "sanctions_user_id_users_id_fk",
+          "tableFrom": "sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sanctions_infraction_id_infractions_id_fk": {
+          "name": "sanctions_infraction_id_infractions_id_fk",
+          "tableFrom": "sanctions",
+          "tableTo": "infractions",
+          "columnsFrom": [
+            "infraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "scheduled_task_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'profile_creation'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_time": {
+          "name": "reminder_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ran_after_due_date": {
+          "name": "ran_after_due_date",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_tasks_profile_id_users_id_fk": {
+          "name": "scheduled_tasks_profile_id_users_id_fk",
+          "tableFrom": "scheduled_tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_tasks_reservation_id_stand_reservations_id_fk": {
+          "name": "scheduled_tasks_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "scheduled_tasks",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stand_holds": {
+      "name": "stand_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stand_holds_stand_idx": {
+          "name": "stand_holds_stand_idx",
+          "columns": [
+            {
+              "expression": "stand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stand_holds_user_festival_idx": {
+          "name": "stand_holds_user_festival_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stand_holds_stand_id_stands_id_fk": {
+          "name": "stand_holds_stand_id_stands_id_fk",
+          "tableFrom": "stand_holds",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stand_holds_user_id_users_id_fk": {
+          "name": "stand_holds_user_id_users_id_fk",
+          "tableFrom": "stand_holds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stand_holds_festival_id_festivals_id_fk": {
+          "name": "stand_holds_festival_id_festivals_id_fk",
+          "tableFrom": "stand_holds",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stand_reservations": {
+      "name": "stand_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "reservation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stand_reservations_stand_id_stands_id_fk": {
+          "name": "stand_reservations_stand_id_stands_id_fk",
+          "tableFrom": "stand_reservations",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stand_subcategories": {
+      "name": "stand_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subcategory_id": {
+          "name": "subcategory_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stand_subcategories_stand_id_stands_id_fk": {
+          "name": "stand_subcategories_stand_id_stands_id_fk",
+          "tableFrom": "stand_subcategories",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stand_subcategories_subcategory_id_subcategories_id_fk": {
+          "name": "stand_subcategories_subcategory_id_subcategories_id_fk",
+          "tableFrom": "stand_subcategories",
+          "tableTo": "subcategories",
+          "columnsFrom": [
+            "subcategory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stands": {
+      "name": "stands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "stand_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "orientation": {
+          "name": "orientation",
+          "type": "stand_orientation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'landscape'"
+        },
+        "stand_number": {
+          "name": "stand_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stand_category": {
+          "name": "stand_category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'illustration'"
+        },
+        "zone": {
+          "name": "zone",
+          "type": "stand_zone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "width": {
+          "name": "width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_left": {
+          "name": "position_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_top": {
+          "name": "position_top",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "participation_type": {
+          "name": "participation_type",
+          "type": "participation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_sector_id": {
+          "name": "festival_sector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qr_code_id": {
+          "name": "qr_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stand_label_idx": {
+          "name": "stand_label_idx",
+          "columns": [
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stands_festival_sector_id_festival_sectors_id_fk": {
+          "name": "stands_festival_sector_id_festival_sectors_id_fk",
+          "tableFrom": "stands",
+          "tableTo": "festival_sectors",
+          "columnsFrom": [
+            "festival_sector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stands_qr_code_id_qr_codes_id_fk": {
+          "name": "stands_qr_code_id_qr_codes_id_fk",
+          "tableFrom": "stands",
+          "tableTo": "qr_codes",
+          "columnsFrom": [
+            "qr_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subcategories": {
+      "name": "subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tickets": {
+      "name": "tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ticket_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_event_day_creation": {
+          "name": "is_event_day_creation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_visitors": {
+          "name": "number_of_visitors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "ticket_number": {
+          "name": "ticket_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_in_at": {
+          "name": "checked_in_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_badges_user_id_users_id_fk": {
+          "name": "user_badges_user_id_users_id_fk",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_badges_id_fk": {
+          "name": "user_badges_badge_id_badges_id_fk",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_requests": {
+      "name": "user_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "user_request_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'become_artist'"
+        },
+        "status": {
+          "name": "status",
+          "type": "participation_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_requests_user_id_users_id_fk": {
+          "name": "user_requests_user_id_users_id_fk",
+          "tableFrom": "user_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_requests_festival_id_festivals_id_fk": {
+          "name": "user_requests_festival_id_festivals_id_fk",
+          "tableFrom": "user_requests",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_socials": {
+      "name": "user_socials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "user_social_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_socials_user_id_users_id_fk": {
+          "name": "user_socials_user_id_users_id_fk",
+          "tableFrom": "user_socials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthdate": {
+          "name": "birthdate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'undisclosed'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BO'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "should_submit_products": {
+          "name": "should_submit_products",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "participation_type": {
+          "name": "participation_type",
+          "type": "participation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "display_name_idx": {
+          "name": "display_name_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.visitors": {
+      "name": "visitors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_discovery": {
+          "name": "event_discovery",
+          "type": "event_discovery",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'undisclosed'"
+        },
+        "birthdate": {
+          "name": "birthdate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "visitors_email_unique": {
+          "name": "visitors_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_level": {
+      "name": "access_level",
+      "schema": "public",
+      "values": [
+        "public",
+        "festival_participants_only"
+      ]
+    },
+    "public.discount_unit": {
+      "name": "discount_unit",
+      "schema": "public",
+      "values": [
+        "percentage",
+        "amount"
+      ]
+    },
+    "public.duration_unit": {
+      "name": "duration_unit",
+      "schema": "public",
+      "values": [
+        "minutes",
+        "hours",
+        "days",
+        "months",
+        "years",
+        "festivals",
+        "indefinitely"
+      ]
+    },
+    "public.event_discovery": {
+      "name": "event_discovery",
+      "schema": "public",
+      "values": [
+        "facebook",
+        "instagram",
+        "tiktok",
+        "cba",
+        "friends",
+        "participant_invitation",
+        "casual",
+        "la_rota",
+        "other"
+      ]
+    },
+    "public.external_participant_type": {
+      "name": "external_participant_type",
+      "schema": "public",
+      "values": [
+        "institution",
+        "social_organization",
+        "sponsor",
+        "partner",
+        "public_entity",
+        "invited_brand",
+        "other"
+      ]
+    },
+    "public.festival_activity_type": {
+      "name": "festival_activity_type",
+      "schema": "public",
+      "values": [
+        "stamp_passport",
+        "sticker_print",
+        "best_stand",
+        "festival_sticker",
+        "coupon_book",
+        "sticker_hunt"
+      ]
+    },
+    "public.festival_map_version": {
+      "name": "festival_map_version",
+      "schema": "public",
+      "values": [
+        "v1",
+        "v2",
+        "v3"
+      ]
+    },
+    "public.festival_status": {
+      "name": "festival_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "active",
+        "archived"
+      ]
+    },
+    "public.festival_type": {
+      "name": "festival_type",
+      "schema": "public",
+      "values": [
+        "glitter",
+        "twinkler",
+        "festicker"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "non_binary",
+        "other",
+        "undisclosed"
+      ]
+    },
+    "public.infraction_severity": {
+      "name": "infraction_severity",
+      "schema": "public",
+      "values": [
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "paid",
+        "cancelled"
+      ]
+    },
+    "public.live_act_category": {
+      "name": "live_act_category",
+      "schema": "public",
+      "values": [
+        "music",
+        "dance",
+        "talk"
+      ]
+    },
+    "public.live_act_status": {
+      "name": "live_act_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "backlog",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.map_element_label_position": {
+      "name": "map_element_label_position",
+      "schema": "public",
+      "values": [
+        "left",
+        "right",
+        "top",
+        "bottom"
+      ]
+    },
+    "public.map_element_type": {
+      "name": "map_element_type",
+      "schema": "public",
+      "values": [
+        "entrance",
+        "stage",
+        "door",
+        "bathroom",
+        "label",
+        "custom",
+        "stairs"
+      ]
+    },
+    "public.marketing_banner_audience": {
+      "name": "marketing_banner_audience",
+      "schema": "public",
+      "values": [
+        "all",
+        "public_only",
+        "participants_only"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "payment_verification",
+        "processing",
+        "paid",
+        "delivered",
+        "cancelled"
+      ]
+    },
+    "public.participation_type": {
+      "name": "participation_type",
+      "schema": "public",
+      "values": [
+        "standard",
+        "live_activity"
+      ]
+    },
+    "public.product_image_upload_status": {
+      "name": "product_image_upload_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active"
+      ]
+    },
+    "public.product_status": {
+      "name": "product_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "presale",
+        "sale"
+      ]
+    },
+    "public.proof_status": {
+      "name": "proof_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected_resubmit",
+        "rejected_removed"
+      ]
+    },
+    "public.proof_type": {
+      "name": "proof_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "text",
+        "both"
+      ]
+    },
+    "public.participation_request_status": {
+      "name": "participation_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.user_request_type": {
+      "name": "user_request_type",
+      "schema": "public",
+      "values": [
+        "festival_participation",
+        "become_artist"
+      ]
+    },
+    "public.reservation_source": {
+      "name": "reservation_source",
+      "schema": "public",
+      "values": [
+        "user_reservation",
+        "admin_assignment"
+      ]
+    },
+    "public.reservation_status": {
+      "name": "reservation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verification_payment",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.sanction_type": {
+      "name": "sanction_type",
+      "schema": "public",
+      "values": [
+        "ban",
+        "warning",
+        "reservation_delay"
+      ]
+    },
+    "public.scheduled_task_type": {
+      "name": "scheduled_task_type",
+      "schema": "public",
+      "values": [
+        "profile_creation",
+        "stand_reservation"
+      ]
+    },
+    "public.stand_orientation": {
+      "name": "stand_orientation",
+      "schema": "public",
+      "values": [
+        "portrait",
+        "landscape"
+      ]
+    },
+    "public.stand_status": {
+      "name": "stand_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "held",
+        "reserved",
+        "confirmed",
+        "disabled"
+      ]
+    },
+    "public.stand_zone": {
+      "name": "stand_zone",
+      "schema": "public",
+      "values": [
+        "main",
+        "secondary"
+      ]
+    },
+    "public.submission_status": {
+      "name": "submission_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.ticket_status": {
+      "name": "ticket_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "checked_in"
+      ]
+    },
+    "public.user_category": {
+      "name": "user_category",
+      "schema": "public",
+      "values": [
+        "none",
+        "illustration",
+        "gastronomy",
+        "entrepreneurship",
+        "new_artist"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "artist",
+        "user",
+        "festival_admin"
+      ]
+    },
+    "public.user_social_type": {
+      "name": "user_social_type",
+      "schema": "public",
+      "values": [
+        "instagram",
+        "facebook",
+        "tiktok",
+        "twitter",
+        "youtube"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "verified",
+        "pending",
+        "rejected",
+        "banned"
+      ]
+    },
+    "public.votable_type": {
+      "name": "votable_type",
+      "schema": "public",
+      "values": [
+        "participant",
+        "stand"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0178_snapshot.json
+++ b/drizzle/meta/0178_snapshot.json
@@ -1,0 +1,5396 @@
+{
+  "id": "fb4f2a0e-1a02-4aa1-ad91-328834664d58",
+  "prevId": "cac6c990-2d6f-489b-8507-bb13cd5fe205",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "badges_festival_id_festivals_id_fk": {
+          "name": "badges_festival_id_festivals_id_fk",
+          "tableFrom": "badges",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cart_items": {
+      "name": "cart_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cart_items_cart_id_idx": {
+          "name": "cart_items_cart_id_idx",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cart_items_product_id_idx": {
+          "name": "cart_items_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cart_items_cart_id_carts_id_fk": {
+          "name": "cart_items_cart_id_carts_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "carts",
+          "columnsFrom": [
+            "cart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cart_items_product_id_products_id_fk": {
+          "name": "cart_items_product_id_products_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cart_items_cart_product_unique": {
+          "name": "cart_items_cart_product_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cart_id",
+            "product_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cart_items_quantity_positive": {
+          "name": "cart_items_quantity_positive",
+          "value": "\"cart_items\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.carts": {
+      "name": "carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "carts_user_id_users_id_fk": {
+          "name": "carts_user_id_users_id_fk",
+          "tableFrom": "carts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "carts_user_id_unique": {
+          "name": "carts_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collaborators": {
+      "name": "collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identification_number": {
+          "name": "identification_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collaborators_attendance_logs": {
+      "name": "collaborators_attendance_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reservation_collaborator_id": {
+          "name": "reservation_collaborator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_date_id": {
+          "name": "festival_date_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collaborators_attendance_logs_reservation_collaborator_id_reservation_collaborators_id_fk": {
+          "name": "collaborators_attendance_logs_reservation_collaborator_id_reservation_collaborators_id_fk",
+          "tableFrom": "collaborators_attendance_logs",
+          "tableTo": "reservation_collaborators",
+          "columnsFrom": [
+            "reservation_collaborator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collaborators_attendance_logs_festival_date_id_festival_dates_id_fk": {
+          "name": "collaborators_attendance_logs_festival_date_id_festival_dates_id_fk",
+          "tableFrom": "collaborators_attendance_logs",
+          "tableTo": "festival_dates",
+          "columnsFrom": [
+            "festival_date_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discount_codes": {
+      "name": "discount_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_unit": {
+          "name": "discount_unit",
+          "type": "discount_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_uses": {
+          "name": "current_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discount_codes_festival_id_festivals_id_fk": {
+          "name": "discount_codes_festival_id_festivals_id_fk",
+          "tableFrom": "discount_codes",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "discount_codes_user_id_users_id_fk": {
+          "name": "discount_codes_user_id_users_id_fk",
+          "tableFrom": "discount_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discount_codes_code_unique": {
+          "name": "discount_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_participants": {
+      "name": "external_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "external_participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_category_label": {
+          "name": "custom_category_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_participants_display_name_idx": {
+          "name": "external_participants_display_name_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_participants_created_by_user_id_users_id_fk": {
+          "name": "external_participants_created_by_user_id_users_id_fk",
+          "tableFrom": "external_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activities": {
+      "name": "festival_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_start_date": {
+          "name": "registration_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_end_date": {
+          "name": "registration_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promotional_art_url": {
+          "name": "promotional_art_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitors_description": {
+          "name": "visitors_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "festival_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stamp_passport'"
+        },
+        "activity_prize_url": {
+          "name": "activity_prize_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allows_voting": {
+          "name": "allows_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "voting_start_date": {
+          "name": "voting_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voting_end_date": {
+          "name": "voting_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_type": {
+          "name": "proof_type",
+          "type": "proof_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_upload_limit_date": {
+          "name": "proof_upload_limit_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "access_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "waitlist_window_minutes": {
+          "name": "waitlist_window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activities_festival_id_festivals_id_fk": {
+          "name": "festival_activities_festival_id_festivals_id_fk",
+          "tableFrom": "festival_activities",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proof_upload_limit_required": {
+          "name": "proof_upload_limit_required",
+          "value": "(\"festival_activities\".\"proof_type\" IS NULL) OR (\"festival_activities\".\"proof_upload_limit_date\" IS NOT NULL)"
+        },
+        "festival_activities_waitlist_window_minutes_positive": {
+          "name": "festival_activities_waitlist_window_minutes_positive",
+          "value": "\"festival_activities\".\"waitlist_window_minutes\" IS NULL OR \"festival_activities\".\"waitlist_window_minutes\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_details": {
+      "name": "festival_activity_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coupon_book_header_image_url": {
+          "name": "coupon_book_header_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participation_limit": {
+          "name": "participation_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_details_activity_id_festival_activities_id_fk": {
+          "name": "festival_activity_details_activity_id_festival_activities_id_fk",
+          "tableFrom": "festival_activity_details",
+          "tableTo": "festival_activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_participant_proofs": {
+      "name": "festival_activity_participant_proofs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participation_id": {
+          "name": "participation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promo_highlight": {
+          "name": "promo_highlight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_description": {
+          "name": "promo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_conditions": {
+          "name": "promo_conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_status": {
+          "name": "proof_status",
+          "type": "proof_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "admin_feedback": {
+          "name": "admin_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_participant_proofs_participation_id_festival_activity_participants_id_fk": {
+          "name": "festival_activity_participant_proofs_participation_id_festival_activity_participants_id_fk",
+          "tableFrom": "festival_activity_participant_proofs",
+          "tableTo": "festival_activity_participants",
+          "columnsFrom": [
+            "participation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_participants": {
+      "name": "festival_activity_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "details_id": {
+          "name": "details_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removal_reason": {
+          "name": "removal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_participants_details_id_festival_activity_details_id_fk": {
+          "name": "festival_activity_participants_details_id_festival_activity_details_id_fk",
+          "tableFrom": "festival_activity_participants",
+          "tableTo": "festival_activity_details",
+          "columnsFrom": [
+            "details_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_participants_user_id_users_id_fk": {
+          "name": "festival_activity_participants_user_id_users_id_fk",
+          "tableFrom": "festival_activity_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "festival_activity_participants_details_id_user_id_unique": {
+          "name": "festival_activity_participants_details_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "details_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_votes": {
+      "name": "festival_activity_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_variant_id": {
+          "name": "activity_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votable_type": {
+          "name": "votable_type",
+          "type": "votable_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_votes_voter_id_users_id_fk": {
+          "name": "festival_activity_votes_voter_id_users_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_votes_activity_variant_id_festival_activity_details_id_fk": {
+          "name": "festival_activity_votes_activity_variant_id_festival_activity_details_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "festival_activity_details",
+          "columnsFrom": [
+            "activity_variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_votes_stand_id_stands_id_fk": {
+          "name": "festival_activity_votes_stand_id_stands_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_votes_participant_id_festival_activity_participants_id_fk": {
+          "name": "festival_activity_votes_participant_id_festival_activity_participants_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "festival_activity_participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_voter_activity": {
+          "name": "unique_voter_activity",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_id",
+            "activity_variant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_waitlist": {
+      "name": "festival_activity_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notified_for_detail_id": {
+          "name": "notified_for_detail_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_waitlist_activity_id_festival_activities_id_fk": {
+          "name": "festival_activity_waitlist_activity_id_festival_activities_id_fk",
+          "tableFrom": "festival_activity_waitlist",
+          "tableTo": "festival_activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_waitlist_user_id_users_id_fk": {
+          "name": "festival_activity_waitlist_user_id_users_id_fk",
+          "tableFrom": "festival_activity_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_waitlist_notified_for_detail_id_festival_activity_details_id_fk": {
+          "name": "festival_activity_waitlist_notified_for_detail_id_festival_activity_details_id_fk",
+          "tableFrom": "festival_activity_waitlist",
+          "tableTo": "festival_activity_details",
+          "columnsFrom": [
+            "notified_for_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "festival_activity_waitlist_activity_id_user_id_unique": {
+          "name": "festival_activity_waitlist_activity_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "activity_id",
+            "user_id"
+          ]
+        },
+        "festival_activity_waitlist_activity_id_position_unique": {
+          "name": "festival_activity_waitlist_activity_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "activity_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "festival_activity_waitlist_position_check": {
+          "name": "festival_activity_waitlist_position_check",
+          "value": "\"festival_activity_waitlist\".\"position\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.festival_dates": {
+      "name": "festival_dates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "festival_dates_festival_id_idx": {
+          "name": "festival_dates_festival_id_idx",
+          "columns": [
+            {
+              "expression": "festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "festival_dates_festival_id_festivals_id_fk": {
+          "name": "festival_dates_festival_id_festivals_id_fk",
+          "tableFrom": "festival_dates",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_sectors": {
+      "name": "festival_sectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_url": {
+          "name": "map_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_in_festival": {
+          "name": "order_in_festival",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mascot_url": {
+          "name": "mascot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_origin_x": {
+          "name": "map_origin_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_origin_y": {
+          "name": "map_origin_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_width": {
+          "name": "map_width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_height": {
+          "name": "map_height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "festival_sector_name_idx": {
+          "name": "festival_sector_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "festival_sectors_festival_id_festivals_id_fk": {
+          "name": "festival_sectors_festival_id_festivals_id_fk",
+          "tableFrom": "festival_sectors",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festivals": {
+      "name": "festivals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label": {
+          "name": "location_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_url": {
+          "name": "location_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "festival_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maps_version": {
+          "name": "maps_version",
+          "type": "festival_map_version",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        },
+        "public_registration": {
+          "name": "public_registration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_day_registration": {
+          "name": "event_day_registration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "keep_store_open": {
+          "name": "keep_store_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reservations_start_date": {
+          "name": "reservations_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "general_map_url": {
+          "name": "general_map_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mascot_url": {
+          "name": "mascot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_type": {
+          "name": "festival_type",
+          "type": "festival_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'glitter'"
+        },
+        "illustration_payment_qr_code_url": {
+          "name": "illustration_payment_qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gastronomy_payment_qr_code_url": {
+          "name": "gastronomy_payment_qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrepreneurship_payment_qr_code_url": {
+          "name": "entrepreneurship_payment_qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "illustration_stand_url": {
+          "name": "illustration_stand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gastronomy_stand_url": {
+          "name": "gastronomy_stand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrepreneurship_stand_url": {
+          "name": "entrepreneurship_stand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_code": {
+          "name": "festival_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_banner_url": {
+          "name": "festival_banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms_and_conditions_url": {
+          "name": "terms_and_conditions_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_url": {
+          "name": "poster_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "festivals_name_unique": {
+          "name": "festivals_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.infraction_types": {
+      "name": "infraction_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "infraction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'low'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "infraction_types_code_unique": {
+          "name": "infraction_types_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.infractions": {
+      "name": "infractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handled": {
+          "name": "handled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_gave_notice": {
+          "name": "user_gave_notice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gave_notice_at": {
+          "name": "gave_notice_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "infractions_user_id_users_id_fk": {
+          "name": "infractions_user_id_users_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "infractions_type_id_infraction_types_id_fk": {
+          "name": "infractions_type_id_infraction_types_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "infraction_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "infractions_festival_id_festivals_id_fk": {
+          "name": "infractions_festival_id_festivals_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "original_amount": {
+          "name": "original_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_code_id": {
+          "name": "discount_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_user_id_users_id_fk": {
+          "name": "invoices_user_id_users_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_reservation_id_stand_reservations_id_fk": {
+          "name": "invoices_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_discount_code_id_discount_codes_id_fk": {
+          "name": "invoices_discount_code_id_discount_codes_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "discount_codes",
+          "columnsFrom": [
+            "discount_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.live_acts": {
+      "name": "live_acts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "act_name": {
+          "name": "act_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "live_act_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_link": {
+          "name": "resource_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "live_act_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "admin_notes": {
+          "name": "admin_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_elements": {
+      "name": "map_elements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "map_element_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_position": {
+          "name": "label_position",
+          "type": "map_element_label_position",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bottom'"
+        },
+        "label_font_size": {
+          "name": "label_font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "label_font_weight": {
+          "name": "label_font_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "show_icon": {
+          "name": "show_icon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "position_left": {
+          "name": "position_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "position_top": {
+          "name": "position_top",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "width": {
+          "name": "width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "height": {
+          "name": "height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "festival_sector_id": {
+          "name": "festival_sector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "map_elements_sector_idx": {
+          "name": "map_elements_sector_idx",
+          "columns": [
+            {
+              "expression": "festival_sector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_elements_festival_sector_id_festival_sectors_id_fk": {
+          "name": "map_elements_festival_sector_id_festival_sectors_id_fk",
+          "tableFrom": "map_elements",
+          "tableTo": "festival_sectors",
+          "columnsFrom": [
+            "festival_sector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_templates": {
+      "name": "map_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_data": {
+          "name": "template_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_festival_id": {
+          "name": "created_from_festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "map_templates_created_by_user_id_users_id_fk": {
+          "name": "map_templates_created_by_user_id_users_id_fk",
+          "tableFrom": "map_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "map_templates_created_from_festival_id_festivals_id_fk": {
+          "name": "map_templates_created_from_festival_id_festivals_id_fk",
+          "tableFrom": "map_templates",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "created_from_festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketing_banners": {
+      "name": "marketing_banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url_tablet": {
+          "name": "image_url_tablet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url_mobile": {
+          "name": "image_url_mobile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "marketing_banner_audience",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "open_in_new_tab": {
+          "name": "open_in_new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "marketing_banners_sort_order_idx": {
+          "name": "marketing_banners_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "marketing_banners_is_visible_idx": {
+          "name": "marketing_banners_is_visible_idx",
+          "columns": [
+            {
+              "expression": "is_visible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_items": {
+      "name": "order_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_at_purchase": {
+          "name": "price_at_purchase",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_items_order_id_idx": {
+          "name": "order_items_order_id_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_items_product_id_idx": {
+          "name": "order_items_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_phone": {
+          "name": "guest_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_order_token": {
+          "name": "guest_order_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_voucher_url": {
+          "name": "payment_voucher_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voucher_submitted_at": {
+          "name": "voucher_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_due_date": {
+          "name": "payment_due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + interval '2 days'"
+        },
+        "payment_reminder1_sent_at": {
+          "name": "payment_reminder1_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder2_sent_at": {
+          "name": "payment_reminder2_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder3_sent_at": {
+          "name": "payment_reminder3_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder1_claimed_at": {
+          "name": "payment_reminder1_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder2_claimed_at": {
+          "name": "payment_reminder2_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder3_claimed_at": {
+          "name": "payment_reminder3_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "orders_user_id_users_id_fk": {
+          "name": "orders_user_id_users_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orders_guest_order_token_unique": {
+          "name": "orders_guest_order_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "guest_order_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "orders_identity_check": {
+          "name": "orders_identity_check",
+          "value": "(\n\t\t\t\t(\"orders\".\"user_id\" IS NOT NULL AND \"orders\".\"guest_name\" IS NULL AND \"orders\".\"guest_email\" IS NULL AND \"orders\".\"guest_phone\" IS NULL AND \"orders\".\"guest_order_token\" IS NULL)\n\t\t\t\tOR\n\t\t\t\t(\"orders\".\"user_id\" IS NULL AND length(trim(\"orders\".\"guest_name\")) > 0 AND length(trim(\"orders\".\"guest_email\")) > 0 AND length(trim(\"orders\".\"guest_phone\")) > 0 AND length(trim(\"orders\".\"guest_order_token\")) > 0)\n\t\t\t)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.participant_products": {
+      "name": "participant_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participation_id": {
+          "name": "participation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_status": {
+          "name": "submission_status",
+          "type": "submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "submission_feedback": {
+          "name": "submission_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_products_user_id_users_id_fk": {
+          "name": "participant_products_user_id_users_id_fk",
+          "tableFrom": "participant_products",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participant_products_participation_id_participations_id_fk": {
+          "name": "participant_products_participation_id_participations_id_fk",
+          "tableFrom": "participant_products",
+          "tableTo": "participations",
+          "columnsFrom": [
+            "participation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voucher_url": {
+          "name": "voucher_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_images": {
+      "name": "product_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_status": {
+          "name": "upload_status",
+          "type": "product_image_upload_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_images_product_id_idx": {
+          "name": "product_images_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pre_order": {
+          "name": "is_pre_order",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "available_date": {
+          "name": "available_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "discount_unit": {
+          "name": "discount_unit",
+          "type": "discount_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "product_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_subcategories": {
+      "name": "profile_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subcategory_id": {
+          "name": "subcategory_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_subcategories_profile_id_users_id_fk": {
+          "name": "profile_subcategories_profile_id_users_id_fk",
+          "tableFrom": "profile_subcategories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_subcategories_subcategory_id_subcategories_id_fk": {
+          "name": "profile_subcategories_subcategory_id_subcategories_id_fk",
+          "tableFrom": "profile_subcategories",
+          "tableTo": "subcategories",
+          "columnsFrom": [
+            "subcategory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_tags": {
+      "name": "profile_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_tags_profile_id_users_id_fk": {
+          "name": "profile_tags_profile_id_users_id_fk",
+          "tableFrom": "profile_tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_tags_tag_id_tags_id_fk": {
+          "name": "profile_tags_tag_id_tags_id_fk",
+          "tableFrom": "profile_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qr_codes": {
+      "name": "qr_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qr_code_url": {
+          "name": "qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reservation_collaborators": {
+      "name": "reservation_collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collaborator_id": {
+          "name": "collaborator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reservation_collaborators_reservation_id_stand_reservations_id_fk": {
+          "name": "reservation_collaborators_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "reservation_collaborators",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reservation_collaborators_collaborator_id_collaborators_id_fk": {
+          "name": "reservation_collaborators_collaborator_id_collaborators_id_fk",
+          "tableFrom": "reservation_collaborators",
+          "tableTo": "collaborators",
+          "columnsFrom": [
+            "collaborator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reservation_external_participants": {
+      "name": "reservation_external_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_participant_id": {
+          "name": "external_participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reservation_external_participants_external_participant_id_external_participants_id_fk": {
+          "name": "reservation_external_participants_external_participant_id_external_participants_id_fk",
+          "tableFrom": "reservation_external_participants",
+          "tableTo": "external_participants",
+          "columnsFrom": [
+            "external_participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reservation_external_participants_reservation_id_stand_reservations_id_fk": {
+          "name": "reservation_external_participants_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "reservation_external_participants",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reservation_external_participants_unique": {
+          "name": "reservation_external_participants_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_participant_id",
+            "reservation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participations": {
+      "name": "participations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_stamp": {
+          "name": "has_stamp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participations_user_id_users_id_fk": {
+          "name": "participations_user_id_users_id_fk",
+          "tableFrom": "participations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participations_reservation_id_stand_reservations_id_fk": {
+          "name": "participations_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "participations",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sanctions": {
+      "name": "sanctions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infraction_id": {
+          "name": "infraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "sanction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_unit": {
+          "name": "duration_unit",
+          "type": "duration_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'indefinitely'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sanctions_user_id_users_id_fk": {
+          "name": "sanctions_user_id_users_id_fk",
+          "tableFrom": "sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sanctions_infraction_id_infractions_id_fk": {
+          "name": "sanctions_infraction_id_infractions_id_fk",
+          "tableFrom": "sanctions",
+          "tableTo": "infractions",
+          "columnsFrom": [
+            "infraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "scheduled_task_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'profile_creation'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_time": {
+          "name": "reminder_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ran_after_due_date": {
+          "name": "ran_after_due_date",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_tasks_profile_id_users_id_fk": {
+          "name": "scheduled_tasks_profile_id_users_id_fk",
+          "tableFrom": "scheduled_tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_tasks_reservation_id_stand_reservations_id_fk": {
+          "name": "scheduled_tasks_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "scheduled_tasks",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stand_holds": {
+      "name": "stand_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stand_holds_stand_idx": {
+          "name": "stand_holds_stand_idx",
+          "columns": [
+            {
+              "expression": "stand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stand_holds_user_festival_idx": {
+          "name": "stand_holds_user_festival_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stand_holds_stand_id_stands_id_fk": {
+          "name": "stand_holds_stand_id_stands_id_fk",
+          "tableFrom": "stand_holds",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stand_holds_user_id_users_id_fk": {
+          "name": "stand_holds_user_id_users_id_fk",
+          "tableFrom": "stand_holds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stand_holds_festival_id_festivals_id_fk": {
+          "name": "stand_holds_festival_id_festivals_id_fk",
+          "tableFrom": "stand_holds",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stand_reservations": {
+      "name": "stand_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "reservation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "reservation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_reservation'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stand_reservations_stand_id_stands_id_fk": {
+          "name": "stand_reservations_stand_id_stands_id_fk",
+          "tableFrom": "stand_reservations",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stand_subcategories": {
+      "name": "stand_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subcategory_id": {
+          "name": "subcategory_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stand_subcategories_stand_id_stands_id_fk": {
+          "name": "stand_subcategories_stand_id_stands_id_fk",
+          "tableFrom": "stand_subcategories",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stand_subcategories_subcategory_id_subcategories_id_fk": {
+          "name": "stand_subcategories_subcategory_id_subcategories_id_fk",
+          "tableFrom": "stand_subcategories",
+          "tableTo": "subcategories",
+          "columnsFrom": [
+            "subcategory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stands": {
+      "name": "stands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "stand_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "orientation": {
+          "name": "orientation",
+          "type": "stand_orientation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'landscape'"
+        },
+        "stand_number": {
+          "name": "stand_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stand_category": {
+          "name": "stand_category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'illustration'"
+        },
+        "zone": {
+          "name": "zone",
+          "type": "stand_zone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "width": {
+          "name": "width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_left": {
+          "name": "position_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_top": {
+          "name": "position_top",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "participation_type": {
+          "name": "participation_type",
+          "type": "participation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_sector_id": {
+          "name": "festival_sector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qr_code_id": {
+          "name": "qr_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stand_label_idx": {
+          "name": "stand_label_idx",
+          "columns": [
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stands_festival_sector_id_festival_sectors_id_fk": {
+          "name": "stands_festival_sector_id_festival_sectors_id_fk",
+          "tableFrom": "stands",
+          "tableTo": "festival_sectors",
+          "columnsFrom": [
+            "festival_sector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stands_qr_code_id_qr_codes_id_fk": {
+          "name": "stands_qr_code_id_qr_codes_id_fk",
+          "tableFrom": "stands",
+          "tableTo": "qr_codes",
+          "columnsFrom": [
+            "qr_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subcategories": {
+      "name": "subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tickets": {
+      "name": "tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ticket_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_event_day_creation": {
+          "name": "is_event_day_creation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_visitors": {
+          "name": "number_of_visitors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "ticket_number": {
+          "name": "ticket_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_in_at": {
+          "name": "checked_in_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_badges_user_id_users_id_fk": {
+          "name": "user_badges_user_id_users_id_fk",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_badges_id_fk": {
+          "name": "user_badges_badge_id_badges_id_fk",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_requests": {
+      "name": "user_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "user_request_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'become_artist'"
+        },
+        "status": {
+          "name": "status",
+          "type": "participation_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_requests_user_id_users_id_fk": {
+          "name": "user_requests_user_id_users_id_fk",
+          "tableFrom": "user_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_requests_festival_id_festivals_id_fk": {
+          "name": "user_requests_festival_id_festivals_id_fk",
+          "tableFrom": "user_requests",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_socials": {
+      "name": "user_socials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "user_social_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_socials_user_id_users_id_fk": {
+          "name": "user_socials_user_id_users_id_fk",
+          "tableFrom": "user_socials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthdate": {
+          "name": "birthdate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'undisclosed'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BO'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "should_submit_products": {
+          "name": "should_submit_products",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "participation_type": {
+          "name": "participation_type",
+          "type": "participation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "display_name_idx": {
+          "name": "display_name_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.visitors": {
+      "name": "visitors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_discovery": {
+          "name": "event_discovery",
+          "type": "event_discovery",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'undisclosed'"
+        },
+        "birthdate": {
+          "name": "birthdate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "visitors_email_unique": {
+          "name": "visitors_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_level": {
+      "name": "access_level",
+      "schema": "public",
+      "values": [
+        "public",
+        "festival_participants_only"
+      ]
+    },
+    "public.discount_unit": {
+      "name": "discount_unit",
+      "schema": "public",
+      "values": [
+        "percentage",
+        "amount"
+      ]
+    },
+    "public.duration_unit": {
+      "name": "duration_unit",
+      "schema": "public",
+      "values": [
+        "minutes",
+        "hours",
+        "days",
+        "months",
+        "years",
+        "festivals",
+        "indefinitely"
+      ]
+    },
+    "public.event_discovery": {
+      "name": "event_discovery",
+      "schema": "public",
+      "values": [
+        "facebook",
+        "instagram",
+        "tiktok",
+        "cba",
+        "friends",
+        "participant_invitation",
+        "casual",
+        "la_rota",
+        "other"
+      ]
+    },
+    "public.external_participant_type": {
+      "name": "external_participant_type",
+      "schema": "public",
+      "values": [
+        "institution",
+        "social_organization",
+        "sponsor",
+        "partner",
+        "public_entity",
+        "invited_brand",
+        "other"
+      ]
+    },
+    "public.festival_activity_type": {
+      "name": "festival_activity_type",
+      "schema": "public",
+      "values": [
+        "stamp_passport",
+        "sticker_print",
+        "best_stand",
+        "festival_sticker",
+        "coupon_book",
+        "sticker_hunt"
+      ]
+    },
+    "public.festival_map_version": {
+      "name": "festival_map_version",
+      "schema": "public",
+      "values": [
+        "v1",
+        "v2",
+        "v3"
+      ]
+    },
+    "public.festival_status": {
+      "name": "festival_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "active",
+        "archived"
+      ]
+    },
+    "public.festival_type": {
+      "name": "festival_type",
+      "schema": "public",
+      "values": [
+        "glitter",
+        "twinkler",
+        "festicker"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "non_binary",
+        "other",
+        "undisclosed"
+      ]
+    },
+    "public.infraction_severity": {
+      "name": "infraction_severity",
+      "schema": "public",
+      "values": [
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "paid",
+        "cancelled"
+      ]
+    },
+    "public.live_act_category": {
+      "name": "live_act_category",
+      "schema": "public",
+      "values": [
+        "music",
+        "dance",
+        "talk"
+      ]
+    },
+    "public.live_act_status": {
+      "name": "live_act_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "backlog",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.map_element_label_position": {
+      "name": "map_element_label_position",
+      "schema": "public",
+      "values": [
+        "left",
+        "right",
+        "top",
+        "bottom"
+      ]
+    },
+    "public.map_element_type": {
+      "name": "map_element_type",
+      "schema": "public",
+      "values": [
+        "entrance",
+        "stage",
+        "door",
+        "bathroom",
+        "label",
+        "custom",
+        "stairs"
+      ]
+    },
+    "public.marketing_banner_audience": {
+      "name": "marketing_banner_audience",
+      "schema": "public",
+      "values": [
+        "all",
+        "public_only",
+        "participants_only"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "payment_verification",
+        "processing",
+        "paid",
+        "delivered",
+        "cancelled"
+      ]
+    },
+    "public.participation_type": {
+      "name": "participation_type",
+      "schema": "public",
+      "values": [
+        "standard",
+        "live_activity"
+      ]
+    },
+    "public.product_image_upload_status": {
+      "name": "product_image_upload_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active"
+      ]
+    },
+    "public.product_status": {
+      "name": "product_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "presale",
+        "sale"
+      ]
+    },
+    "public.proof_status": {
+      "name": "proof_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected_resubmit",
+        "rejected_removed"
+      ]
+    },
+    "public.proof_type": {
+      "name": "proof_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "text",
+        "both"
+      ]
+    },
+    "public.participation_request_status": {
+      "name": "participation_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.user_request_type": {
+      "name": "user_request_type",
+      "schema": "public",
+      "values": [
+        "festival_participation",
+        "become_artist"
+      ]
+    },
+    "public.reservation_source": {
+      "name": "reservation_source",
+      "schema": "public",
+      "values": [
+        "user_reservation",
+        "admin_assignment"
+      ]
+    },
+    "public.reservation_status": {
+      "name": "reservation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verification_payment",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.sanction_type": {
+      "name": "sanction_type",
+      "schema": "public",
+      "values": [
+        "ban",
+        "warning",
+        "reservation_delay"
+      ]
+    },
+    "public.scheduled_task_type": {
+      "name": "scheduled_task_type",
+      "schema": "public",
+      "values": [
+        "profile_creation",
+        "stand_reservation"
+      ]
+    },
+    "public.stand_orientation": {
+      "name": "stand_orientation",
+      "schema": "public",
+      "values": [
+        "portrait",
+        "landscape"
+      ]
+    },
+    "public.stand_status": {
+      "name": "stand_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "held",
+        "reserved",
+        "confirmed",
+        "disabled"
+      ]
+    },
+    "public.stand_zone": {
+      "name": "stand_zone",
+      "schema": "public",
+      "values": [
+        "main",
+        "secondary"
+      ]
+    },
+    "public.submission_status": {
+      "name": "submission_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.ticket_status": {
+      "name": "ticket_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "checked_in"
+      ]
+    },
+    "public.user_category": {
+      "name": "user_category",
+      "schema": "public",
+      "values": [
+        "none",
+        "illustration",
+        "gastronomy",
+        "entrepreneurship",
+        "new_artist"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "artist",
+        "user",
+        "festival_admin"
+      ]
+    },
+    "public.user_social_type": {
+      "name": "user_social_type",
+      "schema": "public",
+      "values": [
+        "instagram",
+        "facebook",
+        "tiktok",
+        "twitter",
+        "youtube"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "verified",
+        "pending",
+        "rejected",
+        "banned"
+      ]
+    },
+    "public.votable_type": {
+      "name": "votable_type",
+      "schema": "public",
+      "values": [
+        "participant",
+        "stand"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0179_snapshot.json
+++ b/drizzle/meta/0179_snapshot.json
@@ -1,0 +1,5412 @@
+{
+  "id": "96ee38a6-ee08-4123-88e5-838af30891cb",
+  "prevId": "fb4f2a0e-1a02-4aa1-ad91-328834664d58",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "badges_festival_id_festivals_id_fk": {
+          "name": "badges_festival_id_festivals_id_fk",
+          "tableFrom": "badges",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cart_items": {
+      "name": "cart_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cart_items_cart_id_idx": {
+          "name": "cart_items_cart_id_idx",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cart_items_product_id_idx": {
+          "name": "cart_items_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cart_items_cart_id_carts_id_fk": {
+          "name": "cart_items_cart_id_carts_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "carts",
+          "columnsFrom": [
+            "cart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cart_items_product_id_products_id_fk": {
+          "name": "cart_items_product_id_products_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cart_items_cart_product_unique": {
+          "name": "cart_items_cart_product_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cart_id",
+            "product_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cart_items_quantity_positive": {
+          "name": "cart_items_quantity_positive",
+          "value": "\"cart_items\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.carts": {
+      "name": "carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "carts_user_id_users_id_fk": {
+          "name": "carts_user_id_users_id_fk",
+          "tableFrom": "carts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "carts_user_id_unique": {
+          "name": "carts_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collaborators": {
+      "name": "collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identification_number": {
+          "name": "identification_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collaborators_attendance_logs": {
+      "name": "collaborators_attendance_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reservation_collaborator_id": {
+          "name": "reservation_collaborator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_date_id": {
+          "name": "festival_date_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collaborators_attendance_logs_reservation_collaborator_id_reservation_collaborators_id_fk": {
+          "name": "collaborators_attendance_logs_reservation_collaborator_id_reservation_collaborators_id_fk",
+          "tableFrom": "collaborators_attendance_logs",
+          "tableTo": "reservation_collaborators",
+          "columnsFrom": [
+            "reservation_collaborator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collaborators_attendance_logs_festival_date_id_festival_dates_id_fk": {
+          "name": "collaborators_attendance_logs_festival_date_id_festival_dates_id_fk",
+          "tableFrom": "collaborators_attendance_logs",
+          "tableTo": "festival_dates",
+          "columnsFrom": [
+            "festival_date_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discount_codes": {
+      "name": "discount_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_unit": {
+          "name": "discount_unit",
+          "type": "discount_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_uses": {
+          "name": "current_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discount_codes_festival_id_festivals_id_fk": {
+          "name": "discount_codes_festival_id_festivals_id_fk",
+          "tableFrom": "discount_codes",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "discount_codes_user_id_users_id_fk": {
+          "name": "discount_codes_user_id_users_id_fk",
+          "tableFrom": "discount_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discount_codes_code_unique": {
+          "name": "discount_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_participants": {
+      "name": "external_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "external_participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_category_label": {
+          "name": "custom_category_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_participants_display_name_idx": {
+          "name": "external_participants_display_name_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_participants_created_by_user_id_users_id_fk": {
+          "name": "external_participants_created_by_user_id_users_id_fk",
+          "tableFrom": "external_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activities": {
+      "name": "festival_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_start_date": {
+          "name": "registration_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_end_date": {
+          "name": "registration_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promotional_art_url": {
+          "name": "promotional_art_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitors_description": {
+          "name": "visitors_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "festival_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stamp_passport'"
+        },
+        "activity_prize_url": {
+          "name": "activity_prize_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allows_voting": {
+          "name": "allows_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "voting_start_date": {
+          "name": "voting_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voting_end_date": {
+          "name": "voting_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_type": {
+          "name": "proof_type",
+          "type": "proof_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_upload_limit_date": {
+          "name": "proof_upload_limit_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "access_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "waitlist_window_minutes": {
+          "name": "waitlist_window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activities_festival_id_festivals_id_fk": {
+          "name": "festival_activities_festival_id_festivals_id_fk",
+          "tableFrom": "festival_activities",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proof_upload_limit_required": {
+          "name": "proof_upload_limit_required",
+          "value": "(\"festival_activities\".\"proof_type\" IS NULL) OR (\"festival_activities\".\"proof_upload_limit_date\" IS NOT NULL)"
+        },
+        "festival_activities_waitlist_window_minutes_positive": {
+          "name": "festival_activities_waitlist_window_minutes_positive",
+          "value": "\"festival_activities\".\"waitlist_window_minutes\" IS NULL OR \"festival_activities\".\"waitlist_window_minutes\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_details": {
+      "name": "festival_activity_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coupon_book_header_image_url": {
+          "name": "coupon_book_header_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participation_limit": {
+          "name": "participation_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_details_activity_id_festival_activities_id_fk": {
+          "name": "festival_activity_details_activity_id_festival_activities_id_fk",
+          "tableFrom": "festival_activity_details",
+          "tableTo": "festival_activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_participant_proofs": {
+      "name": "festival_activity_participant_proofs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participation_id": {
+          "name": "participation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promo_highlight": {
+          "name": "promo_highlight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_description": {
+          "name": "promo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_conditions": {
+          "name": "promo_conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_status": {
+          "name": "proof_status",
+          "type": "proof_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "admin_feedback": {
+          "name": "admin_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_participant_proofs_participation_id_festival_activity_participants_id_fk": {
+          "name": "festival_activity_participant_proofs_participation_id_festival_activity_participants_id_fk",
+          "tableFrom": "festival_activity_participant_proofs",
+          "tableTo": "festival_activity_participants",
+          "columnsFrom": [
+            "participation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_participants": {
+      "name": "festival_activity_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "details_id": {
+          "name": "details_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removal_reason": {
+          "name": "removal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_participants_details_id_festival_activity_details_id_fk": {
+          "name": "festival_activity_participants_details_id_festival_activity_details_id_fk",
+          "tableFrom": "festival_activity_participants",
+          "tableTo": "festival_activity_details",
+          "columnsFrom": [
+            "details_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_participants_user_id_users_id_fk": {
+          "name": "festival_activity_participants_user_id_users_id_fk",
+          "tableFrom": "festival_activity_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "festival_activity_participants_details_id_user_id_unique": {
+          "name": "festival_activity_participants_details_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "details_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_votes": {
+      "name": "festival_activity_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_variant_id": {
+          "name": "activity_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votable_type": {
+          "name": "votable_type",
+          "type": "votable_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_votes_voter_id_users_id_fk": {
+          "name": "festival_activity_votes_voter_id_users_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_votes_activity_variant_id_festival_activity_details_id_fk": {
+          "name": "festival_activity_votes_activity_variant_id_festival_activity_details_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "festival_activity_details",
+          "columnsFrom": [
+            "activity_variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_votes_stand_id_stands_id_fk": {
+          "name": "festival_activity_votes_stand_id_stands_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_votes_participant_id_festival_activity_participants_id_fk": {
+          "name": "festival_activity_votes_participant_id_festival_activity_participants_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "festival_activity_participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_voter_activity": {
+          "name": "unique_voter_activity",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_id",
+            "activity_variant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_waitlist": {
+      "name": "festival_activity_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notified_for_detail_id": {
+          "name": "notified_for_detail_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_waitlist_activity_id_festival_activities_id_fk": {
+          "name": "festival_activity_waitlist_activity_id_festival_activities_id_fk",
+          "tableFrom": "festival_activity_waitlist",
+          "tableTo": "festival_activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_waitlist_user_id_users_id_fk": {
+          "name": "festival_activity_waitlist_user_id_users_id_fk",
+          "tableFrom": "festival_activity_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_waitlist_notified_for_detail_id_festival_activity_details_id_fk": {
+          "name": "festival_activity_waitlist_notified_for_detail_id_festival_activity_details_id_fk",
+          "tableFrom": "festival_activity_waitlist",
+          "tableTo": "festival_activity_details",
+          "columnsFrom": [
+            "notified_for_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "festival_activity_waitlist_activity_id_user_id_unique": {
+          "name": "festival_activity_waitlist_activity_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "activity_id",
+            "user_id"
+          ]
+        },
+        "festival_activity_waitlist_activity_id_position_unique": {
+          "name": "festival_activity_waitlist_activity_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "activity_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "festival_activity_waitlist_position_check": {
+          "name": "festival_activity_waitlist_position_check",
+          "value": "\"festival_activity_waitlist\".\"position\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.festival_dates": {
+      "name": "festival_dates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "festival_dates_festival_id_idx": {
+          "name": "festival_dates_festival_id_idx",
+          "columns": [
+            {
+              "expression": "festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "festival_dates_festival_id_festivals_id_fk": {
+          "name": "festival_dates_festival_id_festivals_id_fk",
+          "tableFrom": "festival_dates",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_sectors": {
+      "name": "festival_sectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_url": {
+          "name": "map_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_in_festival": {
+          "name": "order_in_festival",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mascot_url": {
+          "name": "mascot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_origin_x": {
+          "name": "map_origin_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_origin_y": {
+          "name": "map_origin_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_width": {
+          "name": "map_width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_height": {
+          "name": "map_height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "festival_sector_name_idx": {
+          "name": "festival_sector_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "festival_sectors_festival_id_festivals_id_fk": {
+          "name": "festival_sectors_festival_id_festivals_id_fk",
+          "tableFrom": "festival_sectors",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festivals": {
+      "name": "festivals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label": {
+          "name": "location_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_url": {
+          "name": "location_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "festival_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maps_version": {
+          "name": "maps_version",
+          "type": "festival_map_version",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        },
+        "public_registration": {
+          "name": "public_registration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_day_registration": {
+          "name": "event_day_registration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "keep_store_open": {
+          "name": "keep_store_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reservations_start_date": {
+          "name": "reservations_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "general_map_url": {
+          "name": "general_map_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mascot_url": {
+          "name": "mascot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_type": {
+          "name": "festival_type",
+          "type": "festival_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'glitter'"
+        },
+        "illustration_payment_qr_code_url": {
+          "name": "illustration_payment_qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gastronomy_payment_qr_code_url": {
+          "name": "gastronomy_payment_qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrepreneurship_payment_qr_code_url": {
+          "name": "entrepreneurship_payment_qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "illustration_stand_url": {
+          "name": "illustration_stand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gastronomy_stand_url": {
+          "name": "gastronomy_stand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrepreneurship_stand_url": {
+          "name": "entrepreneurship_stand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_code": {
+          "name": "festival_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_banner_url": {
+          "name": "festival_banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms_and_conditions_url": {
+          "name": "terms_and_conditions_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_url": {
+          "name": "poster_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "festivals_name_unique": {
+          "name": "festivals_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.infraction_types": {
+      "name": "infraction_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "infraction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'low'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "infraction_types_code_unique": {
+          "name": "infraction_types_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.infractions": {
+      "name": "infractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handled": {
+          "name": "handled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_gave_notice": {
+          "name": "user_gave_notice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gave_notice_at": {
+          "name": "gave_notice_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "infractions_user_id_users_id_fk": {
+          "name": "infractions_user_id_users_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "infractions_type_id_infraction_types_id_fk": {
+          "name": "infractions_type_id_infraction_types_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "infraction_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "infractions_festival_id_festivals_id_fk": {
+          "name": "infractions_festival_id_festivals_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "original_amount": {
+          "name": "original_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_code_id": {
+          "name": "discount_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_user_id_users_id_fk": {
+          "name": "invoices_user_id_users_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_reservation_id_stand_reservations_id_fk": {
+          "name": "invoices_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_discount_code_id_discount_codes_id_fk": {
+          "name": "invoices_discount_code_id_discount_codes_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "discount_codes",
+          "columnsFrom": [
+            "discount_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.live_acts": {
+      "name": "live_acts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "act_name": {
+          "name": "act_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "live_act_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_link": {
+          "name": "resource_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "live_act_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "admin_notes": {
+          "name": "admin_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_elements": {
+      "name": "map_elements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "map_element_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_position": {
+          "name": "label_position",
+          "type": "map_element_label_position",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bottom'"
+        },
+        "label_font_size": {
+          "name": "label_font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "label_font_weight": {
+          "name": "label_font_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "show_icon": {
+          "name": "show_icon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "position_left": {
+          "name": "position_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "position_top": {
+          "name": "position_top",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "width": {
+          "name": "width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "height": {
+          "name": "height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "festival_sector_id": {
+          "name": "festival_sector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "map_elements_sector_idx": {
+          "name": "map_elements_sector_idx",
+          "columns": [
+            {
+              "expression": "festival_sector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_elements_festival_sector_id_festival_sectors_id_fk": {
+          "name": "map_elements_festival_sector_id_festival_sectors_id_fk",
+          "tableFrom": "map_elements",
+          "tableTo": "festival_sectors",
+          "columnsFrom": [
+            "festival_sector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_templates": {
+      "name": "map_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_data": {
+          "name": "template_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_festival_id": {
+          "name": "created_from_festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "map_templates_created_by_user_id_users_id_fk": {
+          "name": "map_templates_created_by_user_id_users_id_fk",
+          "tableFrom": "map_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "map_templates_created_from_festival_id_festivals_id_fk": {
+          "name": "map_templates_created_from_festival_id_festivals_id_fk",
+          "tableFrom": "map_templates",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "created_from_festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketing_banners": {
+      "name": "marketing_banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url_tablet": {
+          "name": "image_url_tablet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url_mobile": {
+          "name": "image_url_mobile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "marketing_banner_audience",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "open_in_new_tab": {
+          "name": "open_in_new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "marketing_banners_sort_order_idx": {
+          "name": "marketing_banners_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "marketing_banners_is_visible_idx": {
+          "name": "marketing_banners_is_visible_idx",
+          "columns": [
+            {
+              "expression": "is_visible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_items": {
+      "name": "order_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_at_purchase": {
+          "name": "price_at_purchase",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_items_order_id_idx": {
+          "name": "order_items_order_id_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_items_product_id_idx": {
+          "name": "order_items_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_phone": {
+          "name": "guest_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_order_token": {
+          "name": "guest_order_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_voucher_url": {
+          "name": "payment_voucher_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voucher_submitted_at": {
+          "name": "voucher_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_due_date": {
+          "name": "payment_due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + interval '2 days'"
+        },
+        "payment_reminder1_sent_at": {
+          "name": "payment_reminder1_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder2_sent_at": {
+          "name": "payment_reminder2_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder3_sent_at": {
+          "name": "payment_reminder3_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder1_claimed_at": {
+          "name": "payment_reminder1_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder2_claimed_at": {
+          "name": "payment_reminder2_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder3_claimed_at": {
+          "name": "payment_reminder3_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "orders_user_id_users_id_fk": {
+          "name": "orders_user_id_users_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orders_guest_order_token_unique": {
+          "name": "orders_guest_order_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "guest_order_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "orders_identity_check": {
+          "name": "orders_identity_check",
+          "value": "(\n\t\t\t\t(\"orders\".\"user_id\" IS NOT NULL AND \"orders\".\"guest_name\" IS NULL AND \"orders\".\"guest_email\" IS NULL AND \"orders\".\"guest_phone\" IS NULL AND \"orders\".\"guest_order_token\" IS NULL)\n\t\t\t\tOR\n\t\t\t\t(\"orders\".\"user_id\" IS NULL AND length(trim(\"orders\".\"guest_name\")) > 0 AND length(trim(\"orders\".\"guest_email\")) > 0 AND length(trim(\"orders\".\"guest_phone\")) > 0 AND length(trim(\"orders\".\"guest_order_token\")) > 0)\n\t\t\t)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.participant_products": {
+      "name": "participant_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participation_id": {
+          "name": "participation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_status": {
+          "name": "submission_status",
+          "type": "submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "submission_feedback": {
+          "name": "submission_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_products_user_id_users_id_fk": {
+          "name": "participant_products_user_id_users_id_fk",
+          "tableFrom": "participant_products",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participant_products_participation_id_participations_id_fk": {
+          "name": "participant_products_participation_id_participations_id_fk",
+          "tableFrom": "participant_products",
+          "tableTo": "participations",
+          "columnsFrom": [
+            "participation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voucher_url": {
+          "name": "voucher_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_images": {
+      "name": "product_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_status": {
+          "name": "upload_status",
+          "type": "product_image_upload_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_images_product_id_idx": {
+          "name": "product_images_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pre_order": {
+          "name": "is_pre_order",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "available_date": {
+          "name": "available_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "discount_unit": {
+          "name": "discount_unit",
+          "type": "discount_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "product_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_subcategories": {
+      "name": "profile_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subcategory_id": {
+          "name": "subcategory_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_subcategories_profile_id_users_id_fk": {
+          "name": "profile_subcategories_profile_id_users_id_fk",
+          "tableFrom": "profile_subcategories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_subcategories_subcategory_id_subcategories_id_fk": {
+          "name": "profile_subcategories_subcategory_id_subcategories_id_fk",
+          "tableFrom": "profile_subcategories",
+          "tableTo": "subcategories",
+          "columnsFrom": [
+            "subcategory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_tags": {
+      "name": "profile_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_tags_profile_id_users_id_fk": {
+          "name": "profile_tags_profile_id_users_id_fk",
+          "tableFrom": "profile_tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_tags_tag_id_tags_id_fk": {
+          "name": "profile_tags_tag_id_tags_id_fk",
+          "tableFrom": "profile_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qr_codes": {
+      "name": "qr_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qr_code_url": {
+          "name": "qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reservation_collaborators": {
+      "name": "reservation_collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collaborator_id": {
+          "name": "collaborator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reservation_collaborators_reservation_id_stand_reservations_id_fk": {
+          "name": "reservation_collaborators_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "reservation_collaborators",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reservation_collaborators_collaborator_id_collaborators_id_fk": {
+          "name": "reservation_collaborators_collaborator_id_collaborators_id_fk",
+          "tableFrom": "reservation_collaborators",
+          "tableTo": "collaborators",
+          "columnsFrom": [
+            "collaborator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reservation_external_participants": {
+      "name": "reservation_external_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_participant_id": {
+          "name": "external_participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reservation_external_participants_reservation_id_idx": {
+          "name": "reservation_external_participants_reservation_id_idx",
+          "columns": [
+            {
+              "expression": "reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reservation_external_participants_external_participant_id_external_participants_id_fk": {
+          "name": "reservation_external_participants_external_participant_id_external_participants_id_fk",
+          "tableFrom": "reservation_external_participants",
+          "tableTo": "external_participants",
+          "columnsFrom": [
+            "external_participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reservation_external_participants_reservation_id_stand_reservations_id_fk": {
+          "name": "reservation_external_participants_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "reservation_external_participants",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reservation_external_participants_unique": {
+          "name": "reservation_external_participants_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_participant_id",
+            "reservation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participations": {
+      "name": "participations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_stamp": {
+          "name": "has_stamp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participations_user_id_users_id_fk": {
+          "name": "participations_user_id_users_id_fk",
+          "tableFrom": "participations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participations_reservation_id_stand_reservations_id_fk": {
+          "name": "participations_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "participations",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sanctions": {
+      "name": "sanctions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infraction_id": {
+          "name": "infraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "sanction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_unit": {
+          "name": "duration_unit",
+          "type": "duration_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'indefinitely'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sanctions_user_id_users_id_fk": {
+          "name": "sanctions_user_id_users_id_fk",
+          "tableFrom": "sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sanctions_infraction_id_infractions_id_fk": {
+          "name": "sanctions_infraction_id_infractions_id_fk",
+          "tableFrom": "sanctions",
+          "tableTo": "infractions",
+          "columnsFrom": [
+            "infraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "scheduled_task_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'profile_creation'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_time": {
+          "name": "reminder_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ran_after_due_date": {
+          "name": "ran_after_due_date",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_tasks_profile_id_users_id_fk": {
+          "name": "scheduled_tasks_profile_id_users_id_fk",
+          "tableFrom": "scheduled_tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_tasks_reservation_id_stand_reservations_id_fk": {
+          "name": "scheduled_tasks_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "scheduled_tasks",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stand_holds": {
+      "name": "stand_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stand_holds_stand_idx": {
+          "name": "stand_holds_stand_idx",
+          "columns": [
+            {
+              "expression": "stand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stand_holds_user_festival_idx": {
+          "name": "stand_holds_user_festival_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stand_holds_stand_id_stands_id_fk": {
+          "name": "stand_holds_stand_id_stands_id_fk",
+          "tableFrom": "stand_holds",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stand_holds_user_id_users_id_fk": {
+          "name": "stand_holds_user_id_users_id_fk",
+          "tableFrom": "stand_holds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stand_holds_festival_id_festivals_id_fk": {
+          "name": "stand_holds_festival_id_festivals_id_fk",
+          "tableFrom": "stand_holds",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stand_reservations": {
+      "name": "stand_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "reservation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "reservation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_reservation'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stand_reservations_stand_id_stands_id_fk": {
+          "name": "stand_reservations_stand_id_stands_id_fk",
+          "tableFrom": "stand_reservations",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stand_subcategories": {
+      "name": "stand_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subcategory_id": {
+          "name": "subcategory_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stand_subcategories_stand_id_stands_id_fk": {
+          "name": "stand_subcategories_stand_id_stands_id_fk",
+          "tableFrom": "stand_subcategories",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stand_subcategories_subcategory_id_subcategories_id_fk": {
+          "name": "stand_subcategories_subcategory_id_subcategories_id_fk",
+          "tableFrom": "stand_subcategories",
+          "tableTo": "subcategories",
+          "columnsFrom": [
+            "subcategory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stands": {
+      "name": "stands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "stand_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "orientation": {
+          "name": "orientation",
+          "type": "stand_orientation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'landscape'"
+        },
+        "stand_number": {
+          "name": "stand_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stand_category": {
+          "name": "stand_category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'illustration'"
+        },
+        "zone": {
+          "name": "zone",
+          "type": "stand_zone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "width": {
+          "name": "width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_left": {
+          "name": "position_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_top": {
+          "name": "position_top",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "participation_type": {
+          "name": "participation_type",
+          "type": "participation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_sector_id": {
+          "name": "festival_sector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qr_code_id": {
+          "name": "qr_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stand_label_idx": {
+          "name": "stand_label_idx",
+          "columns": [
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stands_festival_sector_id_festival_sectors_id_fk": {
+          "name": "stands_festival_sector_id_festival_sectors_id_fk",
+          "tableFrom": "stands",
+          "tableTo": "festival_sectors",
+          "columnsFrom": [
+            "festival_sector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stands_qr_code_id_qr_codes_id_fk": {
+          "name": "stands_qr_code_id_qr_codes_id_fk",
+          "tableFrom": "stands",
+          "tableTo": "qr_codes",
+          "columnsFrom": [
+            "qr_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subcategories": {
+      "name": "subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tickets": {
+      "name": "tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ticket_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_event_day_creation": {
+          "name": "is_event_day_creation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_visitors": {
+          "name": "number_of_visitors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "ticket_number": {
+          "name": "ticket_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_in_at": {
+          "name": "checked_in_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_badges_user_id_users_id_fk": {
+          "name": "user_badges_user_id_users_id_fk",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_badges_id_fk": {
+          "name": "user_badges_badge_id_badges_id_fk",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_requests": {
+      "name": "user_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "user_request_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'become_artist'"
+        },
+        "status": {
+          "name": "status",
+          "type": "participation_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_requests_user_id_users_id_fk": {
+          "name": "user_requests_user_id_users_id_fk",
+          "tableFrom": "user_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_requests_festival_id_festivals_id_fk": {
+          "name": "user_requests_festival_id_festivals_id_fk",
+          "tableFrom": "user_requests",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_socials": {
+      "name": "user_socials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "user_social_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_socials_user_id_users_id_fk": {
+          "name": "user_socials_user_id_users_id_fk",
+          "tableFrom": "user_socials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthdate": {
+          "name": "birthdate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'undisclosed'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BO'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "should_submit_products": {
+          "name": "should_submit_products",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "participation_type": {
+          "name": "participation_type",
+          "type": "participation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "display_name_idx": {
+          "name": "display_name_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.visitors": {
+      "name": "visitors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_discovery": {
+          "name": "event_discovery",
+          "type": "event_discovery",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'undisclosed'"
+        },
+        "birthdate": {
+          "name": "birthdate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "visitors_email_unique": {
+          "name": "visitors_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_level": {
+      "name": "access_level",
+      "schema": "public",
+      "values": [
+        "public",
+        "festival_participants_only"
+      ]
+    },
+    "public.discount_unit": {
+      "name": "discount_unit",
+      "schema": "public",
+      "values": [
+        "percentage",
+        "amount"
+      ]
+    },
+    "public.duration_unit": {
+      "name": "duration_unit",
+      "schema": "public",
+      "values": [
+        "minutes",
+        "hours",
+        "days",
+        "months",
+        "years",
+        "festivals",
+        "indefinitely"
+      ]
+    },
+    "public.event_discovery": {
+      "name": "event_discovery",
+      "schema": "public",
+      "values": [
+        "facebook",
+        "instagram",
+        "tiktok",
+        "cba",
+        "friends",
+        "participant_invitation",
+        "casual",
+        "la_rota",
+        "other"
+      ]
+    },
+    "public.external_participant_type": {
+      "name": "external_participant_type",
+      "schema": "public",
+      "values": [
+        "institution",
+        "social_organization",
+        "sponsor",
+        "partner",
+        "public_entity",
+        "invited_brand",
+        "other"
+      ]
+    },
+    "public.festival_activity_type": {
+      "name": "festival_activity_type",
+      "schema": "public",
+      "values": [
+        "stamp_passport",
+        "sticker_print",
+        "best_stand",
+        "festival_sticker",
+        "coupon_book",
+        "sticker_hunt"
+      ]
+    },
+    "public.festival_map_version": {
+      "name": "festival_map_version",
+      "schema": "public",
+      "values": [
+        "v1",
+        "v2",
+        "v3"
+      ]
+    },
+    "public.festival_status": {
+      "name": "festival_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "active",
+        "archived"
+      ]
+    },
+    "public.festival_type": {
+      "name": "festival_type",
+      "schema": "public",
+      "values": [
+        "glitter",
+        "twinkler",
+        "festicker"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "non_binary",
+        "other",
+        "undisclosed"
+      ]
+    },
+    "public.infraction_severity": {
+      "name": "infraction_severity",
+      "schema": "public",
+      "values": [
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "paid",
+        "cancelled"
+      ]
+    },
+    "public.live_act_category": {
+      "name": "live_act_category",
+      "schema": "public",
+      "values": [
+        "music",
+        "dance",
+        "talk"
+      ]
+    },
+    "public.live_act_status": {
+      "name": "live_act_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "backlog",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.map_element_label_position": {
+      "name": "map_element_label_position",
+      "schema": "public",
+      "values": [
+        "left",
+        "right",
+        "top",
+        "bottom"
+      ]
+    },
+    "public.map_element_type": {
+      "name": "map_element_type",
+      "schema": "public",
+      "values": [
+        "entrance",
+        "stage",
+        "door",
+        "bathroom",
+        "label",
+        "custom",
+        "stairs"
+      ]
+    },
+    "public.marketing_banner_audience": {
+      "name": "marketing_banner_audience",
+      "schema": "public",
+      "values": [
+        "all",
+        "public_only",
+        "participants_only"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "payment_verification",
+        "processing",
+        "paid",
+        "delivered",
+        "cancelled"
+      ]
+    },
+    "public.participation_type": {
+      "name": "participation_type",
+      "schema": "public",
+      "values": [
+        "standard",
+        "live_activity"
+      ]
+    },
+    "public.product_image_upload_status": {
+      "name": "product_image_upload_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active"
+      ]
+    },
+    "public.product_status": {
+      "name": "product_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "presale",
+        "sale"
+      ]
+    },
+    "public.proof_status": {
+      "name": "proof_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected_resubmit",
+        "rejected_removed"
+      ]
+    },
+    "public.proof_type": {
+      "name": "proof_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "text",
+        "both"
+      ]
+    },
+    "public.participation_request_status": {
+      "name": "participation_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.user_request_type": {
+      "name": "user_request_type",
+      "schema": "public",
+      "values": [
+        "festival_participation",
+        "become_artist"
+      ]
+    },
+    "public.reservation_source": {
+      "name": "reservation_source",
+      "schema": "public",
+      "values": [
+        "user_reservation",
+        "admin_assignment"
+      ]
+    },
+    "public.reservation_status": {
+      "name": "reservation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verification_payment",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.sanction_type": {
+      "name": "sanction_type",
+      "schema": "public",
+      "values": [
+        "ban",
+        "warning",
+        "reservation_delay"
+      ]
+    },
+    "public.scheduled_task_type": {
+      "name": "scheduled_task_type",
+      "schema": "public",
+      "values": [
+        "profile_creation",
+        "stand_reservation"
+      ]
+    },
+    "public.stand_orientation": {
+      "name": "stand_orientation",
+      "schema": "public",
+      "values": [
+        "portrait",
+        "landscape"
+      ]
+    },
+    "public.stand_status": {
+      "name": "stand_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "held",
+        "reserved",
+        "confirmed",
+        "disabled"
+      ]
+    },
+    "public.stand_zone": {
+      "name": "stand_zone",
+      "schema": "public",
+      "values": [
+        "main",
+        "secondary"
+      ]
+    },
+    "public.submission_status": {
+      "name": "submission_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.ticket_status": {
+      "name": "ticket_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "checked_in"
+      ]
+    },
+    "public.user_category": {
+      "name": "user_category",
+      "schema": "public",
+      "values": [
+        "none",
+        "illustration",
+        "gastronomy",
+        "entrepreneurship",
+        "new_artist"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "artist",
+        "user",
+        "festival_admin"
+      ]
+    },
+    "public.user_social_type": {
+      "name": "user_social_type",
+      "schema": "public",
+      "values": [
+        "instagram",
+        "facebook",
+        "tiktok",
+        "twitter",
+        "youtube"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "verified",
+        "pending",
+        "rejected",
+        "banned"
+      ]
+    },
+    "public.votable_type": {
+      "name": "votable_type",
+      "schema": "public",
+      "values": [
+        "participant",
+        "stand"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1254,6 +1254,13 @@
       "when": 1781585087761,
       "tag": "0178_ordinary_nekra",
       "breakpoints": true
+    },
+    {
+      "idx": 179,
+      "version": "7",
+      "when": 1781620801931,
+      "tag": "0179_gray_white_queen",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1240,6 +1240,20 @@
       "when": 1780501104480,
       "tag": "0176_eager_penance",
       "breakpoints": true
+    },
+    {
+      "idx": 177,
+      "version": "7",
+      "when": 1781584195555,
+      "tag": "0177_grey_speedball",
+      "breakpoints": true
+    },
+    {
+      "idx": 178,
+      "version": "7",
+      "when": 1781585087761,
+      "tag": "0178_ordinary_nekra",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "vercel-build": "npm run generate && npm run migrate && next build",
     "email": "email dev --dir app/emails",
     "test": "vitest",
-    "format:fix": "prettier --write .",
+    "format:write": "prettier --write .",
     "format:check": "prettier --check ."
   },
   "dependencies": {


### PR DESCRIPTION
…nd maps

Introduce external participant models, actions, and schema migration, then wire them into reservation creation and festival map UI so non-registered participants can be selected and displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added external-participant support to stand reservations, including creation and admin assignment (with external-participant image upload).

* **UI Updates**
  * Public and admin maps now recognize “Externo” stands with dedicated coloring, legend entries, and updated stand/tooltip display.
  * Reservations UI now includes a **“Categoría”** column and shows external participant avatars, categories, and contact links.

* **Enhancements**
  * Reservation/sector data loading was expanded to include external participants for consistent display across the app.

* **Chores**
  * Updated formatting script name for Prettier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->