### PR TITLE
feat(store): add OG metadata to product detail pages

### DIFF
--- a/app/(routes)/store/products/[slug]/page.tsx
+++ b/app/(routes)/store/products/[slug]/page.tsx
@@ -1,17 +1,85 @@
 import { ArrowLeftIcon } from "lucide-react";
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound, permanentRedirect } from "next/navigation";
 import { z } from "zod";
 
 import ProductDetailContent from "@/app/components/organisms/store/product-detail-content";
+import { PLACEHOLDER_IMAGE_URLS } from "@/app/lib/constants";
 import { fetchProduct, fetchProductBySlug } from "@/app/lib/products/actions";
+import { getProductVariantImageUrl } from "@/app/lib/products/variants";
 
 const ParamsSchema = z.object({
   slug: z.string().min(1),
 });
 
+type ProductDetailParams = z.infer<typeof ParamsSchema>;
+
+async function resolvePublicProduct(slug: string) {
+  const raw = decodeURIComponent(slug);
+  const product = await fetchProductBySlug(raw, { visibleOnly: true });
+
+  if (product) {
+    return { product, redirectSlug: null };
+  }
+
+  if (/^\d+$/.test(raw)) {
+    const byId = await fetchProduct(Number(raw));
+    if (!byId || !byId.isVisible) {
+      return { product: null, redirectSlug: null };
+    }
+
+    return { product: byId, redirectSlug: byId.slug };
+  }
+
+  return { product: null, redirectSlug: null };
+}
+
+export async function generateMetadata(props: {
+  params: Promise<ProductDetailParams>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const validatedParams = ParamsSchema.safeParse(params);
+
+  if (!validatedParams.success) {
+    return {};
+  }
+
+  const { product } = await resolvePublicProduct(validatedParams.data.slug);
+
+  if (!product) {
+    return {};
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const imageUrl = `${baseUrl}${getProductVariantImageUrl(product, null) ?? PLACEHOLDER_IMAGE_URLS["1200"]}`;
+  const description = product.description ?? undefined;
+
+  return {
+    title: product.name,
+    description,
+    openGraph: {
+      title: product.name,
+      description,
+      url: `/store/products/${encodeURIComponent(product.slug)}`,
+      images: [
+        {
+          url: imageUrl,
+          alt: product.name,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: product.name,
+      description,
+      images: [imageUrl],
+    },
+  };
+}
+
 export default async function ProductDetailPage(props: {
-  params: Promise<z.infer<typeof ParamsSchema>>;
+  params: Promise<ProductDetailParams>;
 }) {
   const params = await props.params;
   const validatedParams = ParamsSchema.safeParse(params);
@@ -20,19 +88,16 @@ export default async function ProductDetailPage(props: {
     return notFound();
   }
 
-  const raw = decodeURIComponent(validatedParams.data.slug);
-
-  const product = await fetchProductBySlug(raw, { visibleOnly: true });
+  const { product, redirectSlug } = await resolvePublicProduct(
+    validatedParams.data.slug,
+  );
 
   if (!product) {
-    if (/^\d+$/.test(raw)) {
-      const byId = await fetchProduct(Number(raw));
-      if (!byId || !byId.isVisible) {
-        return notFound();
-      }
-      return permanentRedirect(`/store/products/${byId.slug}`);
-    }
     return notFound();
+  }
+
+  if (redirectSlug) {
+    return permanentRedirect(`/store/products/${redirectSlug}`);
   }
 
   return (


### PR DESCRIPTION
Generate Open Graph and Twitter card metadata from the product name, description, and variant image so shared links render rich previews. Extract shared product resolution into resolvePublicProduct for reuse by the page and generateMetadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product detail pages now include proper metadata for search engines and social media previews with Open Graph and Twitter card support, including product images.

* **Bug Fixes**
  * Improved product URL handling to support numeric IDs with automatic redirects to canonical product slugs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->