### PR TITLE
Add stand history to reservation stands map

### DIFF
--- a/app/components/maps/admin/admin-overview-map-tooltip.tsx
+++ b/app/components/maps/admin/admin-overview-map-tooltip.tsx
@@ -10,14 +10,17 @@ import {
 import { createPortal } from "react-dom";
 
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
-import { InvoiceWithParticipants } from "@/app/data/invoices/definitions";
 import { ReservationStatus } from "@/app/components/reservations/cells/status";
+import { StandStatusBadge } from "@/app/components/stands/status-badge";
 import { Avatar, AvatarImage } from "@/app/components/ui/avatar";
-import { ClockIcon } from "lucide-react";
+import { Badge } from "@/app/components/ui/badge";
+import { InvoiceWithParticipants } from "@/app/data/invoices/definitions";
+import { ClockIcon, HistoryIcon } from "lucide-react";
 
 type AdminOverviewMapTooltipProps = {
   stand: StandWithReservationsWithParticipants;
-  invoice: InvoiceWithParticipants;
+  invoice: InvoiceWithParticipants | null;
+  cancelledInvoices: InvoiceWithParticipants[];
   anchorRect: DOMRect;
   dueDate?: Date | null;
   isOverdue?: boolean;
@@ -28,6 +31,7 @@ const GAP = 8;
 export default function AdminOverviewMapTooltip({
   stand,
   invoice,
+  cancelledInvoices,
   anchorRect,
   dueDate,
   isOverdue,
@@ -78,9 +82,10 @@ export default function AdminOverviewMapTooltip({
     };
   }, [recomputePosition]);
 
-  const coParticipants = invoice.reservation.participants.filter(
-    (p) => p.user.id !== invoice.user.id,
-  );
+  const coParticipants =
+    invoice?.reservation.participants.filter(
+      (p) => p.user.id !== invoice.user.id,
+    ) ?? [];
 
   const tooltip = (
     <div
@@ -92,50 +97,58 @@ export default function AdminOverviewMapTooltip({
         pointerEvents: "none",
       }}
     >
-      <div className="flex flex-col gap-2 min-w-[180px]">
+      <div className="flex flex-col gap-2 min-w-45">
         <div className="flex items-center justify-between gap-3">
           <div>
             <p className="text-sm font-semibold">
               Espacio {stand.label}
               {stand.standNumber}
             </p>
-            <p className="text-xs text-muted-foreground">
-              Reserva #{invoice.reservation.id}
-            </p>
+            {invoice && (
+              <p className="text-xs text-muted-foreground">
+                Reserva #{invoice.reservation.id}
+              </p>
+            )}
           </div>
-          <ReservationStatus reservation={invoice.reservation} />
+          {invoice ? (
+            <ReservationStatus reservation={invoice.reservation} />
+          ) : (
+            <StandStatusBadge status={stand.status} />
+          )}
         </div>
 
-        <div className="space-y-1.5">
-          <div className="flex items-center gap-2">
-            <Avatar className="h-7 w-7 shrink-0">
-              <AvatarImage
-                src={invoice.user.imageUrl ?? undefined}
-                alt={invoice.user.displayName ?? ""}
-              />
-            </Avatar>
-            <span className="text-sm leading-tight">
-              {invoice.user.displayName}{" "}
-              <span className="text-xs text-muted-foreground">(titular)</span>
-            </span>
-          </div>
-          {coParticipants.map((p) => (
-            <div key={p.id} className="flex items-center gap-2">
+        {invoice && (
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-2">
               <Avatar className="h-7 w-7 shrink-0">
                 <AvatarImage
-                  src={p.user.imageUrl ?? undefined}
-                  alt={p.user.displayName ?? ""}
+                  src={invoice.user.imageUrl ?? undefined}
+                  alt={invoice.user.displayName ?? ""}
                 />
               </Avatar>
               <span className="text-sm leading-tight">
-                {p.user.displayName}
+                {invoice.user.displayName}{" "}
+                <span className="text-xs text-muted-foreground">(titular)</span>
               </span>
             </div>
-          ))}
-        </div>
+            {coParticipants.map((p) => (
+              <div key={p.id} className="flex items-center gap-2">
+                <Avatar className="h-7 w-7 shrink-0">
+                  <AvatarImage
+                    src={p.user.imageUrl ?? undefined}
+                    alt={p.user.displayName ?? ""}
+                  />
+                </Avatar>
+                <span className="text-sm leading-tight">
+                  {p.user.displayName}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
 
         {dueDate && (
-          <div className="flex items-center gap-1.5 pt-1.5 border-t text-xs text-muted-foreground">
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
             <ClockIcon className="h-3 w-3 shrink-0" />
             <span>
               {isOverdue ? "Venció el " : "Vence el "}
@@ -148,6 +161,34 @@ export default function AdminOverviewMapTooltip({
                 }).format(dueDate)}
               </span>
             </span>
+          </div>
+        )}
+
+        {cancelledInvoices.length > 0 && (
+          <div className="space-y-1.5 border-t pt-2">
+            <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+              <HistoryIcon className="h-3.5 w-3.5" />
+              <span>Historial</span>
+            </div>
+            {cancelledInvoices.slice(0, 3).map((cancelledInvoice) => (
+              <div
+                key={cancelledInvoice.reservation.id}
+                className="flex items-center justify-between gap-3 text-xs"
+              >
+                <span>
+                  Reserva #{cancelledInvoice.reservation.id} ·{" "}
+                  {cancelledInvoice.user.displayName}
+                </span>
+                <Badge variant="destructive" size="sm">
+                  Cancelada
+                </Badge>
+              </div>
+            ))}
+            {cancelledInvoices.length > 3 && (
+              <p className="text-[11px] text-muted-foreground">
+                +{cancelledInvoices.length - 3} reservas canceladas
+              </p>
+            )}
           </div>
         )}
       </div>

--- a/app/components/maps/admin/admin-overview-map-tooltip.tsx
+++ b/app/components/maps/admin/admin-overview-map-tooltip.tsx
@@ -172,7 +172,7 @@ export default function AdminOverviewMapTooltip({
             </div>
             {cancelledInvoices.slice(0, 3).map((cancelledInvoice) => (
               <div
-                key={cancelledInvoice.reservation.id}
+                key={cancelledInvoice.id}
                 className="flex items-center justify-between gap-3 text-xs"
               >
                 <span>

--- a/app/components/maps/admin/admin-overview-map.tsx
+++ b/app/components/maps/admin/admin-overview-map.tsx
@@ -19,6 +19,10 @@ import MapToolbar from "@/app/components/maps/map-toolbar";
 import MapTransformWrapper from "@/app/components/maps/map-transform-wrapper";
 import AdminOverviewStandDrawer from "@/app/components/maps/admin/admin-overview-stand-drawer";
 import AdminOverviewMapTooltip from "@/app/components/maps/admin/admin-overview-map-tooltip";
+import {
+  getStandReservationSummary,
+  StandReservationSummary,
+} from "@/app/components/maps/admin/admin-overview-reservations";
 import { Tabs, TabsList, TabsTrigger } from "@/app/components/ui/tabs";
 import { Switch } from "@/app/components/ui/switch";
 import { useMediaQuery } from "@/app/hooks/use-media-query";
@@ -117,13 +121,29 @@ export default function AdminOverviewMap({
     activeSector?.mapElements ?? [],
   );
 
+  const reservationSummaries = useMemo(() => {
+    const summaries = new Map<number, StandReservationSummary>();
+
+    for (const stand of sectors.flatMap((sector) => sector.stands)) {
+      summaries.set(stand.id, getStandReservationSummary(invoices, stand.id));
+    }
+
+    return summaries;
+  }, [invoices, sectors]);
+
+  const getReservationSummary = useCallback(
+    (standId: number): StandReservationSummary =>
+      reservationSummaries.get(standId) ?? {
+        activeInvoice: null,
+        cancelledInvoices: [],
+      },
+    [reservationSummaries],
+  );
+
   const findInvoiceForStand = useCallback(
-    (standId: number): InvoiceWithParticipants | null => {
-      return (
-        invoices.find((inv) => inv.reservation.standId === standId) ?? null
-      );
-    },
-    [invoices],
+    (standId: number): InvoiceWithParticipants | null =>
+      getReservationSummary(standId).activeInvoice,
+    [getReservationSummary],
   );
 
   const getReservationStatus = useCallback(
@@ -231,7 +251,12 @@ export default function AdminOverviewMap({
     (stand: StandWithReservationsWithParticipants, rect?: DOMRect) => {
       if (isSimplifiedMode) {
         // Drawer is completely disabled in simplified mode
-        if (rect && findInvoiceForStand(stand.id)) {
+        const reservationSummary = getReservationSummary(stand.id);
+        if (
+          rect &&
+          (reservationSummary.activeInvoice ||
+            reservationSummary.cancelledInvoices.length > 0)
+        ) {
           setTooltipStand(stand);
           setTooltipAnchorRect(rect);
         }
@@ -240,7 +265,7 @@ export default function AdminOverviewMap({
         setDrawerOpen(true);
       }
     },
-    [isSimplifiedMode, findInvoiceForStand],
+    [isSimplifiedMode, getReservationSummary],
   );
 
   const handleHoverChange = useCallback(
@@ -268,10 +293,16 @@ export default function AdminOverviewMap({
   const selectedInvoice = selectedStand
     ? findInvoiceForStand(selectedStand.id)
     : null;
+  const selectedCancelledInvoices = selectedStand
+    ? getReservationSummary(selectedStand.id).cancelledInvoices
+    : [];
 
   const tooltipInvoice = tooltipStand
     ? findInvoiceForStand(tooltipStand.id)
     : null;
+  const tooltipCancelledInvoices = tooltipStand
+    ? getReservationSummary(tooltipStand.id).cancelledInvoices
+    : [];
 
   return (
     <div className="space-y-4">
@@ -342,13 +373,13 @@ export default function AdminOverviewMap({
           maxScale={4}
           centerOnInit
         >
-          <div className="flex w-full max-w-[500px] items-center justify-between pb-2">
+          <div className="flex w-full max-w-125 items-center justify-between pb-2">
             <p className="text-sm text-muted-foreground font-medium">
               {activeSector?.name}
             </p>
             <MapToolbar />
           </div>
-          <div className="relative w-full max-w-[500px] rounded-lg border bg-background shadow-sm overflow-hidden pb-8 md:pb-0">
+          <div className="relative w-full max-w-125 rounded-lg border bg-background shadow-sm overflow-hidden pb-8 md:pb-0">
             <TransformComponent
               wrapperStyle={{ width: "100%" }}
               contentStyle={{ width: "100%" }}
@@ -395,20 +426,24 @@ export default function AdminOverviewMap({
       </div>
 
       {/* Tooltip (hover for mouse, tap for simplified touch mode) */}
-      {tooltipStand && tooltipAnchorRect && tooltipInvoice && (
-        <AdminOverviewMapTooltip
-          stand={tooltipStand}
-          invoice={tooltipInvoice}
-          anchorRect={tooltipAnchorRect}
-          dueDate={getDueDate(tooltipStand.id)}
-          isOverdue={getIsOverdue(tooltipStand.id)}
-        />
-      )}
+      {tooltipStand &&
+        tooltipAnchorRect &&
+        (tooltipInvoice || tooltipCancelledInvoices.length > 0) && (
+          <AdminOverviewMapTooltip
+            stand={tooltipStand}
+            invoice={tooltipInvoice}
+            cancelledInvoices={tooltipCancelledInvoices}
+            anchorRect={tooltipAnchorRect}
+            dueDate={getDueDate(tooltipStand.id)}
+            isOverdue={getIsOverdue(tooltipStand.id)}
+          />
+        )}
 
       {/* Stand detail drawer */}
       <AdminOverviewStandDrawer
         stand={selectedStand}
         invoice={selectedInvoice}
+        cancelledInvoices={selectedCancelledInvoices}
         sectorName={activeSector?.name ?? ""}
         open={drawerOpen}
         onOpenChange={setDrawerOpen}

--- a/app/components/maps/admin/admin-overview-reservations.test.ts
+++ b/app/components/maps/admin/admin-overview-reservations.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { InvoiceWithParticipants } from "@/app/data/invoices/definitions";
+import { getStandReservationSummary } from "./admin-overview-reservations";
+
+function makeInvoice({
+  invoiceId,
+  reservationId,
+  standId = 10,
+  status,
+  createdAt,
+}: {
+  invoiceId: number;
+  reservationId: number;
+  standId?: number;
+  status: "pending" | "verification_payment" | "accepted" | "rejected";
+  createdAt: string;
+}) {
+  return {
+    id: invoiceId,
+    createdAt: new Date(createdAt),
+    reservation: {
+      id: reservationId,
+      standId,
+      status,
+      createdAt: new Date(createdAt),
+    },
+  } as unknown as InvoiceWithParticipants;
+}
+
+describe("getStandReservationSummary", () => {
+  it("treats a stand with only cancelled reservations as having no active reservation", () => {
+    const cancelled = makeInvoice({
+      invoiceId: 1,
+      reservationId: 100,
+      status: "rejected",
+      createdAt: "2026-06-01T12:00:00.000Z",
+    });
+
+    expect(getStandReservationSummary([cancelled], 10)).toEqual({
+      activeInvoice: null,
+      cancelledInvoices: [cancelled],
+    });
+  });
+
+  it("selects a new active reservation even when an older cancellation comes first", () => {
+    const cancelled = makeInvoice({
+      invoiceId: 1,
+      reservationId: 100,
+      status: "rejected",
+      createdAt: "2026-06-01T12:00:00.000Z",
+    });
+    const active = makeInvoice({
+      invoiceId: 2,
+      reservationId: 101,
+      status: "pending",
+      createdAt: "2026-06-02T12:00:00.000Z",
+    });
+
+    expect(getStandReservationSummary([cancelled, active], 10)).toEqual({
+      activeInvoice: active,
+      cancelledInvoices: [cancelled],
+    });
+  });
+
+  it("uses the newest reservation and orders cancellation history newest first", () => {
+    const olderActive = makeInvoice({
+      invoiceId: 1,
+      reservationId: 100,
+      status: "pending",
+      createdAt: "2026-06-01T12:00:00.000Z",
+    });
+    const olderCancelled = makeInvoice({
+      invoiceId: 2,
+      reservationId: 101,
+      status: "rejected",
+      createdAt: "2026-06-02T12:00:00.000Z",
+    });
+    const newerCancelled = makeInvoice({
+      invoiceId: 3,
+      reservationId: 102,
+      status: "rejected",
+      createdAt: "2026-06-03T12:00:00.000Z",
+    });
+    const newerActive = makeInvoice({
+      invoiceId: 4,
+      reservationId: 103,
+      status: "verification_payment",
+      createdAt: "2026-06-04T12:00:00.000Z",
+    });
+
+    const summary = getStandReservationSummary(
+      [olderActive, olderCancelled, newerCancelled, newerActive],
+      10,
+    );
+
+    expect(summary.activeInvoice).toBe(newerActive);
+    expect(summary.cancelledInvoices).toEqual([newerCancelled, olderCancelled]);
+  });
+
+  it("ignores reservations assigned to another stand", () => {
+    const otherStand = makeInvoice({
+      invoiceId: 1,
+      reservationId: 100,
+      standId: 11,
+      status: "pending",
+      createdAt: "2026-06-01T12:00:00.000Z",
+    });
+
+    expect(getStandReservationSummary([otherStand], 10)).toEqual({
+      activeInvoice: null,
+      cancelledInvoices: [],
+    });
+  });
+});

--- a/app/components/maps/admin/admin-overview-reservations.ts
+++ b/app/components/maps/admin/admin-overview-reservations.ts
@@ -1,0 +1,40 @@
+import { InvoiceWithParticipants } from "@/app/data/invoices/definitions";
+
+export type StandReservationSummary = {
+  activeInvoice: InvoiceWithParticipants | null;
+  cancelledInvoices: InvoiceWithParticipants[];
+};
+
+function newestReservationFirst(
+  a: InvoiceWithParticipants,
+  b: InvoiceWithParticipants,
+) {
+  const createdAtDifference =
+    b.reservation.createdAt.getTime() - a.reservation.createdAt.getTime();
+
+  return createdAtDifference || b.reservation.id - a.reservation.id;
+}
+
+/**
+ * Keeps rejected reservations out of the stand's current state while retaining
+ * them as history. If inconsistent data contains more than one active
+ * reservation, the newest reservation wins deterministically.
+ */
+export function getStandReservationSummary(
+  invoices: InvoiceWithParticipants[],
+  standId: number,
+): StandReservationSummary {
+  const standInvoices = invoices
+    .filter((invoice) => invoice.reservation.standId === standId)
+    .sort(newestReservationFirst);
+
+  return {
+    activeInvoice:
+      standInvoices.find(
+        (invoice) => invoice.reservation.status !== "rejected",
+      ) ?? null,
+    cancelledInvoices: standInvoices.filter(
+      (invoice) => invoice.reservation.status === "rejected",
+    ),
+  };
+}

--- a/app/components/maps/admin/admin-overview-stand-drawer.tsx
+++ b/app/components/maps/admin/admin-overview-stand-drawer.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { ClockIcon, ExternalLinkIcon } from "lucide-react";
+import { ClockIcon, ExternalLinkIcon, HistoryIcon } from "lucide-react";
 
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
 import { InvoiceWithParticipants } from "@/app/data/invoices/definitions";
@@ -19,6 +19,7 @@ import {
 } from "@/app/components/ui/drawer";
 import { Button } from "@/app/components/ui/button";
 import { Avatar, AvatarImage } from "@/app/components/ui/avatar";
+import { Badge } from "@/app/components/ui/badge";
 import {
   Select,
   SelectContent,
@@ -31,6 +32,7 @@ import { cn } from "@/app/lib/utils";
 type AdminOverviewStandDrawerProps = {
   stand: StandWithReservationsWithParticipants | null;
   invoice: InvoiceWithParticipants | null;
+  cancelledInvoices: InvoiceWithParticipants[];
   sectorName: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -65,6 +67,7 @@ function formatPrice(amount: number) {
 export default function AdminOverviewStandDrawer({
   stand,
   invoice,
+  cancelledInvoices,
   sectorName,
   open,
   onOpenChange,
@@ -288,6 +291,43 @@ export default function AdminOverviewStandDrawer({
               <p className="text-sm text-muted-foreground text-center py-2">
                 Sin reserva activa
               </p>
+            )}
+
+            {cancelledInvoices.length > 0 && (
+              <div className="rounded-lg border p-4 space-y-3">
+                <div className="flex items-center gap-2">
+                  <HistoryIcon className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-sm font-medium">
+                    Historial de reservas
+                  </span>
+                </div>
+
+                <div className="divide-y">
+                  {cancelledInvoices.map((cancelledInvoice) => (
+                    <div
+                      key={cancelledInvoice.reservation.id}
+                      className="flex items-start justify-between gap-3 py-3 first:pt-0 last:pb-0"
+                    >
+                      <div className="min-w-0 space-y-0.5">
+                        <p className="text-sm font-medium">
+                          Reserva #{cancelledInvoice.reservation.id}
+                        </p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {cancelledInvoice.user.displayName}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {new Intl.DateTimeFormat("es-BO", {
+                            day: "numeric",
+                            month: "long",
+                            year: "numeric",
+                          }).format(cancelledInvoice.reservation.updatedAt)}
+                        </p>
+                      </div>
+                      <Badge variant="destructive">Cancelada</Badge>
+                    </div>
+                  ))}
+                </div>
+              </div>
             )}
           </div>
         </DrawerContent>

--- a/app/components/maps/admin/admin-overview-stand-drawer.tsx
+++ b/app/components/maps/admin/admin-overview-stand-drawer.tsx
@@ -251,6 +251,7 @@ export default function AdminOverviewStandDrawer({
                       className={cn("", isOverdue ? "text-destructive" : "")}
                     >
                       {new Intl.DateTimeFormat("es-BO", {
+                        timeZone: "America/La_Paz",
                         day: "numeric",
                         month: "long",
                         year: "numeric",
@@ -317,6 +318,7 @@ export default function AdminOverviewStandDrawer({
                         </p>
                         <p className="text-xs text-muted-foreground">
                           {new Intl.DateTimeFormat("es-BO", {
+                            timeZone: "America/La_Paz",
                             day: "numeric",
                             month: "long",
                             year: "numeric",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reservation history for stands, including cancelled reservations.
  * Map tooltips and stand details now show active reservation information or current stand status.
  * Cancelled reservations display their status, details, and dates, with a summary when multiple exist.
  * Stand reservation selection now prioritizes the most recent active reservation.

* **Bug Fixes**
  * Improved handling of stands without active invoices.
  * Ensured reservations are matched to the correct stand and displayed in consistent order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->