### PR TITLE
refactor(navbar): load profile client-side and scope route layouts

### DIFF
--- a/app/(routes)/my_history/layout.tsx
+++ b/app/(routes)/my_history/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+
+export default function MyHistoryLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/(routes)/my_orders/layout.tsx
+++ b/app/(routes)/my_orders/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+
+export default function MyOrdersLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/(routes)/my_participations/layout.tsx
+++ b/app/(routes)/my_participations/layout.tsx
@@ -1,6 +1,6 @@
 export const dynamic = "force-dynamic";
 
-export default function RoutesLayout({
+export default function MyParticipationsLayout({
   children,
 }: {
   children: React.ReactNode;

--- a/app/(routes)/portal/page.tsx
+++ b/app/(routes)/portal/page.tsx
@@ -23,6 +23,8 @@ import { getCurrentUserProfile } from "@/app/lib/users/helpers";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 
+export const dynamic = "force-dynamic";
+
 export default async function ParticipantDashboardPage() {
   const currentProfile = await getCurrentUserProfile();
 

--- a/app/(routes)/store/layout.tsx
+++ b/app/(routes)/store/layout.tsx
@@ -9,6 +9,8 @@ import { getActiveFestivalBase } from "@/app/lib/festivals/helpers";
 import { isFestivalHappeningAt } from "@/app/lib/festivals/store-gate";
 import { getCurrentUserProfile } from "@/app/lib/users/helpers";
 
+export const dynamic = "force-dynamic";
+
 export default async function StoreLayout({
   children,
 }: {

--- a/app/api/users/navbar-profile/route.ts
+++ b/app/api/users/navbar-profile/route.ts
@@ -1,0 +1,18 @@
+import { cachedFetchNavbarProfileByClerkId } from "@/app/lib/users/actions";
+import { currentUser } from "@clerk/nextjs/server";
+
+export async function GET() {
+  const user = await currentUser();
+
+  if (!user) {
+    return Response.json(null);
+  }
+
+  try {
+    const profile = await cachedFetchNavbarProfileByClerkId(user.id);
+    return Response.json(profile);
+  } catch (error) {
+    console.error("Failed to fetch navbar profile:", error);
+    return Response.json({ error: "Failed to fetch profile" }, { status: 500 });
+  }
+}

--- a/app/components/navbar/navbar-client.tsx
+++ b/app/components/navbar/navbar-client.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import GlitterLogo from "@/app/components/landing/glitter-logo";
+import NavbarNavigationMenu from "@/app/components/navbar/navigation-menu";
+import SessionButtons from "@/app/components/navbar/session-buttons";
+import { useNavbarProfile } from "@/app/components/navbar/use-navbar-profile";
+import MobileSidebar from "@/app/components/organisms/mobile-sidebar";
+import { MenuIcon } from "lucide-react";
+import Link from "next/link";
+
+export default function NavbarClient() {
+  const { profile } = useNavbarProfile();
+
+  return (
+    <ul className="grid w-full grid-cols-2 items-center md:grid-cols-3">
+      <li className="flex items-center gap-2">
+        <div className="md:hidden">
+          <MobileSidebar profile={profile}>
+            <MenuIcon className="h-5 w-5" />
+          </MobileSidebar>
+        </div>
+        <Link href="/">
+          <GlitterLogo
+            className="md:hidden"
+            variant="dark"
+            height={40}
+            width={40}
+          />
+          <GlitterLogo
+            className="hidden md:block"
+            variant="dark"
+            height={48}
+            width={48}
+          />
+        </Link>
+      </li>
+      <li className="hidden justify-self-center md:block">
+        <NavbarNavigationMenu profile={profile} />
+      </li>
+      <li className="flex justify-self-end">
+        <SessionButtons profile={profile} />
+      </li>
+    </ul>
+  );
+}

--- a/app/components/navbar/navbar.tsx
+++ b/app/components/navbar/navbar.tsx
@@ -1,49 +1,10 @@
-import GlitterLogo from "@/app/components/landing/glitter-logo";
-import NavbarNavigationMenu from "@/app/components/navbar/navigation-menu";
-import SessionButtons from "@/app/components/navbar/session-buttons";
-import MobileSidebar from "@/app/components/organisms/mobile-sidebar";
-import { getCurrentNavbarProfile } from "@/app/lib/users/helpers";
-import { MenuIcon } from "lucide-react";
-import Link from "next/link";
-import { connection } from "next/server";
+import NavbarClient from "@/app/components/navbar/navbar-client";
 
-export default async function Navbar() {
-  await connection();
-
-  const profile = await getCurrentNavbarProfile();
-
+export default function Navbar() {
   return (
-    <header className="sticky top-0 z-50 bg-background border-b">
-      <nav className="w-full h-16 md:h-20 container m-auto py-3 md:py-4 px-4 md:px-6 flex items-center">
-        <ul className="grid grid-cols-2 md:grid-cols-3 items-center w-full">
-          <li className="flex items-center gap-2">
-            <div className="md:hidden">
-              <MobileSidebar profile={profile}>
-                <MenuIcon className="h-5 w-5" />
-              </MobileSidebar>
-            </div>
-            <Link href="/">
-              <GlitterLogo
-                className="md:hidden"
-                variant="dark"
-                height={40}
-                width={40}
-              />
-              <GlitterLogo
-                className="hidden md:block"
-                variant="dark"
-                height={48}
-                width={48}
-              />
-            </Link>
-          </li>
-          <li className="hidden justify-self-center md:block">
-            <NavbarNavigationMenu profile={profile} />
-          </li>
-          <li className="flex justify-self-end">
-            <SessionButtons profile={profile} />
-          </li>
-        </ul>
+    <header className="sticky top-0 z-50 border-b bg-background">
+      <nav className="container m-auto flex h-16 w-full items-center px-4 py-3 md:h-20 md:px-6 md:py-4">
+        <NavbarClient />
       </nav>
     </header>
   );

--- a/app/components/navbar/use-navbar-profile.ts
+++ b/app/components/navbar/use-navbar-profile.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import type { NavbarProfile } from "@/app/api/users/definitions";
+import { useUser } from "@clerk/nextjs";
+import { useEffect, useState } from "react";
+
+export function useNavbarProfile() {
+  const { isLoaded, isSignedIn, user } = useUser();
+  const [profile, setProfile] = useState<NavbarProfile | null>(null);
+  const [isLoadingProfile, setIsLoadingProfile] = useState(false);
+
+  useEffect(() => {
+    if (!isLoaded) {
+      return;
+    }
+
+    if (!isSignedIn) {
+      setProfile(null);
+      setIsLoadingProfile(false);
+      return;
+    }
+
+    let isCurrent = true;
+    setIsLoadingProfile(true);
+
+    fetch("/api/users/navbar-profile", { cache: "no-store" })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Failed to fetch navbar profile.");
+        }
+
+        return response.json() as Promise<NavbarProfile | null>;
+      })
+      .then((data) => {
+        if (isCurrent) {
+          setProfile(data);
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+        if (isCurrent) {
+          setProfile(null);
+        }
+      })
+      .finally(() => {
+        if (isCurrent) {
+          setIsLoadingProfile(false);
+        }
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [isLoaded, isSignedIn, user?.id]);
+
+  return {
+    profile,
+    isLoading: !isLoaded || isLoadingProfile,
+  };
+}

--- a/app/components/navbar/use-navbar-profile.ts
+++ b/app/components/navbar/use-navbar-profile.ts
@@ -7,21 +7,24 @@ import { useEffect, useState } from "react";
 export function useNavbarProfile() {
   const { isLoaded, isSignedIn, user } = useUser();
   const [profile, setProfile] = useState<NavbarProfile | null>(null);
-  const [isLoadingProfile, setIsLoadingProfile] = useState(false);
+  const [profileUserId, setProfileUserId] = useState<string | null>(null);
+
+  const isLoadingProfile =
+    isSignedIn &&
+    isLoaded &&
+    user?.id != null &&
+    profileUserId !== user.id;
 
   useEffect(() => {
-    if (!isLoaded) {
+    if (!isLoaded || !isSignedIn || !user?.id) {
       return;
     }
 
-    if (!isSignedIn) {
-      setProfile(null);
-      setIsLoadingProfile(false);
+    if (profileUserId === user.id) {
       return;
     }
 
     let isCurrent = true;
-    setIsLoadingProfile(true);
 
     fetch("/api/users/navbar-profile", { cache: "no-store" })
       .then((response) => {
@@ -34,6 +37,7 @@ export function useNavbarProfile() {
       .then((data) => {
         if (isCurrent) {
           setProfile(data);
+          setProfileUserId(user.id);
         }
       })
       .catch((error) => {
@@ -41,20 +45,16 @@ export function useNavbarProfile() {
         if (isCurrent) {
           setProfile(null);
         }
-      })
-      .finally(() => {
-        if (isCurrent) {
-          setIsLoadingProfile(false);
-        }
       });
 
     return () => {
       isCurrent = false;
     };
-  }, [isLoaded, isSignedIn, user?.id]);
+  }, [isLoaded, isSignedIn, user?.id, profileUserId]);
 
   return {
-    profile,
+    profile:
+      isSignedIn && profileUserId === user?.id ? profile : null,
     isLoading: !isLoaded || isLoadingProfile,
   };
 }

--- a/app/lib/users/actions.ts
+++ b/app/lib/users/actions.ts
@@ -104,33 +104,28 @@ export const cachedFetchBaseUserProfileByClerkId = cache(
 export const fetchNavbarProfileByClerkId = async (
   clerkId: string,
 ): Promise<NavbarProfile | null> => {
-  try {
-    const profile = await db.query.users.findFirst({
-      with: {
-        participations: {
-          with: {
-            reservation: {
-              with: {
-                stand: true,
-                festival: true,
-              },
+  const profile = await db.query.users.findFirst({
+    with: {
+      participations: {
+        with: {
+          reservation: {
+            with: {
+              stand: true,
+              festival: true,
             },
           },
         },
-        profileSubcategories: {
-          with: {
-            subcategory: true,
-          },
+      },
+      profileSubcategories: {
+        with: {
+          subcategory: true,
         },
       },
-      where: eq(users.clerkId, clerkId),
-    });
+    },
+    where: eq(users.clerkId, clerkId),
+  });
 
-    return profile || null;
-  } catch (error) {
-    console.error(error);
-    return null;
-  }
+  return profile || null;
 };
 
 export const cachedFetchNavbarProfileByClerkId = cache(


### PR DESCRIPTION
Move navbar profile fetching to a client hook and API route so the header no longer blocks server rendering. Replace the shared (routes) layout with per-route layouts for my_orders, my_history, and my_participations, and mark portal and store as force-dynamic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `GET /api/users/navbar-profile` endpoint to provide navbar profile data (or `null` when signed out).

* **Refactor**
  * Updated the navbar to render on the client using live auth state, fetching profile data via the new endpoint.
  * Split navbar logic into a client component and a dedicated profile hook.

* **Bug Fixes**
  * Improved correctness of user/session-driven pages by forcing dynamic rendering on multiple routes and adding missing history/participations layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->