### PR TITLE
Glitter week additions

### DIFF
--- a/app/api/payments/route.ts
+++ b/app/api/payments/route.ts
@@ -1,6 +1,9 @@
 import { auth } from "@clerk/nextjs/server";
 import { createPayment } from "@/app/data/invoices/actions";
-import { getPostHogClient } from "@/app/lib/posthog-server";
+import {
+  getPostHogClient,
+  POSTHOG_SHUTDOWN_TIMEOUT_MS,
+} from "@/app/lib/posthog-server";
 import { POSTHOG_EVENTS } from "@/app/lib/posthog-events";
 import { z } from "zod";
 
@@ -72,11 +75,7 @@ export async function POST(req: Request) {
         amount: data.amount,
       },
     });
-    // Bounded at 5s. `shutdown()` defaults to 30 seconds, and it is awaited
-    // before the response goes out — so an unreachable PostHog would stall the
-    // caller for half a minute and then, past `maxDuration`, hand them exactly
-    // the failed-upload error this block exists to prevent.
-    await posthog.shutdown(5000);
+    await posthog.shutdown(POSTHOG_SHUTDOWN_TIMEOUT_MS);
   } catch (telemetryError) {
     console.error("PostHog telemetry failed (payments)", telemetryError);
   }

--- a/app/components/dashboard/programs/occurrence-roster-table.test.tsx
+++ b/app/components/dashboard/programs/occurrence-roster-table.test.tsx
@@ -1,0 +1,212 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import OccurrenceRosterTable from "@/app/components/dashboard/programs/occurrence-roster-table";
+import OccurrenceSeatSummary from "@/app/components/dashboard/programs/occurrence-seat-summary";
+import type {
+  OccurrenceRosterSummary,
+  RosterEntry,
+} from "@/app/lib/programs/occurrence-queries";
+import { summarizeRoster } from "@/app/lib/programs/roster";
+
+afterEach(cleanup);
+
+function entry(overrides: Partial<RosterEntry> = {}): RosterEntry {
+  return {
+    lineId: 1,
+    purchaseId: 100,
+    state: "confirmed",
+    attendeeName: "Ana Quiroga",
+    attendeeEmail: "ana@example.com",
+    attendeePhone: null,
+    isGuest: false,
+    ticketCode: "ABC123",
+    unitPrice: 70,
+    isFree: false,
+    holdExpiresAt: null,
+    createdAt: new Date("2026-07-30T15:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+/**
+ * These shapes mirror what the probe returned from the dev database, so the
+ * table is exercised against the same rows an admin will actually see.
+ */
+describe("OccurrenceRosterTable", () => {
+  it("says so plainly when nobody has signed up", () => {
+    render(<OccurrenceRosterTable entries={[]} />);
+    expect(screen.getByText(/todavía nadie se inscribió/i)).toBeTruthy();
+  });
+
+  it("renders a confirmed attendee with their ticket and price", () => {
+    render(<OccurrenceRosterTable entries={[entry()]} />);
+
+    expect(screen.getByText("Ana Quiroga")).toBeTruthy();
+    expect(screen.getByText("ana@example.com")).toBeTruthy();
+    expect(screen.getByText("ABC123")).toBeTruthy();
+    expect(screen.getByText("Confirmado")).toBeTruthy();
+    expect(screen.getByText("Con cuenta")).toBeTruthy();
+    // Localized, not a bare number.
+    expect(screen.getByText("Bs 70,00")).toBeTruthy();
+  });
+
+  it("marks a guest and shows the phone only they provide", () => {
+    render(
+      <OccurrenceRosterTable
+        entries={[
+          entry({
+            isGuest: true,
+            attendeePhone: "+59171234567",
+            ticketCode: null,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Invitado")).toBeTruthy();
+    expect(screen.getByText("+59171234567")).toBeTruthy();
+    expect(screen.getByText("Sin emitir")).toBeTruthy();
+  });
+
+  it("shows a free registration as free rather than Bs 0", () => {
+    render(
+      <OccurrenceRosterTable
+        entries={[entry({ isFree: true, unitPrice: 0 })]}
+      />,
+    );
+    expect(screen.getByText("Gratis")).toBeTruthy();
+    expect(screen.queryByText(/Bs 0/)).toBeNull();
+  });
+
+  it("shows the deadline only while a hold is running", () => {
+    const { rerender } = render(
+      <OccurrenceRosterTable
+        entries={[
+          entry({
+            state: "holding",
+            ticketCode: null,
+            holdExpiresAt: new Date("2026-07-30T15:20:00.000Z"),
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText(/vence/i)).toBeTruthy();
+
+    // A lapsed hold arrives already resolved to `released`; no clock then.
+    rerender(
+      <OccurrenceRosterTable
+        entries={[
+          entry({
+            state: "released",
+            ticketCode: null,
+            holdExpiresAt: new Date("2026-07-30T14:00:00.000Z"),
+          }),
+        ]}
+      />,
+    );
+    expect(screen.queryByText(/vence/i)).toBeNull();
+    expect(screen.getByText("Liberado")).toBeTruthy();
+  });
+
+  it("keeps released rows rather than hiding the drop-off", () => {
+    render(
+      <OccurrenceRosterTable
+        entries={[
+          entry({ lineId: 1, attendeeName: "Confirmada" }),
+          entry({
+            lineId: 2,
+            state: "released",
+            attendeeName: "Abandonó",
+            ticketCode: null,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Confirmada")).toBeTruthy();
+    expect(screen.getByText("Abandonó")).toBeTruthy();
+  });
+
+  it("does not link the buyer's purchase page, which admins cannot open", () => {
+    // `resolvePurchaseAccess` grants only the owner or a valid token.
+    const { container } = render(
+      <OccurrenceRosterTable entries={[entry({ purchaseId: 42 })]} />,
+    );
+
+    expect(screen.getByText("#42")).toBeTruthy();
+    expect(
+      container.querySelector('a[href*="/programs/purchases/"]'),
+    ).toBeNull();
+  });
+});
+
+function summary(
+  overrides: Partial<OccurrenceRosterSummary> = {},
+): OccurrenceRosterSummary {
+  return {
+    occurrenceId: 71,
+    capacity: 20,
+    totals: summarizeRoster(["confirmed", "awaiting_review"]),
+    remaining: 18,
+    isSoldOut: false,
+    waitlistActive: 0,
+    ...overrides,
+  };
+}
+
+describe("OccurrenceSeatSummary", () => {
+  it("leads with what is left, not with the configured capacity", () => {
+    render(<OccurrenceSeatSummary summary={summary()} />);
+    expect(screen.getByText("18 de 20 disponibles")).toBeTruthy();
+    expect(screen.getByText("1 confirmados")).toBeTruthy();
+    expect(screen.getByText("1 por revisar")).toBeTruthy();
+  });
+
+  it("hides counts that are zero so the row stays readable", () => {
+    render(
+      <OccurrenceSeatSummary
+        summary={summary({ totals: summarizeRoster([]), remaining: 20 })}
+      />,
+    );
+
+    expect(screen.getByText("20 de 20 disponibles")).toBeTruthy();
+    expect(screen.queryByText(/confirmados/)).toBeNull();
+    expect(screen.queryByText(/por revisar/)).toBeNull();
+    expect(screen.queryByText(/en espera/)).toBeNull();
+  });
+
+  it("flags a sold-out occurrence and its waiting list", () => {
+    render(
+      <OccurrenceSeatSummary
+        summary={summary({
+          totals: summarizeRoster(Array(20).fill("confirmed")),
+          remaining: 0,
+          isSoldOut: true,
+          waitlistActive: 3,
+        })}
+      />,
+    );
+
+    expect(screen.getByText("0 de 20 disponibles")).toBeTruthy();
+    expect(screen.getByText("3 en espera")).toBeTruthy();
+  });
+
+  it("links to the roster only when given a destination", () => {
+    const { container, rerender } = render(
+      <OccurrenceSeatSummary summary={summary()} />,
+    );
+    expect(screen.queryByText("Ver inscritos")).toBeNull();
+
+    rerender(
+      <OccurrenceSeatSummary
+        summary={summary()}
+        href="/dashboard/programs/occurrences/71"
+      />,
+    );
+    const link = within(container).getByText("Ver inscritos");
+    expect(link.closest("a")?.getAttribute("href")).toBe(
+      "/dashboard/programs/occurrences/71",
+    );
+  });
+});

--- a/app/components/dashboard/programs/occurrence-roster-table.test.tsx
+++ b/app/components/dashboard/programs/occurrence-roster-table.test.tsx
@@ -159,8 +159,23 @@ describe("OccurrenceSeatSummary", () => {
   it("leads with what is left, not with the configured capacity", () => {
     render(<OccurrenceSeatSummary summary={summary()} />);
     expect(screen.getByText("18 de 20 disponibles")).toBeTruthy();
-    expect(screen.getByText("1 confirmados")).toBeTruthy();
+    expect(screen.getByText("1 confirmado")).toBeTruthy();
     expect(screen.getByText("1 por revisar")).toBeTruthy();
+  });
+
+  it("inflects the confirmed count", () => {
+    const { rerender } = render(<OccurrenceSeatSummary summary={summary()} />);
+    expect(screen.getByText("1 confirmado")).toBeTruthy();
+
+    rerender(
+      <OccurrenceSeatSummary
+        summary={summary({
+          totals: summarizeRoster(["confirmed", "confirmed"]),
+          remaining: 18,
+        })}
+      />,
+    );
+    expect(screen.getByText("2 confirmados")).toBeTruthy();
   });
 
   it("hides counts that are zero so the row stays readable", () => {
@@ -171,7 +186,7 @@ describe("OccurrenceSeatSummary", () => {
     );
 
     expect(screen.getByText("20 de 20 disponibles")).toBeTruthy();
-    expect(screen.queryByText(/confirmados/)).toBeNull();
+    expect(screen.queryByText(/confirmado/)).toBeNull();
     expect(screen.queryByText(/por revisar/)).toBeNull();
     expect(screen.queryByText(/en espera/)).toBeNull();
   });

--- a/app/components/dashboard/programs/occurrence-roster-table.tsx
+++ b/app/components/dashboard/programs/occurrence-roster-table.tsx
@@ -1,0 +1,127 @@
+import { DateTime } from "luxon";
+
+import { Badge, type BadgeVariant } from "@/app/components/ui/badge";
+import { formatDate } from "@/app/lib/formatters";
+import type { RosterEntry } from "@/app/lib/programs/occurrence-queries";
+import { formatMoney } from "@/app/lib/programs/pricing";
+import {
+  ROSTER_SEAT_STATE_LABELS,
+  type RosterSeatState,
+} from "@/app/lib/programs/roster";
+
+const STATE_VARIANT: Record<RosterSeatState, BadgeVariant> = {
+  confirmed: "green",
+  awaiting_review: "amber",
+  changes_requested: "orange",
+  holding: "secondary",
+  released: "outline",
+};
+
+type Props = {
+  entries: RosterEntry[];
+};
+
+/**
+ * Who has a seat in one occurrence.
+ *
+ * Released rows are kept rather than filtered out. They are the record of
+ * people who started and did not finish — the drop-off between "reservando"
+ * and "confirmado" is the first place to look when a payment step is failing,
+ * and an admin chasing a specific person needs to find them whatever became of
+ * their purchase.
+ */
+export default function OccurrenceRosterTable({ entries }: Props) {
+  if (entries.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Todavía nadie se inscribió a este horario.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[42rem] text-sm">
+        <thead>
+          <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+            <th className="px-2 py-2 font-medium">Persona</th>
+            <th className="px-2 py-2 font-medium">Estado</th>
+            <th className="px-2 py-2 font-medium">Entrada</th>
+            <th className="px-2 py-2 font-medium">Monto</th>
+            <th className="px-2 py-2 font-medium">Inscripción</th>
+            <th className="px-2 py-2 font-medium">Compra</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry) => (
+            <tr
+              key={entry.lineId}
+              className="border-b border-border/60 last:border-b-0 align-top"
+            >
+              <td className="px-2 py-3">
+                <p className="font-medium">{entry.attendeeName}</p>
+                <p className="text-xs text-muted-foreground">
+                  {entry.attendeeEmail}
+                </p>
+                {entry.attendeePhone ? (
+                  <p className="text-xs text-muted-foreground">
+                    {entry.attendeePhone}
+                  </p>
+                ) : null}
+                <p className="text-xs text-muted-foreground">
+                  {entry.isGuest ? "Invitado" : "Con cuenta"}
+                </p>
+              </td>
+              <td className="px-2 py-3">
+                <Badge variant={STATE_VARIANT[entry.state]}>
+                  {ROSTER_SEAT_STATE_LABELS[entry.state]}
+                </Badge>
+                {/* Only meaningful while the clock is running; a lapsed hold
+                    already reads as "Liberado". */}
+                {entry.state === "holding" && entry.holdExpiresAt ? (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Vence{" "}
+                    {formatDate(entry.holdExpiresAt).toLocaleString(
+                      DateTime.TIME_SIMPLE,
+                    )}
+                  </p>
+                ) : null}
+              </td>
+              <td className="px-2 py-3">
+                {entry.ticketCode ? (
+                  <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                    {entry.ticketCode}
+                  </code>
+                ) : (
+                  <span className="text-xs text-muted-foreground">
+                    Sin emitir
+                  </span>
+                )}
+              </td>
+              <td className="px-2 py-3 whitespace-nowrap">
+                {entry.isFree ? (
+                  <span className="text-xs text-muted-foreground">Gratis</span>
+                ) : (
+                  formatMoney(entry.unitPrice)
+                )}
+              </td>
+              <td className="px-2 py-3 whitespace-nowrap text-xs text-muted-foreground">
+                {formatDate(entry.createdAt).toLocaleString(
+                  DateTime.DATETIME_MED,
+                )}
+              </td>
+              {/* Not a link: `/programs/purchases/[id]` is the buyer's page and
+                  `resolvePurchaseAccess` grants only the owner or a valid
+                  token — there is no admin bypass, so linking there would send
+                  the team to a denied page. The id is here to correlate with
+                  the review queue and with support actions. */}
+              <td className="px-2 py-3 text-xs text-muted-foreground">
+                #{entry.purchaseId}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/components/dashboard/programs/occurrence-row.tsx
+++ b/app/components/dashboard/programs/occurrence-row.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 
 import OccurrenceActionsMenu from "@/app/components/dashboard/programs/occurrence-actions-menu";
 import OccurrenceForm from "@/app/components/dashboard/programs/occurrence-form";
+import OccurrenceSeatSummary from "@/app/components/dashboard/programs/occurrence-seat-summary";
 import ProgramStatusBadge from "@/app/components/programs/program-status-badge";
 import { Button } from "@/app/components/ui/button";
 import { formatDate } from "@/app/lib/formatters";
@@ -13,6 +14,7 @@ import type {
   SessionOccurrence,
   Venue,
 } from "@/app/lib/programs/definitions";
+import type { OccurrenceRosterSummary } from "@/app/lib/programs/occurrence-queries";
 import { resolveOccurrenceState } from "@/app/lib/programs/state";
 
 type Props = {
@@ -21,6 +23,8 @@ type Props = {
   defaultCapacity: number;
   programStatus: ProgramStatus;
   sessionStatus: ProgramStatus;
+  /** Absent only if the summary query missed this occurrence. */
+  summary?: OccurrenceRosterSummary;
 };
 
 /**
@@ -38,6 +42,7 @@ export default function OccurrenceRow({
   defaultCapacity,
   programStatus,
   sessionStatus,
+  summary,
 }: Props) {
   const [isEditing, setIsEditing] = useState(false);
 
@@ -68,8 +73,7 @@ export default function OccurrenceRow({
             {formatDate(occurrence.endsAt).toLocaleString(DateTime.TIME_SIMPLE)}
           </p>
           <p className="text-xs text-muted-foreground">
-            {occurrence.capacity} cupos
-            {venue ? ` · ${venue.name}` : ""}
+            {venue ? venue.name : "Sin lugar asignado"}
             {occurrence.room ? ` · ${occurrence.room}` : ""}
           </p>
           {occurrence.cancelledReason ? (
@@ -83,6 +87,13 @@ export default function OccurrenceRow({
           wasRescheduled={resolved.wasRescheduled}
         />
       </div>
+
+      {summary ? (
+        <OccurrenceSeatSummary
+          summary={summary}
+          href={`/dashboard/programs/occurrences/${occurrence.id}`}
+        />
+      ) : null}
 
       {isEditing ? (
         <div className="space-y-3 border-t border-border/70 pt-3">

--- a/app/components/dashboard/programs/occurrence-seat-summary.tsx
+++ b/app/components/dashboard/programs/occurrence-seat-summary.tsx
@@ -28,8 +28,13 @@ export default function OccurrenceSeatSummary({ summary, href }: Props) {
         {remaining} de {capacity} disponibles
       </Badge>
 
+      {/* The only count here whose noun inflects — "reservando", "por revisar"
+          and "en espera" read the same at any number. */}
       {totals.confirmed > 0 ? (
-        <Badge variant="outline">{totals.confirmed} confirmados</Badge>
+        <Badge variant="outline">
+          {totals.confirmed}{" "}
+          {totals.confirmed === 1 ? "confirmado" : "confirmados"}
+        </Badge>
       ) : null}
 
       {/* The only count that is a to-do list, so it is the only one that

--- a/app/components/dashboard/programs/occurrence-seat-summary.tsx
+++ b/app/components/dashboard/programs/occurrence-seat-summary.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+
+import { Badge } from "@/app/components/ui/badge";
+import type { OccurrenceRosterSummary } from "@/app/lib/programs/occurrence-queries";
+
+type Props = {
+  summary: OccurrenceRosterSummary;
+  /** Omitted on the detail page itself, which is where the link would go. */
+  href?: string;
+};
+
+/**
+ * The seat line for one occurrence: what is sold, what needs attention, and
+ * what is left.
+ *
+ * This replaced a bare `20 cupos` — the configured capacity, which told an
+ * admin nothing about whether the session had sold nothing or sold out. Every
+ * number here comes from `fetchOccurrenceSummaries`, which derives them from
+ * the same `resolveAvailability` the public pages use, so what an admin reads
+ * is what a buyer is allowed to take.
+ */
+export default function OccurrenceSeatSummary({ summary, href }: Props) {
+  const { totals, capacity, remaining, waitlistActive, isSoldOut } = summary;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <Badge variant={isSoldOut ? "red" : "green"}>
+        {remaining} de {capacity} disponibles
+      </Badge>
+
+      {totals.confirmed > 0 ? (
+        <Badge variant="outline">{totals.confirmed} confirmados</Badge>
+      ) : null}
+
+      {/* The only count that is a to-do list, so it is the only one that
+          shouts. Everything else is context. */}
+      {totals.needsAction > 0 ? (
+        <Badge variant="amber">{totals.needsAction} por revisar</Badge>
+      ) : null}
+
+      {totals.holding > 0 ? (
+        <Badge variant="outline">{totals.holding} reservando</Badge>
+      ) : null}
+
+      {waitlistActive > 0 ? (
+        <Badge variant="secondary">{waitlistActive} en espera</Badge>
+      ) : null}
+
+      {href ? (
+        <Link
+          href={href}
+          className="text-xs font-medium text-primary underline-offset-2 hover:underline"
+        >
+          Ver inscritos
+        </Link>
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/dashboard/programs/purchase-review-card.tsx
+++ b/app/components/dashboard/programs/purchase-review-card.tsx
@@ -23,7 +23,10 @@ import {
   cancelPurchaseAsAdmin,
   resendPurchaseLink,
 } from "@/app/lib/programs/support-actions";
-import type { ReviewDecision } from "@/app/lib/programs/review";
+import {
+  reviewDecisionRequiresReason,
+  type ReviewDecision,
+} from "@/app/lib/programs/review";
 
 type Props = {
   purchaseId: number;
@@ -66,7 +69,7 @@ export default function PurchaseReviewCard({
   const previous = vouchers.slice(1);
 
   async function decide(decision: ReviewDecision) {
-    if (reason.trim().length < 3) {
+    if (reviewDecisionRequiresReason(decision) && reason.trim().length < 3) {
       toast.error("Escribe el motivo de tu decisión");
       return;
     }
@@ -207,7 +210,9 @@ export default function PurchaseReviewCard({
         ) : null}
 
         <div className="space-y-1">
-          <Label htmlFor={`reason-${purchaseId}`}>Motivo</Label>
+          <Label htmlFor={`reason-${purchaseId}`}>
+            Motivo (opcional al aprobar)
+          </Label>
           <Textarea
             id={`reason-${purchaseId}`}
             value={reason}

--- a/app/components/festivals/client-map.tsx
+++ b/app/components/festivals/client-map.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 import { Loader2Icon } from "lucide-react";
 
 import { ProfileType } from "@/app/api/users/definitions";
@@ -11,6 +18,7 @@ import UserMap from "@/app/components/maps/user/user-map";
 import { StandInfoCard } from "@/app/components/festivals/reservations/stand-info-card";
 import { useStandPolling } from "@/app/hooks/use-stand-polling";
 import { getActiveHold } from "@/app/lib/stands/hold-actions";
+import { findJointGroup } from "@/app/lib/stands/groups";
 
 type ActiveHold = { id: number; standId: number } | null;
 
@@ -52,6 +60,10 @@ export default function ClientMap({
     selectedStandId != null
       ? (stands.find((s) => s.id === selectedStandId) ?? null)
       : null;
+  const selectedGroupStands = useMemo(
+    () => findJointGroup(stands, selectedStandId)?.stands,
+    [stands, selectedStandId],
+  );
   const [activeHold, setActiveHold] = useState<ActiveHold>(
     initialActiveHold ?? null,
   );
@@ -133,6 +145,7 @@ export default function ClientMap({
           key={selectedStand.id}
           stand={selectedStand}
           sectorName={sectorName}
+          groupStands={selectedGroupStands}
           profile={profile}
           festival={festival}
           activeHold={activeHold}

--- a/app/components/festivals/reservations/hold-confirmation-client.tsx
+++ b/app/components/festivals/reservations/hold-confirmation-client.tsx
@@ -463,7 +463,7 @@ export default function HoldConfirmationClient({
                     Stand seleccionado
                   </p>
                   <p className="text-lg font-bold text-primary">
-                    Stand #{formatStandLabel(stand)}
+                    Stand {formatStandLabel(stand)}
                   </p>
                 </div>
                 <div>

--- a/app/components/festivals/reservations/stand-info-card.tsx
+++ b/app/components/festivals/reservations/stand-info-card.tsx
@@ -13,7 +13,8 @@ import { Badge } from "@/app/components/ui/badge";
 import { Button } from "@/app/components/ui/button";
 import { profileHasReservation } from "@/app/helpers/next_event";
 import { FestivalBase } from "@/app/lib/festivals/definitions";
-import { canStandBeReserved, formatStandLabel } from "@/app/lib/stands/helpers";
+import { canStandBeReserved } from "@/app/lib/stands/helpers";
+import { formatStandsLabel } from "@/app/lib/stands/groups";
 import { toast } from "sonner";
 
 type ActiveHold = { id: number; standId: number } | null;
@@ -21,6 +22,11 @@ type ActiveHold = { id: number; standId: number } | null;
 type StandInfoCardProps = {
   stand: StandWithReservationsWithParticipants;
   sectorName: string;
+  /**
+   * Every stand of the joint group that was tapped, when the stand belongs to
+   * one. Defaults to just the tapped stand.
+   */
+  groupStands?: StandWithReservationsWithParticipants[];
   profile: ProfileType;
   festival: FestivalBase;
   activeHold?: ActiveHold;
@@ -88,6 +94,7 @@ function getEligibilityMessage(
 export function StandInfoCard({
   stand,
   sectorName,
+  groupStands,
   profile,
   festival,
   activeHold,
@@ -135,6 +142,9 @@ export function StandInfoCard({
     }).format(price);
 
   const dimensions = getStandDimensions(stand.standCategory);
+  // Groups only form on stands somebody already holds, so this card never shows
+  // a joined unit as reservable — only its label widens to name both stands.
+  const cardStands = groupStands?.length ? groupStands : [stand];
 
   const handleSelectStand = () => {
     if (!canReserve || isPending) return;
@@ -203,7 +213,8 @@ export function StandInfoCard({
               </div>
               <div className="flex items-baseline gap-2">
                 <h4 className="text-xl font-bold">
-                  Stand #{formatStandLabel(stand)}
+                  {cardStands.length > 1 ? "Stands" : "Stand"}{" "}
+                  {formatStandsLabel(cardStands)}
                 </h4>
                 <span className="text-sm sm:text-base text-muted-foreground">
                   <span className="hidden sm:block">Sector</span> {sectorName}

--- a/app/components/festivals/terms-form.tsx
+++ b/app/components/festivals/terms-form.tsx
@@ -1,5 +1,8 @@
 "use client";
-import { captureClientEvent, identifyClientUser } from "@/app/lib/posthog-capture";
+import {
+  captureClientEvent,
+  identifyClientUser,
+} from "@/app/lib/posthog-capture";
 import { POSTHOG_EVENTS } from "@/app/lib/posthog-events";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";

--- a/app/components/maps/admin/admin-map-canvas.tsx
+++ b/app/components/maps/admin/admin-map-canvas.tsx
@@ -13,6 +13,7 @@ import { MapElementBase } from "@/app/lib/map_elements/definitions";
 import MapCanvas from "@/app/components/maps/map-canvas";
 import DraggableMapStand from "./draggable-map-stand";
 import DraggableMapElement from "./draggable-map-element";
+import AdminMapStandGroups from "./admin-map-stand-groups";
 import { STAND_SIZE } from "../map-utils";
 
 export type GuideLine = {
@@ -644,6 +645,8 @@ const AdminMapCanvas = forwardRef<AdminMapCanvasHandle, AdminMapCanvasProps>(
             />
           );
         })}
+        {/* Group outlines sit behind the stands they enclose */}
+        <AdminMapStandGroups stands={stands} positions={positions} />
         {stands.map((stand) => {
           const pos = positions.get(stand.id);
           if (!pos) return null;

--- a/app/components/maps/admin/admin-map-stand-groups.test.tsx
+++ b/app/components/maps/admin/admin-map-stand-groups.test.tsx
@@ -1,0 +1,112 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import AdminMapStandGroups from "@/app/components/maps/admin/admin-map-stand-groups";
+import type { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+
+afterEach(cleanup);
+
+function stand(
+  id: number,
+  groupId: number | null,
+): StandWithReservationsWithParticipants {
+  // The editor reads live positions from the map, never from the stand row
+  return { id, standGroupId: groupId } as StandWithReservationsWithParticipants;
+}
+
+function renderGroups(
+  stands: StandWithReservationsWithParticipants[],
+  positions: [number, { left: number; top: number }][],
+) {
+  const { container } = render(
+    <svg>
+      <AdminMapStandGroups stands={stands} positions={new Map(positions)} />
+    </svg>,
+  );
+  return container;
+}
+
+describe("AdminMapStandGroups", () => {
+  it("draws nothing when no stand is grouped", () => {
+    const container = renderGroups(
+      [stand(1, null), stand(2, null)],
+      [
+        [1, { left: 0, top: 0 }],
+        [2, { left: 8.7, top: 0 }],
+      ],
+    );
+    expect(container.querySelectorAll("rect")).toHaveLength(0);
+  });
+
+  it("outlines a declared group even before anyone occupies it", () => {
+    const container = renderGroups(
+      [stand(1, 10), stand(2, 10)],
+      [
+        [1, { left: 69.8, top: 84.5 }],
+        [2, { left: 78.5, top: 84.5 }],
+      ],
+    );
+
+    const rect = container.querySelector("rect");
+    expect(rect).toBeTruthy();
+    // Union of both 6x6 stands, padded by 1 on every side
+    expect(Number(rect?.getAttribute("x"))).toBeCloseTo(68.8, 5);
+    expect(Number(rect?.getAttribute("y"))).toBeCloseTo(83.5, 5);
+    expect(Number(rect?.getAttribute("width"))).toBeCloseTo(16.7, 5);
+    expect(Number(rect?.getAttribute("height"))).toBeCloseTo(8, 5);
+    expect(container.textContent).toBe("");
+  });
+
+  it("flags a group whose members were dragged out of line", () => {
+    const container = renderGroups(
+      [stand(1, 10), stand(2, 10)],
+      [
+        [1, { left: 69.8, top: 84.5 }],
+        [2, { left: 78.5, top: 95 }],
+      ],
+    );
+
+    expect(container.textContent).toContain("sin alinear");
+  });
+
+  it("follows the live drag position rather than the stored one", () => {
+    const container = renderGroups(
+      [stand(1, 10), stand(2, 10)],
+      [
+        [1, { left: 0, top: 0 }],
+        [2, { left: 8.7, top: 0 }],
+      ],
+    );
+
+    expect(Number(container.querySelector("rect")?.getAttribute("x"))).toBe(-1);
+  });
+
+  it("ignores a group with only one member on the canvas", () => {
+    const container = renderGroups([stand(1, 10)], [[1, { left: 0, top: 0 }]]);
+    expect(container.querySelectorAll("rect")).toHaveLength(0);
+  });
+
+  it("keeps separate groups in separate outlines", () => {
+    const container = renderGroups(
+      [stand(1, 10), stand(2, 10), stand(3, 11), stand(4, 11)],
+      [
+        [1, { left: 0, top: 0 }],
+        [2, { left: 8.7, top: 0 }],
+        [3, { left: 0, top: 20 }],
+        [4, { left: 8.7, top: 20 }],
+      ],
+    );
+    expect(container.querySelectorAll("rect")).toHaveLength(2);
+  });
+
+  it("never intercepts pointer events meant for the stands", () => {
+    const container = renderGroups(
+      [stand(1, 10), stand(2, 10)],
+      [
+        [1, { left: 0, top: 0 }],
+        [2, { left: 8.7, top: 0 }],
+      ],
+    );
+    expect(container.querySelector("g")?.style.pointerEvents).toBe("none");
+  });
+});

--- a/app/components/maps/admin/admin-map-stand-groups.test.tsx
+++ b/app/components/maps/admin/admin-map-stand-groups.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import AdminMapStandGroups from "@/app/components/maps/admin/admin-map-stand-groups";
@@ -67,6 +67,21 @@ describe("AdminMapStandGroups", () => {
     );
 
     expect(container.textContent).toContain("sin alinear");
+    expect(
+      screen.getByRole("img", { name: "Grupo 10 sin alinear" }),
+    ).toBeTruthy();
+  });
+
+  it("leaves aligned groups unnamed for assistive tech", () => {
+    renderGroups(
+      [stand(1, 10), stand(2, 10)],
+      [
+        [1, { left: 69.8, top: 84.5 }],
+        [2, { left: 78.5, top: 84.5 }],
+      ],
+    );
+
+    expect(screen.queryByRole("img")).toBeNull();
   });
 
   it("follows the live drag position rather than the stored one", () => {

--- a/app/components/maps/admin/admin-map-stand-groups.tsx
+++ b/app/components/maps/admin/admin-map-stand-groups.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import { STAND_SIZE } from "@/app/components/maps/map-utils";
+import { resolveJointAxis } from "@/app/lib/stands/groups";
+
+type AdminMapStandGroupsProps = {
+  stands: StandWithReservationsWithParticipants[];
+  /** Live editor positions, so the outline follows stands while dragging */
+  positions: Map<number, { left: number; top: number }>;
+};
+
+const PADDING = 1;
+const CORNER_RADIUS = 1.4;
+
+const ALIGNED_STROKE = "rgba(139, 92, 246, 0.9)"; // violet-500
+const MISALIGNED_STROKE = "rgba(217, 119, 6, 0.95)"; // amber-600
+
+type GroupOutline = {
+  id: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  aligned: boolean;
+};
+
+function buildOutlines(
+  stands: StandWithReservationsWithParticipants[],
+  positions: Map<number, { left: number; top: number }>,
+): GroupOutline[] {
+  const byGroupId = new Map<number, { left: number; top: number }[]>();
+  for (const stand of stands) {
+    if (stand.standGroupId == null) continue;
+    const position = positions.get(stand.id);
+    if (!position) continue;
+    const members = byGroupId.get(stand.standGroupId) ?? [];
+    members.push(position);
+    byGroupId.set(stand.standGroupId, members);
+  }
+
+  const outlines: GroupOutline[] = [];
+  for (const [id, members] of byGroupId) {
+    if (members.length < 2) continue;
+
+    const lefts = members.map((m) => m.left);
+    const tops = members.map((m) => m.top);
+    const x = Math.min(...lefts);
+    const y = Math.min(...tops);
+
+    outlines.push({
+      id,
+      x: x - PADDING,
+      y: y - PADDING,
+      width: Math.max(...lefts) + STAND_SIZE - x + PADDING * 2,
+      height: Math.max(...tops) + STAND_SIZE - y + PADDING * 2,
+      aligned:
+        resolveJointAxis(
+          members.map((m) => ({ positionLeft: m.left, positionTop: m.top })),
+        ) !== null,
+    });
+  }
+
+  return outlines;
+}
+
+/**
+ * Marks admin-declared stand groups in the map editor. The editor is the only
+ * place a group can be broken — dragging a member out of line stops the public
+ * map from ever drawing it joined — so misaligned groups are called out amber.
+ */
+export default function AdminMapStandGroups({
+  stands,
+  positions,
+}: AdminMapStandGroupsProps) {
+  const outlines = buildOutlines(stands, positions);
+  if (outlines.length === 0) return null;
+
+  return (
+    <g aria-hidden="true" style={{ pointerEvents: "none" }}>
+      {outlines.map((outline) => (
+        <g key={`group-${outline.id}`}>
+          <rect
+            x={outline.x}
+            y={outline.y}
+            width={outline.width}
+            height={outline.height}
+            rx={CORNER_RADIUS}
+            fill="none"
+            stroke={outline.aligned ? ALIGNED_STROKE : MISALIGNED_STROKE}
+            strokeWidth={0.25}
+            strokeDasharray={outline.aligned ? "1,0.6" : "0.6,0.5"}
+          />
+          {!outline.aligned && (
+            <text
+              x={outline.x + 0.4}
+              y={outline.y - 0.6}
+              fontSize={1.6}
+              fontWeight={700}
+              fill={MISALIGNED_STROKE}
+              style={{ userSelect: "none" }}
+            >
+              ⚠ sin alinear
+            </text>
+          )}
+        </g>
+      ))}
+    </g>
+  );
+}

--- a/app/components/maps/admin/admin-map-stand-groups.tsx
+++ b/app/components/maps/admin/admin-map-stand-groups.tsx
@@ -77,9 +77,15 @@ export default function AdminMapStandGroups({
   if (outlines.length === 0) return null;
 
   return (
-    <g aria-hidden="true" style={{ pointerEvents: "none" }}>
+    <g style={{ pointerEvents: "none" }}>
       {outlines.map((outline) => (
-        <g key={`group-${outline.id}`}>
+        <g
+          key={`group-${outline.id}`}
+          role={outline.aligned ? undefined : "img"}
+          aria-label={
+            outline.aligned ? undefined : `Grupo ${outline.id} sin alinear`
+          }
+        >
           <rect
             x={outline.x}
             y={outline.y}
@@ -98,6 +104,7 @@ export default function AdminMapStandGroups({
               fontSize={1.6}
               fontWeight={700}
               fill={MISALIGNED_STROKE}
+              aria-hidden="true"
               style={{ userSelect: "none" }}
             >
               ⚠ sin alinear

--- a/app/components/maps/admin/admin-overview-map.tsx
+++ b/app/components/maps/admin/admin-overview-map.tsx
@@ -367,6 +367,10 @@ export default function AdminOverviewMap({
         <MapSurface
           stands={visibleStands}
           mapElements={activeSector?.mapElements ?? []}
+          // Stand color here encodes each stand's own payment state, which two
+          // members of a group can disagree on. Joining them would show only
+          // the first member's status.
+          joinGroups={false}
           getColors={(stand) =>
             getAdminOverviewColors(
               stand.status,

--- a/app/components/maps/admin/admin-overview-map.tsx
+++ b/app/components/maps/admin/admin-overview-map.tsx
@@ -2,21 +2,14 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { DateTime } from "luxon";
-import { TransformComponent } from "react-zoom-pan-pinch";
-import { MapPin } from "lucide-react";
 
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
 import { InvoiceWithParticipants } from "@/app/data/invoices/definitions";
 import { FestivalSectorWithStandsWithReservationsWithParticipants } from "@/app/lib/festival_sectors/definitions";
-import {
-  computeCanvasBounds,
-  getAdminOverviewColors,
-} from "@/app/components/maps/map-utils";
-import MapCanvas from "@/app/components/maps/map-canvas";
-import MapStand from "@/app/components/maps/map-stand";
-import MapElement from "@/app/components/maps/map-element";
+import { getAdminOverviewColors } from "@/app/components/maps/map-utils";
+import MapSurface from "@/app/components/maps/map-surface";
 import MapToolbar from "@/app/components/maps/map-toolbar";
-import MapTransformWrapper from "@/app/components/maps/map-transform-wrapper";
+import ZoomableMapFrame from "@/app/components/maps/zoomable-map-frame";
 import AdminOverviewStandDrawer from "@/app/components/maps/admin/admin-overview-stand-drawer";
 import AdminOverviewMapTooltip from "@/app/components/maps/admin/admin-overview-map-tooltip";
 import {
@@ -115,11 +108,6 @@ export default function AdminOverviewMap({
   }, []);
 
   const visibleStands = activeSector?.stands ?? [];
-
-  const canvasBounds = computeCanvasBounds(
-    activeSector?.stands ?? [],
-    activeSector?.mapElements ?? [],
-  );
 
   const reservationSummaries = useMemo(() => {
     const summaries = new Map<number, StandReservationSummary>();
@@ -366,64 +354,32 @@ export default function AdminOverviewMap({
       </div>
 
       {/* Map */}
-      <div className="flex flex-col items-center w-full">
-        <MapTransformWrapper
-          initialScale={1}
-          minScale={1}
-          maxScale={4}
-          centerOnInit
-        >
-          <div className="flex w-full max-w-125 items-center justify-between pb-2">
+      <ZoomableMapFrame
+        header={
+          <>
             <p className="text-sm text-muted-foreground font-medium">
               {activeSector?.name}
             </p>
             <MapToolbar />
-          </div>
-          <div className="relative w-full max-w-125 rounded-lg border bg-background shadow-sm overflow-hidden pb-8 md:pb-0">
-            <TransformComponent
-              wrapperStyle={{ width: "100%" }}
-              contentStyle={{ width: "100%" }}
-            >
-              <MapCanvas
-                config={{
-                  minX: canvasBounds.minX,
-                  minY: canvasBounds.minY,
-                  width: canvasBounds.width,
-                  height: canvasBounds.height,
-                }}
-              >
-                {activeSector?.mapElements.map((element) => (
-                  <MapElement key={`el-${element.id}`} element={element} />
-                ))}
-                {visibleStands.map((stand) => (
-                  <MapStand
-                    key={stand.id}
-                    stand={stand}
-                    canBeReserved={false}
-                    colors={getAdminOverviewColors(
-                      stand.status,
-                      getReservationStatus(stand.id),
-                      getIsOverdue(stand.id),
-                      hasExternalParticipants(stand),
-                    )}
-                    onClick={handleStandClick}
-                    onTouchTap={handleTouchTap}
-                    onHoverChange={handleHoverChange}
-                  />
-                ))}
-              </MapCanvas>
-            </TransformComponent>
-            <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 md:hidden">
-              <div className="flex items-center gap-1.5 rounded-full bg-gray-900/80 px-3 py-1.5 text-white backdrop-blur-sm">
-                <MapPin className="h-3 w-3" />
-                <span className="text-xs font-medium">
-                  Pellizca para ampliar
-                </span>
-              </div>
-            </div>
-          </div>
-        </MapTransformWrapper>
-      </div>
+          </>
+        }
+      >
+        <MapSurface
+          stands={visibleStands}
+          mapElements={activeSector?.mapElements ?? []}
+          getColors={(stand) =>
+            getAdminOverviewColors(
+              stand.status,
+              getReservationStatus(stand.id),
+              getIsOverdue(stand.id),
+              hasExternalParticipants(stand),
+            )
+          }
+          onStandClick={handleStandClick}
+          onStandTouchTap={handleTouchTap}
+          onStandHoverChange={handleHoverChange}
+        />
+      </ZoomableMapFrame>
 
       {/* Tooltip (hover for mouse, tap for simplified touch mode) */}
       {tooltipStand &&

--- a/app/components/maps/admin/stand-position-editor.tsx
+++ b/app/components/maps/admin/stand-position-editor.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/app/api/stands/actions";
 import { updateSectorMapBounds } from "@/app/lib/festival_sectors/actions";
 import { groupStands, ungroupStands } from "@/app/lib/stands/group-actions";
+import { getPrunedGroupIds } from "@/app/lib/stands/groups";
 import {
   MapElementBase,
   MapElementLabelPosition,
@@ -95,6 +96,20 @@ type StandPositionEditorProps = {
   festivalId: number;
   sectors: FestivalSectorWithStandsWithReservationsWithParticipants[];
 };
+
+/** Coordinates are floats, so treat sub-epsilon differences as unmoved */
+const POSITION_EPSILON = 0.01;
+
+function hasStandMoved(
+  position: { left: number; top: number } | undefined,
+  original: { left: number; top: number } | undefined,
+): boolean {
+  if (!position || !original) return false;
+  return (
+    Math.abs(original.left - position.left) > POSITION_EPSILON ||
+    Math.abs(original.top - position.top) > POSITION_EPSILON
+  );
+}
 
 function buildPositionsMap(
   sectors: FestivalSectorWithStandsWithReservationsWithParticipants[],
@@ -581,18 +596,38 @@ export default function StandPositionEditor({
     toast.success(result.message);
   }, [selectedStands, standsPerSector]);
 
-  /** Patches standGroupId locally so the editor reflects the change at once */
+  /**
+   * Patches standGroupId locally so the editor reflects the change at once.
+   *
+   * Mirrors pruneEmptyGroups on the server: moving stands out of a group can
+   * leave it with fewer than two members, in which case the server deletes it
+   * and the ON DELETE SET NULL foreign key clears whoever stayed behind. Those
+   * stands are never in `ids`, so they need clearing here too — otherwise they
+   * keep a group id that no longer exists and still offer "Separar".
+   */
   const applyGroupIdLocally = useCallback(
     (ids: number[], standGroupId: number | null) => {
       const affected = new Set(ids);
       setStandsPerSector((prev) => {
+        const prunedGroupIds = getPrunedGroupIds(
+          Array.from(prev.values()).flat(),
+          affected,
+        );
+
         const next = new Map(prev);
         for (const [sectorId, sectorStands] of next) {
           next.set(
             sectorId,
-            sectorStands.map((stand) =>
-              affected.has(stand.id) ? { ...stand, standGroupId } : stand,
-            ),
+            sectorStands.map((stand) => {
+              if (affected.has(stand.id)) return { ...stand, standGroupId };
+              if (
+                stand.standGroupId != null &&
+                prunedGroupIds.has(stand.standGroupId)
+              ) {
+                return { ...stand, standGroupId: null };
+              }
+              return stand;
+            }),
           );
         }
         return next;
@@ -605,6 +640,19 @@ export default function StandPositionEditor({
     if (selectedStands.size < 2) return;
 
     const ids = Array.from(selectedStands);
+
+    // groupStands validates alignment against the saved coordinates, so
+    // grouping stands that were only dragged into line would be rejected as
+    // misaligned while looking perfectly aligned on screen.
+    if (
+      ids.some((id) =>
+        hasStandMoved(positions.get(id), originalPositions.get(id)),
+      )
+    ) {
+      toast.error("Guarda los cambios antes de unir espacios");
+      return;
+    }
+
     setIsGrouping(true);
     const result = await groupStands(ids);
     setIsGrouping(false);
@@ -616,8 +664,9 @@ export default function StandPositionEditor({
 
     applyGroupIdLocally(ids, result.groupId);
     toast.success(result.message);
-  }, [selectedStands, applyGroupIdLocally]);
+  }, [selectedStands, applyGroupIdLocally, positions, originalPositions]);
 
+  // Ungrouping only clears standGroupId, so unsaved positions cannot affect it
   const handleUngroupStands = useCallback(async () => {
     if (selectedStands.size === 0) return;
 
@@ -887,14 +936,7 @@ export default function StandPositionEditor({
   };
 
   const changedStandCount = Array.from(positions.entries()).filter(
-    ([id, pos]) => {
-      const orig = originalPositions.get(id);
-      if (!orig) return false;
-      return (
-        Math.abs(orig.left - pos.left) > 0.01 ||
-        Math.abs(orig.top - pos.top) > 0.01
-      );
-    },
+    ([id, pos]) => hasStandMoved(pos, originalPositions.get(id)),
   ).length;
 
   const changedElementCount =

--- a/app/components/maps/admin/stand-position-editor.tsx
+++ b/app/components/maps/admin/stand-position-editor.tsx
@@ -654,16 +654,24 @@ export default function StandPositionEditor({
     }
 
     setIsGrouping(true);
-    const result = await groupStands(ids);
-    setIsGrouping(false);
+    try {
+      const result = await groupStands(ids);
 
-    if (!result.success || result.groupId == null) {
-      toast.error(result.message);
-      return;
+      if (!result.success || result.groupId == null) {
+        toast.error(result.message);
+        return;
+      }
+
+      applyGroupIdLocally(ids, result.groupId);
+      toast.success(result.message);
+    } catch (error) {
+      // The action reports its own failures, so reaching here means the call
+      // itself never completed
+      console.error("Error grouping stands", error);
+      toast.error("Error al unir los espacios");
+    } finally {
+      setIsGrouping(false);
     }
-
-    applyGroupIdLocally(ids, result.groupId);
-    toast.success(result.message);
   }, [selectedStands, applyGroupIdLocally, positions, originalPositions]);
 
   // Ungrouping only clears standGroupId, so unsaved positions cannot affect it
@@ -672,16 +680,24 @@ export default function StandPositionEditor({
 
     const ids = Array.from(selectedStands);
     setIsGrouping(true);
-    const result = await ungroupStands(ids);
-    setIsGrouping(false);
+    try {
+      const result = await ungroupStands(ids);
 
-    if (!result.success) {
-      toast.error(result.message);
-      return;
+      if (!result.success) {
+        toast.error(result.message);
+        return;
+      }
+
+      applyGroupIdLocally(ids, null);
+      toast.success(result.message);
+    } catch (error) {
+      // The action reports its own failures, so reaching here means the call
+      // itself never completed
+      console.error("Error ungrouping stands", error);
+      toast.error("Error al separar los espacios");
+    } finally {
+      setIsGrouping(false);
     }
-
-    applyGroupIdLocally(ids, null);
-    toast.success(result.message);
   }, [selectedStands, applyGroupIdLocally]);
 
   // --- Element add/delete/edit ---

--- a/app/components/maps/admin/stand-position-editor.tsx
+++ b/app/components/maps/admin/stand-position-editor.tsx
@@ -16,6 +16,7 @@ import {
   AlignVerticalSpaceAround,
   Download,
   Grid3x3,
+  Link2,
   ListTree,
   Magnet,
   MapPin,
@@ -27,6 +28,7 @@ import {
   Save,
   Trash2,
   Undo2,
+  Unlink,
   Upload,
   ZoomIn,
   ZoomOut,
@@ -42,6 +44,7 @@ import {
   updateStandPositions,
 } from "@/app/api/stands/actions";
 import { updateSectorMapBounds } from "@/app/lib/festival_sectors/actions";
+import { groupStands, ungroupStands } from "@/app/lib/stands/group-actions";
 import {
   MapElementBase,
   MapElementLabelPosition,
@@ -270,6 +273,7 @@ export default function StandPositionEditor({
   >("disabled");
   const [isAdding, setIsAdding] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isGrouping, setIsGrouping] = useState(false);
 
   // Edit stand dialog state
   const [editDialogOpen, setEditDialogOpen] = useState(false);
@@ -576,6 +580,60 @@ export default function StandPositionEditor({
     setFocusedStandId(null);
     toast.success(result.message);
   }, [selectedStands, standsPerSector]);
+
+  /** Patches standGroupId locally so the editor reflects the change at once */
+  const applyGroupIdLocally = useCallback(
+    (ids: number[], standGroupId: number | null) => {
+      const affected = new Set(ids);
+      setStandsPerSector((prev) => {
+        const next = new Map(prev);
+        for (const [sectorId, sectorStands] of next) {
+          next.set(
+            sectorId,
+            sectorStands.map((stand) =>
+              affected.has(stand.id) ? { ...stand, standGroupId } : stand,
+            ),
+          );
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const handleGroupStands = useCallback(async () => {
+    if (selectedStands.size < 2) return;
+
+    const ids = Array.from(selectedStands);
+    setIsGrouping(true);
+    const result = await groupStands(ids);
+    setIsGrouping(false);
+
+    if (!result.success || result.groupId == null) {
+      toast.error(result.message);
+      return;
+    }
+
+    applyGroupIdLocally(ids, result.groupId);
+    toast.success(result.message);
+  }, [selectedStands, applyGroupIdLocally]);
+
+  const handleUngroupStands = useCallback(async () => {
+    if (selectedStands.size === 0) return;
+
+    const ids = Array.from(selectedStands);
+    setIsGrouping(true);
+    const result = await ungroupStands(ids);
+    setIsGrouping(false);
+
+    if (!result.success) {
+      toast.error(result.message);
+      return;
+    }
+
+    applyGroupIdLocally(ids, null);
+    toast.success(result.message);
+  }, [selectedStands, applyGroupIdLocally]);
 
   // --- Element add/delete/edit ---
   const handleAddElement = async (type: MapElementType) => {
@@ -1376,6 +1434,13 @@ export default function StandPositionEditor({
   const hasElementSelection = selectedElements.size >= 2;
   const hasAnyAlignmentSelection = hasSelection || hasElementSelection;
 
+  const selectedStandRecords = Array.from(standsPerSector.values())
+    .flat()
+    .filter((stand) => selectedStands.has(stand.id));
+  const hasGroupedSelection = selectedStandRecords.some(
+    (stand) => stand.standGroupId != null,
+  );
+
   return (
     <div className="space-y-4">
       {/* Main toolbar: Save / Undo / Reset */}
@@ -1601,6 +1666,30 @@ export default function StandPositionEditor({
             ))}
           </DropdownMenuContent>
         </DropdownMenu>
+        {selectedStands.size >= 2 && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleGroupStands}
+            disabled={isGrouping}
+            title="Tratar los espacios seleccionados como uno solo en el plano"
+          >
+            <Link2 className="h-4 w-4 mr-1" />
+            {isGrouping ? "Uniendo..." : `Unir (${selectedStands.size})`}
+          </Button>
+        )}
+        {hasGroupedSelection && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleUngroupStands}
+            disabled={isGrouping}
+            title="Dejar de tratar los espacios seleccionados como uno solo"
+          >
+            <Unlink className="h-4 w-4 mr-1" />
+            Separar
+          </Button>
+        )}
         {selectedStands.size === 1 && (
           <Button variant="outline" size="sm" onClick={openEditDialog}>
             <Pencil className="h-4 w-4 mr-1" />

--- a/app/components/maps/festival-nav/festival-nav-map-canvas.tsx
+++ b/app/components/maps/festival-nav/festival-nav-map-canvas.tsx
@@ -2,28 +2,28 @@
 
 import { useCallback } from "react";
 import { TransformComponent } from "react-zoom-pan-pinch";
-import { MapPin } from "lucide-react";
 
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
 import { MapElementBase } from "@/app/lib/map_elements/definitions";
+import { MapBounds } from "@/app/components/maps/map-types";
 import {
-  STAND_SIZE,
   StandColors,
-  computeCanvasBounds,
   getExternalParticipantStandColors,
   getPublicStandColors,
-  getStandPosition,
 } from "@/app/components/maps/map-utils";
-import MapCanvas from "@/app/components/maps/map-canvas";
-import MapStand from "@/app/components/maps/map-stand";
-import MapElement from "@/app/components/maps/map-element";
+import MapPinchHint from "@/app/components/maps/map-pinch-hint";
+import MapSurface from "@/app/components/maps/map-surface";
 import MapTransformWrapper from "@/app/components/maps/map-transform-wrapper";
-import { hasExternalParticipants } from "@/app/components/maps/map-participants";
+import FestivalNavStandBadges from "@/app/components/maps/festival-nav/festival-nav-stand-badges";
+import {
+  hasActivityParticipant,
+  hasExternalParticipants,
+} from "@/app/components/maps/map-participants";
 
 type FestivalNavMapCanvasProps = {
   stands: StandWithReservationsWithParticipants[];
   mapElements: MapElementBase[];
-  mapBounds?: { minX: number; minY: number; width: number; height: number };
+  mapBounds?: MapBounds;
   selectedStandId: number | null;
   couponBookUserIdSet: Set<number>;
   passportUserIdSet: Set<number>;
@@ -39,22 +39,6 @@ function isOccupied(stand: StandWithReservationsWithParticipants): boolean {
   return stand.status === "reserved" || stand.status === "confirmed";
 }
 
-function getStandParticipantUserIds(
-  stand: StandWithReservationsWithParticipants,
-): number[] {
-  return stand.reservations
-    .filter((r) => r.status !== "rejected")
-    .flatMap((r) => r.participants)
-    .map((p) => p.user.id);
-}
-
-function hasActivityParticipant(
-  stand: StandWithReservationsWithParticipants,
-  userIdSet: Set<number>,
-): boolean {
-  return getStandParticipantUserIds(stand).some((id) => userIdSet.has(id));
-}
-
 function getNavStandColors(
   stand: StandWithReservationsWithParticipants,
   couponBookUserIdSet: Set<number>,
@@ -65,11 +49,7 @@ function getNavStandColors(
   if (hasExternalParticipants(stand))
     return getExternalParticipantStandColors();
 
-  const hasCoupon = hasActivityParticipant(stand, couponBookUserIdSet);
-  const hasPassport = hasActivityParticipant(stand, passportUserIdSet);
-  const hasStickerHunt = hasActivityParticipant(stand, stickerHuntUserIdSet);
-
-  if (hasCoupon) {
+  if (hasActivityParticipant(stand, couponBookUserIdSet)) {
     return {
       fill: "rgba(217, 119, 6, 0.85)",
       hoverFill: "rgba(180, 83, 9, 0.95)",
@@ -78,7 +58,7 @@ function getNavStandColors(
     };
   }
 
-  if (hasPassport) {
+  if (hasActivityParticipant(stand, passportUserIdSet)) {
     return {
       fill: "rgba(5, 150, 105, 0.85)",
       hoverFill: "rgba(4, 120, 87, 0.95)",
@@ -87,7 +67,7 @@ function getNavStandColors(
     };
   }
 
-  if (hasStickerHunt) {
+  if (hasActivityParticipant(stand, stickerHuntUserIdSet)) {
     return {
       fill: "rgba(219, 39, 119, 0.85)",
       hoverFill: "rgba(190, 24, 93, 0.95)",
@@ -111,8 +91,7 @@ export default function FestivalNavMapCanvas({
   onStandSelect,
 }: FestivalNavMapCanvasProps) {
   const visibleStands = stands.filter((s) => s.status !== "disabled");
-  const canvasBounds =
-    mapBounds ?? computeCanvasBounds(visibleStands, mapElements);
+  const occupiedStands = visibleStands.filter(isOccupied);
 
   const handleStandSelect = useCallback(
     (stand: StandWithReservationsWithParticipants) => {
@@ -121,24 +100,6 @@ export default function FestivalNavMapCanvas({
     },
     [onStandSelect, sectorName],
   );
-
-  const occupiedStands = visibleStands.filter(isOccupied);
-  const couponStands = occupiedStands.filter((s) =>
-    hasActivityParticipant(s, couponBookUserIdSet),
-  );
-  const passportStands = occupiedStands.filter((s) =>
-    hasActivityParticipant(s, passportUserIdSet),
-  );
-  const stickerHuntStands = occupiedStands.filter((s) =>
-    hasActivityParticipant(s, stickerHuntUserIdSet),
-  );
-
-  const canvasConfig = {
-    minX: canvasBounds.minX,
-    minY: canvasBounds.minY,
-    width: canvasBounds.width,
-    height: canvasBounds.height,
-  };
 
   return (
     <div className="relative w-full border rounded-lg overflow-hidden">
@@ -152,150 +113,32 @@ export default function FestivalNavMapCanvas({
           wrapperStyle={{ width: "100%" }}
           contentStyle={{ width: "100%" }}
         >
-          <MapCanvas config={canvasConfig}>
-            {mapElements.map((element) => (
-              <MapElement key={`el-${element.id}`} element={element} />
-            ))}
-            {visibleStands.map((stand) => (
-              <MapStand
-                key={stand.id}
-                stand={stand}
-                canBeReserved={false}
-                selected={stand.id === selectedStandId}
-                colors={getNavStandColors(
-                  stand,
-                  couponBookUserIdSet,
-                  passportUserIdSet,
-                  stickerHuntUserIdSet,
-                )}
-                onTouchTap={handleStandSelect}
-                onClick={handleStandSelect}
-              />
-            ))}
-            {/* Activity badge overlay — painted after stands */}
-            <g aria-hidden="true">
-              {couponStands.map((stand) => {
-                const { left, top } = getStandPosition(stand);
-                return (
-                  <g
-                    key={`coupon-${stand.id}`}
-                    transform={`translate(${left}, ${top})`}
-                    style={{ pointerEvents: "none" }}
-                  >
-                    <circle
-                      cx={STAND_SIZE - 0.8}
-                      cy={0.8}
-                      r={1.3}
-                      fill="#F59E0B"
-                      stroke="#fff"
-                      strokeWidth={0.3}
-                    />
-                    <text
-                      x={STAND_SIZE - 0.8}
-                      y={0.8}
-                      textAnchor="middle"
-                      dominantBaseline="central"
-                      fontSize={1.4}
-                      fontWeight={700}
-                      fill="#fff"
-                      style={{ userSelect: "none" }}
-                    >
-                      %
-                    </text>
-                  </g>
-                );
-              })}
-              {passportStands.map((stand) => {
-                const { left, top } = getStandPosition(stand);
-                // If stand also has a coupon badge, shift the passport badge left
-                const hasCoupon = hasActivityParticipant(
-                  stand,
-                  couponBookUserIdSet,
-                );
-                const cx = hasCoupon ? STAND_SIZE - 2.8 : STAND_SIZE - 0.8;
-                return (
-                  <g
-                    key={`passport-${stand.id}`}
-                    transform={`translate(${left}, ${top})`}
-                    style={{ pointerEvents: "none" }}
-                  >
-                    <circle
-                      cx={cx}
-                      cy={0.8}
-                      r={1.3}
-                      fill="#059669"
-                      stroke="#fff"
-                      strokeWidth={0.3}
-                    />
-                    <text
-                      x={cx}
-                      y={0.8}
-                      textAnchor="middle"
-                      dominantBaseline="central"
-                      fontSize={1.4}
-                      fontWeight={700}
-                      fill="#fff"
-                      style={{ userSelect: "none" }}
-                    >
-                      ★
-                    </text>
-                  </g>
-                );
-              })}
-              {stickerHuntStands.map((stand) => {
-                const { left, top } = getStandPosition(stand);
-                // Shift left of any coupon/passport badges that may already be present
-                const hasCoupon = hasActivityParticipant(
-                  stand,
-                  couponBookUserIdSet,
-                );
-                const hasPassport = hasActivityParticipant(
-                  stand,
-                  passportUserIdSet,
-                );
-                const occupiedBadges =
-                  (hasCoupon ? 1 : 0) + (hasPassport ? 1 : 0);
-                const cx = STAND_SIZE - 0.8 - occupiedBadges * 2;
-                return (
-                  <g
-                    key={`sticker-hunt-${stand.id}`}
-                    transform={`translate(${left}, ${top})`}
-                    style={{ pointerEvents: "none" }}
-                  >
-                    <circle
-                      cx={cx}
-                      cy={0.8}
-                      r={1.3}
-                      fill="#DB2777"
-                      stroke="#fff"
-                      strokeWidth={0.3}
-                    />
-                    <text
-                      x={cx}
-                      y={0.8}
-                      textAnchor="middle"
-                      dominantBaseline="central"
-                      fontSize={1.4}
-                      fontWeight={700}
-                      fill="#fff"
-                      style={{ userSelect: "none" }}
-                    >
-                      ♦
-                    </text>
-                  </g>
-                );
-              })}
-            </g>
-          </MapCanvas>
+          <MapSurface
+            stands={visibleStands}
+            mapElements={mapElements}
+            mapBounds={mapBounds}
+            selectedStandId={selectedStandId}
+            getColors={(stand) =>
+              getNavStandColors(
+                stand,
+                couponBookUserIdSet,
+                passportUserIdSet,
+                stickerHuntUserIdSet,
+              )
+            }
+            onStandClick={handleStandSelect}
+            onStandTouchTap={handleStandSelect}
+          >
+            <FestivalNavStandBadges
+              stands={occupiedStands}
+              couponBookUserIdSet={couponBookUserIdSet}
+              passportUserIdSet={passportUserIdSet}
+              stickerHuntUserIdSet={stickerHuntUserIdSet}
+            />
+          </MapSurface>
         </TransformComponent>
 
-        {/* Zoom hint (mobile only) */}
-        <div className="absolute bottom-12 left-1/2 -translate-x-1/2 z-10 md:hidden pointer-events-none">
-          <div className="flex items-center gap-1.5 rounded-full bg-gray-900/80 px-3 py-1.5 text-white backdrop-blur-sm">
-            <MapPin className="h-3 w-3" />
-            <span className="text-xs font-medium">Pellizca para ampliar</span>
-          </div>
-        </div>
+        <MapPinchHint className="bottom-12 pointer-events-none" />
       </MapTransformWrapper>
     </div>
   );

--- a/app/components/maps/festival-nav/festival-nav-map-canvas.tsx
+++ b/app/components/maps/festival-nav/festival-nav-map-canvas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { TransformComponent } from "react-zoom-pan-pinch";
 
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
@@ -19,6 +19,10 @@ import {
   hasActivityParticipant,
   hasExternalParticipants,
 } from "@/app/components/maps/map-participants";
+import {
+  dedupeJointGroupMembers,
+  resolveJointGroups,
+} from "@/app/lib/stands/groups";
 
 type FestivalNavMapCanvasProps = {
   stands: StandWithReservationsWithParticipants[];
@@ -90,8 +94,20 @@ export default function FestivalNavMapCanvas({
   sectorName,
   onStandSelect,
 }: FestivalNavMapCanvasProps) {
-  const visibleStands = stands.filter((s) => s.status !== "disabled");
-  const occupiedStands = visibleStands.filter(isOccupied);
+  const visibleStands = useMemo(
+    () => stands.filter((s) => s.status !== "disabled"),
+    [stands],
+  );
+  // Resolved from the same list MapSurface draws, so a group that renders as
+  // one outline carries exactly one set of activity badges.
+  const occupiedStands = useMemo(
+    () =>
+      dedupeJointGroupMembers(
+        visibleStands.filter(isOccupied),
+        resolveJointGroups(visibleStands),
+      ),
+    [visibleStands],
+  );
 
   const handleStandSelect = useCallback(
     (stand: StandWithReservationsWithParticipants) => {

--- a/app/components/maps/festival-nav/festival-nav-map.tsx
+++ b/app/components/maps/festival-nav/festival-nav-map.tsx
@@ -14,6 +14,10 @@ import FestivalNavStandDrawer, {
 } from "@/app/components/maps/festival-nav/festival-nav-stand-drawer";
 import FestivalNavMapLegend from "@/app/components/maps/festival-nav/festival-nav-map-legend";
 import { formatStandLabel } from "@/app/lib/stands/helpers";
+import {
+  indexJointGroupsByStandId,
+  resolveJointGroups,
+} from "@/app/lib/stands/groups";
 
 type FestivalNavMapProps = {
   festivalName: string;
@@ -81,6 +85,21 @@ export default function FestivalNavMap({
     });
     return entries;
   }, [sectors]);
+
+  // Built from the same stands the canvases draw, so the drawer always
+  // describes the unit the visitor sees. Covers search hits too, which never
+  // pass through the map's own tap handler.
+  const jointGroupByStandId = useMemo(
+    () =>
+      indexJointGroupsByStandId(
+        resolveJointGroups(
+          sectors.flatMap((sector) =>
+            sector.stands.filter((stand) => stand.status !== "disabled"),
+          ),
+        ),
+      ),
+    [sectors],
+  );
 
   const handleStandSelect = useCallback(
     (stand: StandWithReservationsWithParticipants, sectorName: string) => {
@@ -219,6 +238,11 @@ export default function FestivalNavMap({
       <FestivalNavStandDrawer
         stand={selectedStand}
         sectorName={selectedSectorName}
+        groupStands={
+          selectedStand
+            ? jointGroupByStandId.get(selectedStand.id)?.stands
+            : undefined
+        }
         open={drawerOpen}
         onOpenChange={setDrawerOpen}
         couponBookProofs={couponBookProofs}

--- a/app/components/maps/festival-nav/festival-nav-stand-badges.test.tsx
+++ b/app/components/maps/festival-nav/festival-nav-stand-badges.test.tsx
@@ -1,0 +1,135 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import FestivalNavStandBadges from "@/app/components/maps/festival-nav/festival-nav-stand-badges";
+import type { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+
+afterEach(cleanup);
+
+/**
+ * Badges stack right to left from the stand's top-right corner, so the x
+ * positions asserted below are STAND_SIZE - 0.8 minus 2 per preceding badge.
+ */
+const FIRST_SLOT = 5.2;
+const SECOND_SLOT = 3.2;
+const THIRD_SLOT = 1.2;
+
+function stand(
+  id: number,
+  userIds: number[],
+  { rejected = false }: { rejected?: boolean } = {},
+): StandWithReservationsWithParticipants {
+  return {
+    id,
+    positionLeft: 10,
+    positionTop: 20,
+    reservations: [
+      {
+        status: rejected ? "rejected" : "accepted",
+        participants: userIds.map((userId) => ({ user: { id: userId } })),
+        externalParticipants: [],
+      },
+    ],
+  } as unknown as StandWithReservationsWithParticipants;
+}
+
+function renderBadges(
+  stands: StandWithReservationsWithParticipants[],
+  sets: {
+    coupon?: number[];
+    passport?: number[];
+    stickerHunt?: number[];
+  } = {},
+) {
+  const { container } = render(
+    <svg>
+      <FestivalNavStandBadges
+        stands={stands}
+        couponBookUserIdSet={new Set(sets.coupon ?? [])}
+        passportUserIdSet={new Set(sets.passport ?? [])}
+        stickerHuntUserIdSet={new Set(sets.stickerHunt ?? [])}
+      />
+    </svg>,
+  );
+
+  return Array.from(container.querySelectorAll("text")).map((node) => ({
+    glyph: node.textContent,
+    // Rounded because the slot offsets accumulate binary float error
+    x: Math.round(Number(node.getAttribute("x")) * 1000) / 1000,
+  }));
+}
+
+describe("FestivalNavStandBadges", () => {
+  it("renders nothing for stands with no activity participants", () => {
+    expect(renderBadges([stand(1, [7])], { coupon: [99] })).toEqual([]);
+  });
+
+  it("puts a lone badge in the first slot whichever activity it is", () => {
+    expect(renderBadges([stand(1, [7])], { coupon: [7] })).toEqual([
+      { glyph: "%", x: FIRST_SLOT },
+    ]);
+    expect(renderBadges([stand(1, [7])], { passport: [7] })).toEqual([
+      { glyph: "★", x: FIRST_SLOT },
+    ]);
+    expect(renderBadges([stand(1, [7])], { stickerHunt: [7] })).toEqual([
+      { glyph: "♦", x: FIRST_SLOT },
+    ]);
+  });
+
+  it("stacks all three activities without overlapping", () => {
+    expect(
+      renderBadges([stand(1, [7])], {
+        coupon: [7],
+        passport: [7],
+        stickerHunt: [7],
+      }),
+    ).toEqual([
+      { glyph: "%", x: FIRST_SLOT },
+      { glyph: "★", x: SECOND_SLOT },
+      { glyph: "♦", x: THIRD_SLOT },
+    ]);
+  });
+
+  it("closes the gap when a middle activity is missing", () => {
+    expect(
+      renderBadges([stand(1, [7])], { coupon: [7], stickerHunt: [7] }),
+    ).toEqual([
+      { glyph: "%", x: FIRST_SLOT },
+      { glyph: "♦", x: SECOND_SLOT },
+    ]);
+  });
+
+  it("counts every participant sharing the stand", () => {
+    expect(
+      renderBadges([stand(1, [7, 8])], { coupon: [8], passport: [7] }),
+    ).toEqual([
+      { glyph: "%", x: FIRST_SLOT },
+      { glyph: "★", x: SECOND_SLOT },
+    ]);
+  });
+
+  it("ignores participants whose reservation was rejected", () => {
+    expect(
+      renderBadges([stand(1, [7], { rejected: true })], { coupon: [7] }),
+    ).toEqual([]);
+  });
+
+  it("positions each stand's badges at its own coordinates", () => {
+    const { container } = render(
+      <svg>
+        <FestivalNavStandBadges
+          stands={[stand(1, [7]), stand(2, [8])]}
+          couponBookUserIdSet={new Set([7, 8])}
+          passportUserIdSet={new Set()}
+          stickerHuntUserIdSet={new Set()}
+        />
+      </svg>,
+    );
+
+    const groups = Array.from(container.querySelectorAll("g[transform]")).map(
+      (node) => node.getAttribute("transform"),
+    );
+    expect(groups).toEqual(["translate(10, 20)", "translate(10, 20)"]);
+    expect(container.querySelectorAll("circle")).toHaveLength(2);
+  });
+});

--- a/app/components/maps/festival-nav/festival-nav-stand-badges.test.tsx
+++ b/app/components/maps/festival-nav/festival-nav-stand-badges.test.tsx
@@ -17,12 +17,16 @@ const THIRD_SLOT = 1.2;
 function stand(
   id: number,
   userIds: number[],
-  { rejected = false }: { rejected?: boolean } = {},
+  {
+    rejected = false,
+    positionLeft = 10,
+    positionTop = 20,
+  }: { rejected?: boolean; positionLeft?: number; positionTop?: number } = {},
 ): StandWithReservationsWithParticipants {
   return {
     id,
-    positionLeft: 10,
-    positionTop: 20,
+    positionLeft,
+    positionTop,
     reservations: [
       {
         status: rejected ? "rejected" : "accepted",

--- a/app/components/maps/festival-nav/festival-nav-stand-badges.test.tsx
+++ b/app/components/maps/festival-nav/festival-nav-stand-badges.test.tsx
@@ -122,7 +122,10 @@ describe("FestivalNavStandBadges", () => {
     const { container } = render(
       <svg>
         <FestivalNavStandBadges
-          stands={[stand(1, [7]), stand(2, [8])]}
+          stands={[
+            stand(1, [7]),
+            stand(2, [8], { positionLeft: 30, positionTop: 40 }),
+          ]}
           couponBookUserIdSet={new Set([7, 8])}
           passportUserIdSet={new Set()}
           stickerHuntUserIdSet={new Set()}
@@ -133,7 +136,7 @@ describe("FestivalNavStandBadges", () => {
     const groups = Array.from(container.querySelectorAll("g[transform]")).map(
       (node) => node.getAttribute("transform"),
     );
-    expect(groups).toEqual(["translate(10, 20)", "translate(10, 20)"]);
+    expect(groups).toEqual(["translate(10, 20)", "translate(30, 40)"]);
     expect(container.querySelectorAll("circle")).toHaveLength(2);
   });
 });

--- a/app/components/maps/festival-nav/festival-nav-stand-badges.tsx
+++ b/app/components/maps/festival-nav/festival-nav-stand-badges.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import { STAND_SIZE, getStandPosition } from "@/app/components/maps/map-utils";
+import { hasActivityParticipant } from "@/app/components/maps/map-participants";
+
+type FestivalNavStandBadgesProps = {
+  /** Occupied stands only — badges are meaningless on empty spaces */
+  stands: StandWithReservationsWithParticipants[];
+  couponBookUserIdSet: Set<number>;
+  passportUserIdSet: Set<number>;
+  stickerHuntUserIdSet: Set<number>;
+};
+
+const BADGE_RADIUS = 1.3;
+const BADGE_SPACING = 2;
+
+type Badge = {
+  key: string;
+  fill: string;
+  glyph: string;
+};
+
+/**
+ * Activity markers painted on top of the stands. Badges stack right to left so
+ * a stand carrying several activities keeps them all visible.
+ */
+export default function FestivalNavStandBadges({
+  stands,
+  couponBookUserIdSet,
+  passportUserIdSet,
+  stickerHuntUserIdSet,
+}: FestivalNavStandBadgesProps) {
+  return (
+    <g aria-hidden="true">
+      {stands.map((stand) => {
+        const badges: Badge[] = [];
+        if (hasActivityParticipant(stand, couponBookUserIdSet)) {
+          badges.push({ key: "coupon", fill: "#F59E0B", glyph: "%" });
+        }
+        if (hasActivityParticipant(stand, passportUserIdSet)) {
+          badges.push({ key: "passport", fill: "#059669", glyph: "★" });
+        }
+        if (hasActivityParticipant(stand, stickerHuntUserIdSet)) {
+          badges.push({ key: "sticker-hunt", fill: "#DB2777", glyph: "♦" });
+        }
+        if (badges.length === 0) return null;
+
+        const { left, top } = getStandPosition(stand);
+        return (
+          <g
+            key={stand.id}
+            transform={`translate(${left}, ${top})`}
+            style={{ pointerEvents: "none" }}
+          >
+            {badges.map((badge, index) => {
+              const cx = STAND_SIZE - 0.8 - index * BADGE_SPACING;
+              return (
+                <g key={badge.key}>
+                  <circle
+                    cx={cx}
+                    cy={0.8}
+                    r={BADGE_RADIUS}
+                    fill={badge.fill}
+                    stroke="#fff"
+                    strokeWidth={0.3}
+                  />
+                  <text
+                    x={cx}
+                    y={0.8}
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                    fontSize={1.4}
+                    fontWeight={700}
+                    fill="#fff"
+                    style={{ userSelect: "none" }}
+                  >
+                    {badge.glyph}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+        );
+      })}
+    </g>
+  );
+}

--- a/app/components/maps/festival-nav/festival-nav-stand-drawer.tsx
+++ b/app/components/maps/festival-nav/festival-nav-stand-drawer.tsx
@@ -14,7 +14,7 @@ import {
   DrawerHeader,
 } from "@/app/components/ui/drawer";
 import { socialsUrls, socialsIcons } from "@/app/lib/users/utils";
-import { formatStandLabel } from "@/app/lib/stands/helpers";
+import { formatStandsLabel, getStandsProducts } from "@/app/lib/stands/groups";
 
 export type CouponProof = {
   promoHighlight: string | null;
@@ -25,6 +25,11 @@ export type CouponProof = {
 type FestivalNavStandDrawerProps = {
   stand: StandWithReservationsWithParticipants | null;
   sectorName: string;
+  /**
+   * Every stand of the joint group that was tapped, when the stand belongs to
+   * one. Defaults to just the tapped stand.
+   */
+  groupStands?: StandWithReservationsWithParticipants[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
   couponBookProofs: Record<number, CouponProof[]>;
@@ -49,6 +54,7 @@ function getCategoryLabel(category: string): string {
 export default function FestivalNavStandDrawer({
   stand,
   sectorName,
+  groupStands,
   open,
   onOpenChange,
   couponBookProofs,
@@ -68,9 +74,12 @@ export default function FestivalNavStandDrawer({
   if (!stand) return null;
 
   const currentParticipant = participants[clampedTab] ?? participants[0];
-  const standLabel = formatStandLabel(stand);
+  // Members of a joint group share their participants, so the tapped stand
+  // still speaks for the whole unit apart from the label and products.
+  const drawerStands = groupStands?.length ? groupStands : [stand];
+  const standLabel = formatStandsLabel(drawerStands);
   const categoryLabel = getCategoryLabel(stand.standCategory);
-  const products = stand.standSubcategories.map((sc) => sc.subcategory.label);
+  const products = getStandsProducts(drawerStands);
 
   const couponProof =
     currentParticipant?.kind === "user" && currentParticipant.userId != null
@@ -160,7 +169,8 @@ export default function FestivalNavStandDrawer({
                         {currentParticipant.displayName}
                       </h3>
                       <p className="text-sm text-muted-foreground">
-                        Stand #{standLabel} · {sectorName}
+                        {drawerStands.length > 1 ? "Stands" : "Stand"}{" "}
+                        {standLabel} · {sectorName}
                       </p>
                       {currentParticipant.kind === "external" && (
                         <Badge

--- a/app/components/maps/map-participants.test.ts
+++ b/app/components/maps/map-participants.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { getStandMapParticipants } from "@/app/components/maps/map-participants";
+import type { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+
+function userReservation() {
+  return {
+    status: "accepted",
+    participants: [
+      {
+        id: 1,
+        user: {
+          id: 42,
+          displayName: "Pandora",
+          imageUrl: null,
+          category: "illustration",
+          userSocials: [
+            { id: 1, type: "instagram", username: "garabatosdepandora" },
+            { id: 2, type: "facebook", username: "garabatosdepandora" },
+          ],
+        },
+      },
+    ],
+    externalParticipants: [],
+  };
+}
+
+function externalReservation() {
+  return {
+    status: "accepted",
+    participants: [],
+    externalParticipants: [
+      {
+        externalParticipant: {
+          id: 9,
+          displayName: "Café Vecino",
+          imageUrl: null,
+          websiteUrl: "https://cafevecino.example",
+          instagramUrl: null,
+          contactEmail: "hola@cafevecino.example",
+        },
+      },
+    ],
+  };
+}
+
+function stand(reservations: unknown[]): StandWithReservationsWithParticipants {
+  return { id: 7, reservations } as StandWithReservationsWithParticipants;
+}
+
+describe("getStandMapParticipants", () => {
+  it("gives a registered user socials and no duplicate links", () => {
+    const [participant] = getStandMapParticipants(stand([userReservation()]));
+
+    expect(participant.kind).toBe("user");
+    expect(participant.userSocials).toHaveLength(2);
+    // Cards render one "Contacto" section per field, so populating both here
+    // listed the same accounts twice
+    expect(participant.links).toEqual([]);
+  });
+
+  it("gives an external participant links and no socials", () => {
+    const [participant] = getStandMapParticipants(
+      stand([externalReservation()]),
+    );
+
+    expect(participant.kind).toBe("external");
+    expect(participant.userSocials).toEqual([]);
+    expect(participant.links.map((link) => link.label)).toEqual([
+      "Sitio web",
+      "Correo",
+    ]);
+  });
+
+  it("never populates both contact fields for the same participant", () => {
+    const participants = getStandMapParticipants(
+      stand([userReservation(), externalReservation()]),
+    );
+
+    expect(participants).toHaveLength(2);
+    for (const participant of participants) {
+      expect(
+        participant.userSocials.length > 0 && participant.links.length > 0,
+      ).toBe(false);
+    }
+  });
+
+  it("skips rejected reservations", () => {
+    expect(
+      getStandMapParticipants(
+        stand([{ ...userReservation(), status: "rejected" }]),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/app/components/maps/map-participants.ts
+++ b/app/components/maps/map-participants.ts
@@ -5,7 +5,6 @@ import {
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
 import { UserCategory, UserSocial } from "@/app/api/users/definitions";
 import { getExternalParticipantCategoryLabel } from "@/app/lib/external_participants/definitions";
-import { socialsUrls } from "@/app/lib/users/utils";
 
 type BaseMapParticipant = {
   id: string;
@@ -64,12 +63,11 @@ export function getStandMapParticipants(
       categoryLabel: participant.user.category,
       userId: participant.user.id,
       userSocials: participant.user.userSocials ?? [],
-      links: participant.user.userSocials
-        .filter((social) => !!social.username)
-        .map((social) => ({
-          label: `@${social.username}`,
-          href: `${socialsUrls[social.type]}${social.username}`,
-        })),
+      // Registered users carry their contact details in userSocials, which the
+      // cards render as icon rows. `links` is the external-participant path;
+      // deriving it from the socials here made every card list the same
+      // accounts twice, under two "Contacto" headings.
+      links: [],
     }));
 
     const externalParticipants =

--- a/app/components/maps/map-participants.ts
+++ b/app/components/maps/map-participants.ts
@@ -42,6 +42,16 @@ export function hasExternalParticipants(
   );
 }
 
+/** Whether any user participating in the stand belongs to the given set */
+export function hasActivityParticipant(
+  stand: StandWithReservationsWithParticipants,
+  userIdSet: Set<number>,
+): boolean {
+  return getActiveStandReservations(stand)
+    .flatMap((reservation) => reservation.participants)
+    .some((participant) => userIdSet.has(participant.user.id));
+}
+
 export function getStandMapParticipants(
   stand: StandWithReservationsWithParticipants,
 ): MapParticipant[] {

--- a/app/components/maps/map-pinch-hint.tsx
+++ b/app/components/maps/map-pinch-hint.tsx
@@ -1,0 +1,23 @@
+import { MapPin } from "lucide-react";
+
+import { cn } from "@/app/lib/utils";
+
+type MapPinchHintProps = {
+  className?: string;
+};
+
+export default function MapPinchHint({ className }: MapPinchHintProps) {
+  return (
+    <div
+      className={cn(
+        "absolute bottom-2 left-1/2 -translate-x-1/2 z-10 md:hidden",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-1.5 rounded-full bg-gray-900/80 px-3 py-1.5 text-white backdrop-blur-sm">
+        <MapPin className="h-3 w-3" />
+        <span className="text-xs font-medium">Pellizca para ampliar</span>
+      </div>
+    </div>
+  );
+}

--- a/app/components/maps/map-stand-group.tsx
+++ b/app/components/maps/map-stand-group.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { memo, useRef, useState } from "react";
+
+import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import {
+  JointGroup,
+  buildJointGroupPath,
+  getJointGroupBounds,
+} from "@/app/lib/stands/groups";
+import { formatStandLabel } from "@/app/lib/stands/helpers";
+import {
+  SELECTED_FILL,
+  SELECTED_RING,
+  SELECTED_STROKE,
+  SELECTED_TEXT,
+  STAND_SIZE,
+  getStandFillColor,
+  getStandHoverFillColor,
+  getStandStrokeColor,
+  getStandTextColor,
+  getStandPosition,
+} from "./map-utils";
+import type { StandColors } from "./map-utils";
+
+type MapStandGroupProps = {
+  group: JointGroup;
+  selected?: boolean;
+  colors?: StandColors;
+  onClick?: (stand: StandWithReservationsWithParticipants) => void;
+  onTouchTap?: (
+    stand: StandWithReservationsWithParticipants,
+    rect?: DOMRect,
+  ) => void;
+  onHoverChange?: (
+    stand: StandWithReservationsWithParticipants | null,
+    rect: DOMRect | null,
+  ) => void;
+};
+
+const RING_PADDING = 0.8;
+
+/**
+ * Stands an admin declared as one physical unit, drawn as a single outline with
+ * a notch at each seam. Hovering or tapping any member acts on the whole group,
+ * and handlers receive the first member as the group's representative stand.
+ */
+const MapStandGroup = ({
+  group,
+  selected,
+  colors,
+  onClick,
+  onTouchTap,
+  onHoverChange,
+}: MapStandGroupProps) => {
+  const [hovered, setHovered] = useState(false);
+  const gRef = useRef<SVGGElement>(null);
+  const touchStartPos = useRef<{ x: number; y: number } | null>(null);
+
+  const primaryStand = group.stands[0];
+  const { status } = primaryStand;
+  const bounds = getJointGroupBounds(group);
+  const path = buildJointGroupPath(bounds, group.axis);
+
+  const fillColor = selected
+    ? SELECTED_FILL
+    : colors
+      ? hovered
+        ? colors.hoverFill
+        : colors.fill
+      : hovered
+        ? getStandHoverFillColor(status, false)
+        : getStandFillColor(status, false);
+  const strokeColor = selected
+    ? SELECTED_STROKE
+    : (colors?.stroke ?? getStandStrokeColor(status, false));
+  const textColor = selected
+    ? SELECTED_TEXT
+    : (colors?.text ?? getStandTextColor(status, false));
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    if (e.pointerType === "touch" || e.pointerType === "pen") {
+      touchStartPos.current = { x: e.clientX, y: e.clientY };
+    }
+  };
+
+  const handlePointerUp = (e: React.PointerEvent) => {
+    if (e.pointerType === "touch" || e.pointerType === "pen") {
+      const start = touchStartPos.current;
+      touchStartPos.current = null;
+      if (start) {
+        const dx = Math.abs(e.clientX - start.x);
+        const dy = Math.abs(e.clientY - start.y);
+        if (dx < 10 && dy < 10) {
+          onTouchTap?.(primaryStand, gRef.current?.getBoundingClientRect());
+        }
+      }
+    } else {
+      onClick?.(primaryStand);
+    }
+  };
+
+  const label = group.stands.map(formatStandLabel).join(" - ");
+
+  return (
+    <g
+      ref={gRef}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerEnter={(e) => {
+        if (e.pointerType !== "mouse") return;
+        setHovered(true);
+        if (onHoverChange && gRef.current) {
+          onHoverChange(primaryStand, gRef.current.getBoundingClientRect());
+        }
+      }}
+      onPointerLeave={(e) => {
+        if (e.pointerType !== "mouse") return;
+        setHovered(false);
+        onHoverChange?.(null, null);
+      }}
+      style={{
+        cursor: onClick ? "pointer" : "default",
+        touchAction: "manipulation",
+        outline: "none",
+      }}
+      role={onClick ? "button" : undefined}
+      aria-label={`Espacios unidos ${label} - ${status}`}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick?.(primaryStand);
+        }
+      }}
+    >
+      {/* Outer ring when selected, traced along the joined outline */}
+      {selected && (
+        <path
+          d={path}
+          fill={SELECTED_RING}
+          stroke={SELECTED_RING}
+          strokeWidth={RING_PADDING * 2}
+          strokeLinejoin="round"
+          style={{ pointerEvents: "none" }}
+        />
+      )}
+      <path
+        d={path}
+        fill={fillColor}
+        stroke={strokeColor}
+        strokeWidth={selected ? 0.3 : 0.4}
+        style={{ transition: "fill 150ms ease" }}
+      />
+      {group.stands.map((stand) => {
+        const { left, top } = getStandPosition(stand);
+        return (
+          <text
+            key={stand.id}
+            x={left + STAND_SIZE / 2}
+            y={top + STAND_SIZE / 2}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fontSize={2.2}
+            fontWeight={selected ? 700 : 600}
+            fill={textColor}
+            style={{ pointerEvents: "none", userSelect: "none" }}
+          >
+            {stand.label}
+            {stand.standNumber}
+          </text>
+        );
+      })}
+    </g>
+  );
+};
+
+MapStandGroup.displayName = "MapStandGroup";
+export default memo(MapStandGroup);

--- a/app/components/maps/map-surface.test.tsx
+++ b/app/components/maps/map-surface.test.tsx
@@ -1,0 +1,144 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import MapSurface from "@/app/components/maps/map-surface";
+import type { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+
+afterEach(cleanup);
+
+type StandOptions = {
+  groupId?: number | null;
+  left?: number;
+  top?: number;
+  users?: number[];
+};
+
+function stand(
+  id: number,
+  label: string,
+  { groupId = null, left = 0, top = 0, users = [] }: StandOptions = {},
+): StandWithReservationsWithParticipants {
+  return {
+    id,
+    label,
+    standNumber: id,
+    status: users.length > 0 ? "confirmed" : "available",
+    standGroupId: groupId,
+    positionLeft: left,
+    positionTop: top,
+    reservations:
+      users.length > 0
+        ? [
+            {
+              status: "accepted",
+              participants: users.map((userId) => ({ user: { id: userId } })),
+              externalParticipants: [],
+            },
+          ]
+        : [],
+  } as unknown as StandWithReservationsWithParticipants;
+}
+
+/** A7 and A8 side by side, both held by user 7, declared as group 10 */
+function jointPair() {
+  return [
+    stand(7, "A", { groupId: 10, left: 69.8, top: 84.5, users: [7] }),
+    stand(8, "A", { groupId: 10, left: 78.5, top: 84.5, users: [7] }),
+  ];
+}
+
+function standNodes(container: HTMLElement) {
+  return Array.from(container.querySelectorAll("g[aria-label^='Espacio ']"));
+}
+
+function groupNodes(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll("g[aria-label^='Espacios unidos']"),
+  );
+}
+
+describe("MapSurface joint groups", () => {
+  it("draws a declared pair as one outline instead of two stands", () => {
+    const { container } = render(<MapSurface stands={jointPair()} />);
+
+    expect(groupNodes(container)).toHaveLength(1);
+    expect(standNodes(container)).toHaveLength(0);
+    expect(groupNodes(container)[0].getAttribute("aria-label")).toContain(
+      "A7 - A8",
+    );
+    // Both member labels stay legible inside the joined shape
+    expect(container.textContent).toContain("A7");
+    expect(container.textContent).toContain("A8");
+  });
+
+  it("keeps ungrouped stands rendering individually", () => {
+    const { container } = render(
+      <MapSurface
+        stands={[
+          ...jointPair(),
+          stand(9, "A", { left: 86.35, top: 60.2, users: [8] }),
+        ]}
+      />,
+    );
+
+    expect(groupNodes(container)).toHaveLength(1);
+    expect(standNodes(container)).toHaveLength(1);
+  });
+
+  it("splits a group back apart when the members stop sharing a participant", () => {
+    const [a] = jointPair();
+    const b = stand(8, "A", { groupId: 10, left: 78.5, top: 84.5, users: [9] });
+    const { container } = render(<MapSurface stands={[a, b]} />);
+
+    expect(groupNodes(container)).toHaveLength(0);
+    expect(standNodes(container)).toHaveLength(2);
+  });
+
+  it("selects the whole group when any single member is selected", () => {
+    const { container } = render(
+      <MapSurface stands={jointPair()} selectedStandId={8} />,
+    );
+
+    // The selection ring is a second copy of the joined outline
+    expect(groupNodes(container)[0].querySelectorAll("path")).toHaveLength(2);
+  });
+
+  it("draws no selection ring when the selected stand is elsewhere", () => {
+    const { container } = render(
+      <MapSurface stands={jointPair()} selectedStandId={99} />,
+    );
+
+    expect(groupNodes(container)[0].querySelectorAll("path")).toHaveLength(1);
+  });
+
+  it("reports the first member when either half is clicked", () => {
+    const onStandClick = vi.fn();
+    const { container } = render(
+      <MapSurface stands={jointPair()} onStandClick={onStandClick} />,
+    );
+
+    const pointerUp = new MouseEvent("pointerup", { bubbles: true });
+    Object.defineProperty(pointerUp, "pointerType", { value: "mouse" });
+    groupNodes(container)[0].dispatchEvent(pointerUp);
+
+    expect(onStandClick).toHaveBeenCalledTimes(1);
+    expect(onStandClick.mock.calls[0][0]).toMatchObject({ id: 7 });
+  });
+
+  it("colors the group from its representative stand", () => {
+    const getColors = vi.fn(() => ({
+      fill: "rgb(1, 2, 3)",
+      hoverFill: "rgb(4, 5, 6)",
+      stroke: "rgb(7, 8, 9)",
+      text: "#fff",
+    }));
+    const { container } = render(
+      <MapSurface stands={jointPair()} getColors={getColors} />,
+    );
+
+    expect(getColors).toHaveBeenCalledWith(expect.objectContaining({ id: 7 }));
+    const outline = groupNodes(container)[0].querySelector("path");
+    expect(outline?.getAttribute("fill")).toBe("rgb(1, 2, 3)");
+    expect(outline?.getAttribute("stroke")).toBe("rgb(7, 8, 9)");
+  });
+});

--- a/app/components/maps/map-surface.test.tsx
+++ b/app/components/maps/map-surface.test.tsx
@@ -71,6 +71,15 @@ describe("MapSurface joint groups", () => {
     expect(container.textContent).toContain("A8");
   });
 
+  it("leaves members separate when the caller opts out of joining", () => {
+    const { container } = render(
+      <MapSurface stands={jointPair()} joinGroups={false} />,
+    );
+
+    expect(groupNodes(container)).toHaveLength(0);
+    expect(standNodes(container)).toHaveLength(2);
+  });
+
   it("keeps ungrouped stands rendering individually", () => {
     const { container } = render(
       <MapSurface

--- a/app/components/maps/map-surface.tsx
+++ b/app/components/maps/map-surface.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import { MapElementBase } from "@/app/lib/map_elements/definitions";
+import { MapBounds } from "@/app/components/maps/map-types";
+import {
+  StandColors,
+  computeCanvasBounds,
+} from "@/app/components/maps/map-utils";
+import MapCanvas from "@/app/components/maps/map-canvas";
+import MapElement from "@/app/components/maps/map-element";
+import MapStand from "@/app/components/maps/map-stand";
+
+type MapSurfaceProps = {
+  stands: StandWithReservationsWithParticipants[];
+  mapElements?: MapElementBase[];
+  /** Explicit viewBox. Falls back to bounds computed from stands and elements */
+  mapBounds?: MapBounds;
+  selectedStandId?: number | null;
+  /** Returning undefined leaves MapStand on its status-based default palette */
+  getColors?: (
+    stand: StandWithReservationsWithParticipants,
+  ) => StandColors | undefined;
+  canBeReserved?: (stand: StandWithReservationsWithParticipants) => boolean;
+  onStandClick?: (stand: StandWithReservationsWithParticipants) => void;
+  onStandTouchTap?: (
+    stand: StandWithReservationsWithParticipants,
+    rect?: DOMRect,
+  ) => void;
+  onStandHoverChange?: (
+    stand: StandWithReservationsWithParticipants | null,
+    rect: DOMRect | null,
+  ) => void;
+  /** Extra SVG content painted on top of the stands */
+  children?: React.ReactNode;
+};
+
+const noColors = () => undefined;
+const notReservable = () => false;
+
+/**
+ * The SVG body shared by every stand map: canvas viewBox, map elements and the
+ * stands themselves. Callers own the color, filtering and interaction policy.
+ */
+export default function MapSurface({
+  stands,
+  mapElements,
+  mapBounds,
+  selectedStandId,
+  getColors = noColors,
+  canBeReserved = notReservable,
+  onStandClick,
+  onStandTouchTap,
+  onStandHoverChange,
+  children,
+}: MapSurfaceProps) {
+  const bounds = mapBounds ?? computeCanvasBounds(stands, mapElements);
+
+  return (
+    <MapCanvas config={bounds}>
+      {mapElements?.map((element) => (
+        <MapElement key={`el-${element.id}`} element={element} />
+      ))}
+      {stands.map((stand) => (
+        <MapStand
+          key={stand.id}
+          stand={stand}
+          canBeReserved={canBeReserved(stand)}
+          selected={stand.id === selectedStandId}
+          colors={getColors(stand)}
+          onClick={onStandClick}
+          onTouchTap={onStandTouchTap}
+          onHoverChange={onStandHoverChange}
+        />
+      ))}
+      {children}
+    </MapCanvas>
+  );
+}

--- a/app/components/maps/map-surface.tsx
+++ b/app/components/maps/map-surface.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useMemo } from "react";
+
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
 import { MapElementBase } from "@/app/lib/map_elements/definitions";
 import { MapBounds } from "@/app/components/maps/map-types";
@@ -7,9 +9,14 @@ import {
   StandColors,
   computeCanvasBounds,
 } from "@/app/components/maps/map-utils";
+import {
+  indexJointGroupsByStandId,
+  resolveJointGroups,
+} from "@/app/lib/stands/groups";
 import MapCanvas from "@/app/components/maps/map-canvas";
 import MapElement from "@/app/components/maps/map-element";
 import MapStand from "@/app/components/maps/map-stand";
+import MapStandGroup from "@/app/components/maps/map-stand-group";
 
 type MapSurfaceProps = {
   stands: StandWithReservationsWithParticipants[];
@@ -55,19 +62,38 @@ export default function MapSurface({
   children,
 }: MapSurfaceProps) {
   const bounds = mapBounds ?? computeCanvasBounds(stands, mapElements);
+  const jointGroups = useMemo(() => resolveJointGroups(stands), [stands]);
+  const groupByStandId = useMemo(
+    () => indexJointGroupsByStandId(jointGroups),
+    [jointGroups],
+  );
 
   return (
     <MapCanvas config={bounds}>
       {mapElements?.map((element) => (
         <MapElement key={`el-${element.id}`} element={element} />
       ))}
-      {stands.map((stand) => (
-        <MapStand
-          key={stand.id}
-          stand={stand}
-          canBeReserved={canBeReserved(stand)}
-          selected={stand.id === selectedStandId}
-          colors={getColors(stand)}
+      {stands.map((stand) =>
+        // Members render once, as part of their group's joined outline
+        groupByStandId.has(stand.id) ? null : (
+          <MapStand
+            key={stand.id}
+            stand={stand}
+            canBeReserved={canBeReserved(stand)}
+            selected={stand.id === selectedStandId}
+            colors={getColors(stand)}
+            onClick={onStandClick}
+            onTouchTap={onStandTouchTap}
+            onHoverChange={onStandHoverChange}
+          />
+        ),
+      )}
+      {jointGroups.map((group) => (
+        <MapStandGroup
+          key={`group-${group.id}`}
+          group={group}
+          selected={group.stands.some((s) => s.id === selectedStandId)}
+          colors={getColors(group.stands[0])}
           onClick={onStandClick}
           onTouchTap={onStandTouchTap}
           onHoverChange={onStandHoverChange}

--- a/app/components/maps/map-surface.tsx
+++ b/app/components/maps/map-surface.tsx
@@ -38,6 +38,12 @@ type MapSurfaceProps = {
     stand: StandWithReservationsWithParticipants | null,
     rect: DOMRect | null,
   ) => void;
+  /**
+   * Draw admin-declared groups as one joined stand. Views that encode per-stand
+   * state in a stand's color must opt out, since one outline can only carry one
+   * color and would hide the difference between members.
+   */
+  joinGroups?: boolean;
   /** Extra SVG content painted on top of the stands */
   children?: React.ReactNode;
 };
@@ -59,10 +65,14 @@ export default function MapSurface({
   onStandClick,
   onStandTouchTap,
   onStandHoverChange,
+  joinGroups = true,
   children,
 }: MapSurfaceProps) {
   const bounds = mapBounds ?? computeCanvasBounds(stands, mapElements);
-  const jointGroups = useMemo(() => resolveJointGroups(stands), [stands]);
+  const jointGroups = useMemo(
+    () => (joinGroups ? resolveJointGroups(stands) : []),
+    [stands, joinGroups],
+  );
   const groupByStandId = useMemo(
     () => indexJointGroupsByStandId(jointGroups),
     [jointGroups],

--- a/app/components/maps/map-types.ts
+++ b/app/components/maps/map-types.ts
@@ -1,10 +1,13 @@
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
 
-export type MapCanvasConfig = {
+export type MapBounds = {
   minX: number;
   minY: number;
   width: number;
   height: number;
+};
+
+export type MapCanvasConfig = MapBounds & {
   backgroundColor: string;
 };
 

--- a/app/components/maps/public/public-map-card-provider.tsx
+++ b/app/components/maps/public/public-map-card-provider.tsx
@@ -16,6 +16,7 @@ type PublicMapCardContextValue = {
 	openCard: (
 		stand: StandWithReservationsWithParticipants,
 		sectorName?: string,
+		groupStands?: StandWithReservationsWithParticipants[],
 	) => void;
 	closeCard: () => void;
 	selectedStandId: number | null;
@@ -41,6 +42,9 @@ export function PublicMapCardProvider({
 	const [cardSectorName, setCardSectorName] = useState<string | undefined>(
 		undefined,
 	);
+	const [cardGroupStands, setCardGroupStands] = useState<
+		StandWithReservationsWithParticipants[] | undefined
+	>(undefined);
 	const [cardOpen, setCardOpen] = useState(false);
 
 	// Tracks whether openCard was just called during the current pointer event,
@@ -50,10 +54,15 @@ export function PublicMapCardProvider({
 	const cardRef = useRef<HTMLDivElement | null>(null);
 
 	const openCard = useCallback(
-		(stand: StandWithReservationsWithParticipants, sectorName?: string) => {
+		(
+			stand: StandWithReservationsWithParticipants,
+			sectorName?: string,
+			groupStands?: StandWithReservationsWithParticipants[],
+		) => {
 			justOpenedRef.current = true;
 			setSelectedStand(stand);
 			setCardSectorName(sectorName);
+			setCardGroupStands(groupStands);
 			setCardOpen(true);
 			// Reset flag after current event loop so the pointerup listener can close
 			// on future outside taps.
@@ -105,6 +114,7 @@ export function PublicMapCardProvider({
 				stand={selectedStand}
 				open={cardOpen}
 				sectorName={cardSectorName}
+				groupStands={cardGroupStands}
 				cardRef={cardRef}
 			/>
 		</PublicMapCardContext.Provider>

--- a/app/components/maps/public/public-map-drawer.test.tsx
+++ b/app/components/maps/public/public-map-drawer.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import PublicMapStandCard from "@/app/components/maps/public/public-map-drawer";
+import type { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+
+afterEach(cleanup);
+
+function stand(
+  id: number,
+  { products = [] }: { products?: string[] } = {},
+): StandWithReservationsWithParticipants {
+  return {
+    id,
+    label: "A",
+    standNumber: id,
+    standCategory: "illustration",
+    standSubcategories: products.map((label, index) => ({
+      subcategoryId: index,
+      subcategory: { label },
+    })),
+    reservations: [
+      {
+        status: "accepted",
+        participants: [
+          {
+            id: 1,
+            user: {
+              id: 42,
+              displayName: "Pandora",
+              imageUrl: null,
+              category: "illustration",
+              userSocials: [],
+            },
+          },
+        ],
+        externalParticipants: [],
+      },
+    ],
+  } as unknown as StandWithReservationsWithParticipants;
+}
+
+describe("PublicMapStandCard", () => {
+  it("names a lone stand in the singular", () => {
+    render(
+      <PublicMapStandCard stand={stand(7)} open sectorName="Lobby" />,
+    );
+
+    expect(screen.getByText(/^Stand A7/)).toBeTruthy();
+  });
+
+  it("names both halves of a joint group", () => {
+    const stands = [stand(7), stand(8)];
+    render(
+      <PublicMapStandCard
+        stand={stands[0]}
+        open
+        sectorName="Lobby"
+        groupStands={stands}
+      />,
+    );
+
+    expect(screen.getByText(/^Stands A7 - A8/)).toBeTruthy();
+    // The badge carries the joined label too
+    expect(screen.getAllByText("A7 - A8").length).toBeGreaterThan(0);
+  });
+
+  it("orders double-digit stands numerically", () => {
+    // Map order puts A10 first; the card should still read A9 - A10
+    const stands = [stand(10), stand(9)];
+    render(
+      <PublicMapStandCard stand={stands[0]} open groupStands={stands} />,
+    );
+
+    expect(screen.getByText(/^Stands A9 - A10/)).toBeTruthy();
+  });
+
+  it("shows the products of every stand in the group", () => {
+    const stands = [
+      stand(7, { products: ["Stickers", "Prints"] }),
+      stand(8, { products: ["Prints", "Pins"] }),
+    ];
+    render(
+      <PublicMapStandCard stand={stands[0]} open groupStands={stands} />,
+    );
+
+    expect(screen.getByText("Stickers")).toBeTruthy();
+    expect(screen.getByText("Pins")).toBeTruthy();
+    // Shared products are not repeated
+    expect(screen.getAllByText("Prints")).toHaveLength(1);
+  });
+
+  it("falls back to the tapped stand when no group is passed", () => {
+    render(
+      <PublicMapStandCard
+        stand={stand(7, { products: ["Stickers"] })}
+        open
+        groupStands={[]}
+      />,
+    );
+
+    expect(screen.getByText(/^Stand A7/)).toBeTruthy();
+    expect(screen.getByText("Stickers")).toBeTruthy();
+  });
+});

--- a/app/components/maps/public/public-map-drawer.tsx
+++ b/app/components/maps/public/public-map-drawer.tsx
@@ -8,12 +8,17 @@ import { getStandMapParticipants } from "@/app/components/maps/map-participants"
 import { Avatar, AvatarImage } from "@/app/components/ui/avatar";
 import { Badge } from "@/app/components/ui/badge";
 import { socialsUrls, socialsIcons } from "@/app/lib/users/utils";
-import { formatStandLabel } from "@/app/lib/stands/helpers";
+import { formatStandsLabel, getStandsProducts } from "@/app/lib/stands/groups";
 
 type PublicMapStandCardProps = {
 	stand: StandWithReservationsWithParticipants | null;
 	open: boolean;
 	sectorName?: string;
+	/**
+	 * Every stand of the joint group that was tapped, when the stand belongs to
+	 * one. Defaults to just the tapped stand.
+	 */
+	groupStands?: StandWithReservationsWithParticipants[];
 	cardRef?: React.RefObject<HTMLDivElement | null>;
 };
 
@@ -35,6 +40,7 @@ export default function PublicMapStandCard({
 	stand,
 	open,
 	sectorName,
+	groupStands,
 	cardRef,
 }: PublicMapStandCardProps) {
 	const [activeTab, setActiveTab] = useState(0);
@@ -47,9 +53,12 @@ export default function PublicMapStandCard({
 	if (participants.length === 0) return null;
 
 	const currentParticipant = participants[clampedTab] ?? participants[0];
-	const standLabel = formatStandLabel(stand);
+	// Members of a joint group share their participants, so the tapped stand
+	// still speaks for the whole unit apart from the label and products.
+	const cardStands = groupStands?.length ? groupStands : [stand];
+	const standLabel = formatStandsLabel(cardStands);
 	const categoryLabel = getCategoryLabel(stand.standCategory);
-	const products = stand.standSubcategories.map((sc) => sc.subcategory.label);
+	const products = getStandsProducts(cardStands);
 
 	return (
 		<div
@@ -113,7 +122,7 @@ export default function PublicMapStandCard({
 								{currentParticipant.displayName}
 							</h3>
 							<p className="text-sm text-muted-foreground">
-								Stand #{standLabel}
+								{cardStands.length > 1 ? "Stands" : "Stand"} {standLabel}
 								{sectorName ? ` • ${sectorName}` : ""}
 							</p>
 							{currentParticipant.kind === "external" && (

--- a/app/components/maps/public/public-map.tsx
+++ b/app/components/maps/public/public-map.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
 import { MapElementBase } from "@/app/lib/map_elements/definitions";
 import { MapBounds } from "@/app/components/maps/map-types";
+import {
+	indexJointGroupsByStandId,
+	resolveJointGroups,
+} from "@/app/lib/stands/groups";
 import {
 	getExternalParticipantStandColors,
 	getPublicStandColors,
@@ -38,7 +42,10 @@ export default function PublicMap({
 		useState<StandWithReservationsWithParticipants | null>(null);
 	const [hoveredRect, setHoveredRect] = useState<DOMRect | null>(null);
 
-	const visibleStands = stands.filter((s) => s.status !== "disabled");
+	const visibleStands = useMemo(
+		() => stands.filter((s) => s.status !== "disabled"),
+		[stands],
+	);
 
 	const handleHoverChange = useCallback(
 		(
@@ -52,12 +59,17 @@ export default function PublicMap({
 		[],
 	);
 
+	const jointGroupByStandId = useMemo(
+		() => indexJointGroupsByStandId(resolveJointGroups(visibleStands)),
+		[visibleStands],
+	);
+
 	const handleStandSelect = useCallback(
 		(stand: StandWithReservationsWithParticipants) => {
 			if (!isOccupied(stand)) return;
-			openCard(stand, sectorName);
+			openCard(stand, sectorName, jointGroupByStandId.get(stand.id)?.stands);
 		},
-		[openCard, sectorName],
+		[openCard, sectorName, jointGroupByStandId],
 	);
 
 	return (

--- a/app/components/maps/public/public-map.tsx
+++ b/app/components/maps/public/public-map.tsx
@@ -4,24 +4,22 @@ import { useCallback, useState } from "react";
 
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
 import { MapElementBase } from "@/app/lib/map_elements/definitions";
+import { MapBounds } from "@/app/components/maps/map-types";
 import {
-	computeCanvasBounds,
 	getExternalParticipantStandColors,
 	getPublicStandColors,
 } from "@/app/components/maps/map-utils";
 import { usePublicMapCard } from "@/app/components/maps/public/public-map-card-provider";
 import { hasExternalParticipants } from "@/app/components/maps/map-participants";
 
-import MapCanvas from "@/app/components/maps/map-canvas";
-import MapStand from "@/app/components/maps/map-stand";
-import MapElement from "@/app/components/maps/map-element";
+import MapSurface from "@/app/components/maps/map-surface";
 import PublicMapLegend from "@/app/components/maps/public/public-map-legend";
 import PublicMapTooltip from "@/app/components/maps/public/public-map-tooltip";
 
 type PublicMapProps = {
 	stands: StandWithReservationsWithParticipants[];
 	mapElements?: MapElementBase[];
-	mapBounds?: { minX: number; minY: number; width: number; height: number };
+	mapBounds?: MapBounds;
 	sectorName?: string;
 };
 
@@ -62,44 +60,27 @@ export default function PublicMap({
 		[openCard, sectorName],
 	);
 
-	const canvasBounds =
-		mapBounds ?? computeCanvasBounds(visibleStands, mapElements);
-
 	return (
 		<div className="flex flex-col items-center w-full">
-			<div className="flex w-full max-w-[500px] items-center pb-2">
+			<div className="flex w-full max-w-125 items-center pb-2">
 				<PublicMapLegend />
 			</div>
-			<div className="w-full max-w-[500px] rounded-lg border bg-background shadow-sm overflow-hidden">
+			<div className="w-full max-w-125 rounded-lg border bg-background shadow-sm overflow-hidden">
 				<div className="w-full">
-					<MapCanvas
-						config={{
-							minX: canvasBounds.minX,
-							minY: canvasBounds.minY,
-							width: canvasBounds.width,
-							height: canvasBounds.height,
-						}}
-					>
-						{mapElements?.map((element) => (
-							<MapElement key={`el-${element.id}`} element={element} />
-						))}
-						{visibleStands.map((stand) => (
-							<MapStand
-								key={stand.id}
-										stand={stand}
-										canBeReserved={false}
-										selected={stand.id === selectedStandId}
-										colors={
-											hasExternalParticipants(stand)
-												? getExternalParticipantStandColors()
-												: getPublicStandColors(stand.status)
-										}
-										onHoverChange={handleHoverChange}
-								onTouchTap={handleStandSelect}
-								onClick={handleStandSelect}
-							/>
-						))}
-					</MapCanvas>
+					<MapSurface
+						stands={visibleStands}
+						mapElements={mapElements}
+						mapBounds={mapBounds}
+						selectedStandId={selectedStandId}
+						getColors={(stand) =>
+							hasExternalParticipants(stand)
+								? getExternalParticipantStandColors()
+								: getPublicStandColors(stand.status)
+						}
+						onStandClick={handleStandSelect}
+						onStandTouchTap={handleStandSelect}
+						onStandHoverChange={handleHoverChange}
+					/>
 				</div>
 			</div>
 			{hoveredStand && hoveredRect && (

--- a/app/components/maps/user/user-map.tsx
+++ b/app/components/maps/user/user-map.tsx
@@ -1,29 +1,22 @@
 "use client";
 
-import { TransformComponent } from "react-zoom-pan-pinch";
-import { MapPin } from "lucide-react";
-
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
 import { BaseProfile, ProfileType } from "@/app/api/users/definitions";
 import { MapElementBase } from "@/app/lib/map_elements/definitions";
 import { canStandBeReserved } from "@/app/lib/stands/helpers";
 
-import MapCanvas from "@/app/components/maps/map-canvas";
-import MapStand from "@/app/components/maps/map-stand";
-import MapElement from "@/app/components/maps/map-element";
-import MapToolbar from "@/app/components/maps/map-toolbar";
 import MapLegend from "@/app/components/maps/map-legend";
-import MapTransformWrapper from "@/app/components/maps/map-transform-wrapper";
-import {
-  computeCanvasBounds,
-  getExternalParticipantStandColors,
-} from "@/app/components/maps/map-utils";
+import MapSurface from "@/app/components/maps/map-surface";
+import MapToolbar from "@/app/components/maps/map-toolbar";
+import ZoomableMapFrame from "@/app/components/maps/zoomable-map-frame";
+import { MapBounds } from "@/app/components/maps/map-types";
+import { getExternalParticipantStandColors } from "@/app/components/maps/map-utils";
 import { hasExternalParticipants } from "@/app/components/maps/map-participants";
 
 type UserMapProps = {
   stands: StandWithReservationsWithParticipants[];
   mapElements?: MapElementBase[];
-  mapBounds?: { minX: number; minY: number; width: number; height: number };
+  mapBounds?: MapBounds;
   profile?: ProfileType | BaseProfile | null;
   selectedStandId?: number | null;
   subcategoryIds?: number[];
@@ -41,67 +34,31 @@ export default function UserMap({
   onStandClick,
   onStandTouchTap,
 }: UserMapProps) {
-  const canvasBounds = mapBounds ?? computeCanvasBounds(stands, mapElements);
-
   return (
-    <div className="flex flex-col items-center w-full">
-      <MapTransformWrapper
-        initialScale={1}
-        minScale={1}
-        maxScale={4}
-        centerOnInit
-      >
-        <div className="flex w-full max-w-[500px] items-center justify-between pb-2">
+    <ZoomableMapFrame
+      header={
+        <>
           <MapLegend />
           <MapToolbar />
-        </div>
-        <div className="relative w-full max-w-[500px] rounded-lg border bg-background shadow-sm overflow-hidden pb-8 md:pb-0">
-          <TransformComponent
-            wrapperStyle={{ width: "100%" }}
-            contentStyle={{ width: "100%" }}
-          >
-            <MapCanvas
-              config={{
-                minX: canvasBounds.minX,
-                minY: canvasBounds.minY,
-                width: canvasBounds.width,
-                height: canvasBounds.height,
-              }}
-            >
-              {mapElements?.map((element) => (
-                <MapElement key={`el-${element.id}`} element={element} />
-              ))}
-              {stands.map((stand) => {
-                const standCanBeReserved =
-                  !!profile &&
-                  canStandBeReserved(stand, profile, subcategoryIds);
-
-                return (
-                  <MapStand
-                    key={stand.id}
-                    stand={stand}
-                    canBeReserved={standCanBeReserved}
-                    selected={stand.id === selectedStandId}
-                    colors={
-                      hasExternalParticipants(stand)
-                        ? getExternalParticipantStandColors()
-                        : undefined
-                    }
-                    onClick={onStandClick}
-                    onTouchTap={onStandTouchTap}
-                  />
-                );
-              })}
-            </MapCanvas>
-          </TransformComponent>
-          <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 md:hidden">
-            <div className="flex items-center gap-1.5 rounded-full bg-gray-900/80 px-3 py-1.5 text-white backdrop-blur-sm">
-              <MapPin className="h-3 w-3" />
-              <span className="text-xs font-medium">Pellizca para ampliar</span>
-            </div>
-          </div>
-        </div>
-      </MapTransformWrapper>
-    </div>
+        </>
+      }
+    >
+      <MapSurface
+        stands={stands}
+        mapElements={mapElements}
+        mapBounds={mapBounds}
+        selectedStandId={selectedStandId}
+        canBeReserved={(stand) =>
+          !!profile && canStandBeReserved(stand, profile, subcategoryIds)
+        }
+        getColors={(stand) =>
+          hasExternalParticipants(stand)
+            ? getExternalParticipantStandColors()
+            : undefined
+        }
+        onStandClick={onStandClick}
+        onStandTouchTap={onStandTouchTap}
+      />
+    </ZoomableMapFrame>
   );
 }

--- a/app/components/maps/zoomable-map-frame.tsx
+++ b/app/components/maps/zoomable-map-frame.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { TransformComponent } from "react-zoom-pan-pinch";
+
+import MapPinchHint from "@/app/components/maps/map-pinch-hint";
+import MapTransformWrapper from "@/app/components/maps/map-transform-wrapper";
+
+type ZoomableMapFrameProps = {
+  /** Row rendered above the map, laid out with space between its children */
+  header?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+/**
+ * Bordered, zoom/pan enabled shell around a MapSurface, with the mobile pinch
+ * hint. Used by the maps that share the centered 500px card layout.
+ */
+export default function ZoomableMapFrame({
+  header,
+  children,
+}: ZoomableMapFrameProps) {
+  return (
+    <div className="flex flex-col items-center w-full">
+      <MapTransformWrapper
+        initialScale={1}
+        minScale={1}
+        maxScale={4}
+        centerOnInit
+      >
+        {header && (
+          <div className="flex w-full max-w-125 items-center justify-between pb-2">
+            {header}
+          </div>
+        )}
+        <div className="relative w-full max-w-125 rounded-lg border bg-background shadow-sm overflow-hidden pb-8 md:pb-0">
+          <TransformComponent
+            wrapperStyle={{ width: "100%" }}
+            contentStyle={{ width: "100%" }}
+          >
+            {children}
+          </TransformComponent>
+          <MapPinchHint />
+        </div>
+      </MapTransformWrapper>
+    </div>
+  );
+}

--- a/app/components/organisms/upcoming-festival/info-tab-content.tsx
+++ b/app/components/organisms/upcoming-festival/info-tab-content.tsx
@@ -51,7 +51,7 @@ export default function InfoTabContent({
         {reservation && (
           <div>
             <h3 className="font-semibold">
-              Espacio #{reservation.stand.label}
+              Espacio {reservation.stand.label}
               {reservation.stand.standNumber}
             </h3>
             <div className="mt-2 flex flex-wrap items-center gap-2">

--- a/app/dashboard/programs/[id]/sessions/[sessionId]/page.tsx
+++ b/app/dashboard/programs/[id]/sessions/[sessionId]/page.tsx
@@ -29,6 +29,7 @@ import {
   SESSION_PUBLISH_BLOCKER_LABELS,
   resolveSessionPublishability,
 } from "@/app/lib/programs/state";
+import { fetchOccurrenceSummaries } from "@/app/lib/programs/occurrence-queries";
 import { requireAdminOrFestivalAdmin } from "@/app/lib/users/helpers";
 
 type Props = {
@@ -53,6 +54,9 @@ export default async function SessionDetailPage({ params }: Props) {
   ]);
 
   if (!session || session.programId !== programId) notFound();
+
+  // After the session is known, so an unknown id costs no roster query.
+  const summaries = await fetchOccurrenceSummaries(session.occurrences);
 
   const publishability = resolveSessionPublishability({
     status: session.status,
@@ -130,6 +134,7 @@ export default async function SessionDetailPage({ params }: Props) {
                     defaultCapacity={settings.defaultOccurrenceCapacity}
                     programStatus={session.program.status}
                     sessionStatus={session.status}
+                    summary={summaries.get(occurrence.id)}
                   />
                 ))}
               </ul>

--- a/app/dashboard/programs/occurrences/[occurrenceId]/page.tsx
+++ b/app/dashboard/programs/occurrences/[occurrenceId]/page.tsx
@@ -14,9 +14,8 @@ import {
 import { formatDate } from "@/app/lib/formatters";
 import { SESSION_TYPE_LABELS } from "@/app/lib/programs/definitions";
 import {
+  fetchOccurrenceDashboard,
   fetchOccurrenceForAdmin,
-  fetchOccurrenceRosters,
-  fetchOccurrenceSummaries,
 } from "@/app/lib/programs/occurrence-queries";
 import { resolveOccurrenceState } from "@/app/lib/programs/state";
 import { requireAdminOrFestivalAdmin } from "@/app/lib/users/helpers";
@@ -39,15 +38,11 @@ export default async function OccurrenceDashboardPage({ params }: Props) {
   const { session } = occurrence;
   const { program } = session;
 
-  const [summaries, rosters] = await Promise.all([
-    fetchOccurrenceSummaries([
-      { id: occurrence.id, capacity: occurrence.capacity },
-    ]),
-    fetchOccurrenceRosters([occurrence.id]),
-  ]);
-
-  const summary = summaries.get(occurrence.id);
-  const entries = rosters.get(occurrence.id) ?? [];
+  // One load, one `now`: the badge above and the table below are the same read.
+  const { summary, entries } = await fetchOccurrenceDashboard({
+    id: occurrence.id,
+    capacity: occurrence.capacity,
+  });
 
   const resolved = resolveOccurrenceState({
     programStatus: program.status,
@@ -86,7 +81,7 @@ export default async function OccurrenceDashboardPage({ params }: Props) {
           {occurrence.venue ? ` · ${occurrence.venue.name}` : ""}
           {occurrence.room ? ` · ${occurrence.room}` : ""}
         </p>
-        {summary ? <OccurrenceSeatSummary summary={summary} /> : null}
+        <OccurrenceSeatSummary summary={summary} />
       </div>
 
       <Card>

--- a/app/dashboard/programs/occurrences/[occurrenceId]/page.tsx
+++ b/app/dashboard/programs/occurrences/[occurrenceId]/page.tsx
@@ -1,0 +1,102 @@
+import { DateTime } from "luxon";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import OccurrenceRosterTable from "@/app/components/dashboard/programs/occurrence-roster-table";
+import OccurrenceSeatSummary from "@/app/components/dashboard/programs/occurrence-seat-summary";
+import ProgramStatusBadge from "@/app/components/programs/program-status-badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/app/components/ui/card";
+import { formatDate } from "@/app/lib/formatters";
+import { SESSION_TYPE_LABELS } from "@/app/lib/programs/definitions";
+import {
+  fetchOccurrenceForAdmin,
+  fetchOccurrenceRosters,
+  fetchOccurrenceSummaries,
+} from "@/app/lib/programs/occurrence-queries";
+import { resolveOccurrenceState } from "@/app/lib/programs/state";
+import { requireAdminOrFestivalAdmin } from "@/app/lib/users/helpers";
+
+type Props = {
+  params: Promise<{ occurrenceId: string }>;
+};
+
+export default async function OccurrenceDashboardPage({ params }: Props) {
+  const profile = await requireAdminOrFestivalAdmin();
+  if (!profile) redirect("/dashboard");
+
+  const { occurrenceId: rawId } = await params;
+  const occurrenceId = Number(rawId);
+  if (!Number.isInteger(occurrenceId)) notFound();
+
+  const occurrence = await fetchOccurrenceForAdmin(occurrenceId);
+  if (!occurrence) notFound();
+
+  const { session } = occurrence;
+  const { program } = session;
+
+  const [summaries, rosters] = await Promise.all([
+    fetchOccurrenceSummaries([
+      { id: occurrence.id, capacity: occurrence.capacity },
+    ]),
+    fetchOccurrenceRosters([occurrence.id]),
+  ]);
+
+  const summary = summaries.get(occurrence.id);
+  const entries = rosters.get(occurrence.id) ?? [];
+
+  const resolved = resolveOccurrenceState({
+    programStatus: program.status,
+    sessionStatus: session.status,
+    lifecycleStatus: occurrence.lifecycleStatus,
+    salesStartAt: occurrence.salesStartAt,
+    salesEndAt: occurrence.salesEndAt,
+    salesClosedAt: occurrence.salesClosedAt,
+    rescheduledAt: occurrence.rescheduledAt,
+  });
+
+  return (
+    <div className="container mx-auto space-y-6 py-6">
+      <div className="space-y-2">
+        <Link
+          href={`/dashboard/programs/${program.id}/sessions/${session.id}`}
+          className="text-sm text-muted-foreground underline-offset-2 hover:underline"
+        >
+          ← {session.title}
+        </Link>
+        <div className="flex flex-wrap items-center gap-2">
+          <h1 className="text-2xl font-bold">
+            {formatDate(occurrence.startsAt).toLocaleString(
+              DateTime.DATETIME_MED,
+            )}
+            {" — "}
+            {formatDate(occurrence.endsAt).toLocaleString(DateTime.TIME_SIMPLE)}
+          </h1>
+          <ProgramStatusBadge
+            state={resolved.state}
+            wasRescheduled={resolved.wasRescheduled}
+          />
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {program.name} · {SESSION_TYPE_LABELS[session.type]}
+          {occurrence.venue ? ` · ${occurrence.venue.name}` : ""}
+          {occurrence.room ? ` · ${occurrence.room}` : ""}
+        </p>
+        {summary ? <OccurrenceSeatSummary summary={summary} /> : null}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Inscritos</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <OccurrenceRosterTable entries={entries} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/lib/orders/actions.ts
+++ b/app/lib/orders/actions.ts
@@ -51,7 +51,10 @@ import {
 } from "@/app/lib/rentals/validation";
 import type { ProductTransactionType } from "@/app/lib/rentals/types";
 import type { RentalOrderFilter } from "@/app/lib/rentals/order-filters";
-import { getPostHogClient } from "@/app/lib/posthog-server";
+import {
+  getPostHogClient,
+  POSTHOG_SHUTDOWN_TIMEOUT_MS,
+} from "@/app/lib/posthog-server";
 import { POSTHOG_EVENTS } from "@/app/lib/posthog-events";
 import {
   getOrderItemDisplayName,
@@ -1240,7 +1243,7 @@ export async function submitOrderPaymentVoucher(
         event: POSTHOG_EVENTS.ORDER_PAYMENT_VOUCHER_UPLOADED,
         properties: { order_id: orderId },
       });
-      await posthog.shutdown();
+      await posthog.shutdown(POSTHOG_SHUTDOWN_TIMEOUT_MS);
     } catch (posthogError) {
       console.error("[submitOrderPaymentVoucher] PostHog capture failed", {
         orderId,
@@ -1320,7 +1323,7 @@ export async function submitGuestOrderPaymentVoucher(
         event: POSTHOG_EVENTS.ORDER_PAYMENT_VOUCHER_UPLOADED,
         properties: { order_id: orderId, is_guest: true },
       });
-      await posthog.shutdown();
+      await posthog.shutdown(POSTHOG_SHUTDOWN_TIMEOUT_MS);
     } catch (posthogError) {
       console.error("[submitGuestOrderPaymentVoucher] PostHog capture failed", {
         orderId,

--- a/app/lib/posthog-server.ts
+++ b/app/lib/posthog-server.ts
@@ -5,6 +5,22 @@ const noop = new Proxy({} as PostHog, {
   get: () => async () => {},
 });
 
+/**
+ * How long `shutdown()` may block before the caller gives up on the flush.
+ *
+ * Every capture in this app is awaited inside a request or a server action,
+ * *after* the work it reports has already been committed. `shutdown()` defaults
+ * to 30 seconds, so an unreachable PostHog would hold the response open for
+ * half a minute and then, past `vercel.json`'s `maxDuration`, hand the user an
+ * error for an operation that in fact succeeded. Wrapping the capture in
+ * try/catch does not help: the failure mode is a hang, not a throw.
+ *
+ * Five seconds is far above a healthy flush — the client is configured
+ * `flushAt: 1, flushInterval: 0`, so the event is already in flight — and far
+ * below anything a person would wait through.
+ */
+export const POSTHOG_SHUTDOWN_TIMEOUT_MS = 5_000;
+
 export function getPostHogClient(): PostHog {
   if (serverEnv.VERCEL_ENV !== "production") return noop;
   return new PostHog(getClientEnv().NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {

--- a/app/lib/programs/occurrence-queries.ts
+++ b/app/lib/programs/occurrence-queries.ts
@@ -1,0 +1,229 @@
+import "server-only";
+
+import { and, asc, eq, inArray, notInArray } from "drizzle-orm";
+import { cache } from "react";
+
+import { resolveAvailability } from "@/app/lib/programs/inventory";
+import { resolveAttendeeIdentity } from "@/app/lib/programs/registration";
+import {
+  resolveRosterSeatState,
+  rosterStateOrder,
+  summarizeRoster,
+  type RosterSeatState,
+  type RosterTotals,
+} from "@/app/lib/programs/roster";
+import { db } from "@/db";
+import {
+  sessionOccurrences,
+  sessionPurchaseLines,
+  sessionWaitlistEntries,
+} from "@/db/schema";
+
+/** One seat in one occurrence, as the admin roster shows it. */
+export type RosterEntry = {
+  lineId: number;
+  purchaseId: number;
+  state: RosterSeatState;
+  attendeeName: string;
+  attendeeEmail: string;
+  /** Only guests give one; a signed-in buyer's phone lives on their profile. */
+  attendeePhone: string | null;
+  isGuest: boolean;
+  ticketCode: string | null;
+  unitPrice: number;
+  isFree: boolean;
+  holdExpiresAt: Date | null;
+  createdAt: Date;
+};
+
+export type OccurrenceRosterSummary = {
+  occurrenceId: number;
+  capacity: number;
+  totals: RosterTotals;
+  remaining: number;
+  isSoldOut: boolean;
+  waitlistActive: number;
+};
+
+/**
+ * Everyone who has taken a seat in these occurrences, grouped by occurrence.
+ *
+ * One query for the whole session rather than one per occurrence: a session
+ * lists a handful of occurrences of at most a few dozen seats, so the rows are
+ * cheap, and computing every count in TypeScript from a single source is what
+ * keeps the list totals and the detail page from ever disagreeing.
+ *
+ * Buyers who abandoned checkout are included and land in `released`. They are
+ * not noise — "eleven people started and three finished" is the signal that
+ * something in the payment step is broken.
+ */
+export async function fetchOccurrenceRosters(
+  occurrenceIds: number[],
+  options: { now?: Date } = {},
+): Promise<Map<number, RosterEntry[]>> {
+  const byOccurrence = new Map<number, RosterEntry[]>();
+  if (occurrenceIds.length === 0) return byOccurrence;
+
+  const now = options.now ?? new Date();
+
+  const lines = await db.query.sessionPurchaseLines.findMany({
+    where: inArray(sessionPurchaseLines.occurrenceId, occurrenceIds),
+    with: {
+      purchase: { with: { buyer: true } },
+      ticket: true,
+    },
+    orderBy: [asc(sessionPurchaseLines.id)],
+  });
+
+  for (const line of lines) {
+    const { purchase } = line;
+
+    const state = resolveRosterSeatState(
+      {
+        purchaseStatus: purchase.status,
+        ticketStatus: line.ticket?.status ?? null,
+        holdExpiresAt: purchase.holdExpiresAt,
+      },
+      now,
+    );
+
+    /**
+     * The ticket is the most authoritative name once issued — it is what was
+     * printed and emailed. Before that, identity comes from the same helper
+     * checkout used, so the roster shows exactly who the purchase was made as.
+     */
+    const identity =
+      line.ticket !== null && line.ticket !== undefined
+        ? {
+            userId: purchase.userId,
+            name: line.ticket.attendeeName,
+            email: line.ticket.attendeeEmail,
+          }
+        : resolveAttendeeIdentity(
+            purchase.buyer ?? null,
+            purchase.guestName && purchase.guestEmail
+              ? { name: purchase.guestName, email: purchase.guestEmail }
+              : null,
+          );
+
+    const entries = byOccurrence.get(line.occurrenceId) ?? [];
+    entries.push({
+      lineId: line.id,
+      purchaseId: purchase.id,
+      state,
+      // An anonymized purchase (a deleted account) keeps its seat but loses its
+      // person, so the roster says so rather than rendering an empty cell.
+      attendeeName: identity?.name ?? "Registro anonimizado",
+      attendeeEmail: identity?.email ?? "—",
+      attendeePhone: purchase.guestPhone,
+      isGuest: purchase.userId === null,
+      ticketCode: line.ticket?.code ?? null,
+      unitPrice: line.unitPrice,
+      isFree: purchase.paymentMode === "free",
+      holdExpiresAt: purchase.holdExpiresAt,
+      createdAt: purchase.createdAt,
+    });
+    byOccurrence.set(line.occurrenceId, entries);
+  }
+
+  for (const entries of byOccurrence.values()) {
+    entries.sort(
+      (a, b) =>
+        rosterStateOrder(a.state) - rosterStateOrder(b.state) ||
+        a.attendeeName.localeCompare(b.attendeeName, "es"),
+    );
+  }
+
+  return byOccurrence;
+}
+
+/** Active waitlist size per occurrence — neither removed nor already converted. */
+async function fetchWaitlistCounts(
+  occurrenceIds: number[],
+): Promise<Map<number, number>> {
+  const counts = new Map<number, number>();
+  if (occurrenceIds.length === 0) return counts;
+
+  const rows = await db
+    .select({
+      occurrenceId: sessionWaitlistEntries.occurrenceId,
+      id: sessionWaitlistEntries.id,
+    })
+    .from(sessionWaitlistEntries)
+    .where(
+      and(
+        inArray(sessionWaitlistEntries.occurrenceId, occurrenceIds),
+        // Someone who withdrew, was taken off, or already bought their seat is
+        // not still waiting — counting them would tell an admin to invite from
+        // a list that is emptier than it looks.
+        notInArray(sessionWaitlistEntries.status, ["removed", "converted"]),
+      ),
+    );
+
+  for (const row of rows) {
+    counts.set(row.occurrenceId, (counts.get(row.occurrenceId) ?? 0) + 1);
+  }
+
+  return counts;
+}
+
+/**
+ * Seat counts for every occurrence in a list, for the admin session page.
+ *
+ * `remaining` comes from `resolveAvailability` — the same function the public
+ * pages and checkout use — fed from the roster totals, so the number an admin
+ * reads is the number a buyer is allowed to take.
+ */
+export async function fetchOccurrenceSummaries(
+  occurrences: { id: number; capacity: number }[],
+  options: { now?: Date } = {},
+): Promise<Map<number, OccurrenceRosterSummary>> {
+  const summaries = new Map<number, OccurrenceRosterSummary>();
+  if (occurrences.length === 0) return summaries;
+
+  const ids = occurrences.map((occurrence) => occurrence.id);
+  const [rosters, waitlist] = await Promise.all([
+    fetchOccurrenceRosters(ids, options),
+    fetchWaitlistCounts(ids),
+  ]);
+
+  for (const occurrence of occurrences) {
+    const entries = rosters.get(occurrence.id) ?? [];
+    const totals = summarizeRoster(entries.map((entry) => entry.state));
+
+    const availability = resolveAvailability({
+      capacity: occurrence.capacity,
+      validTickets: totals.confirmed,
+      activeHolds:
+        totals.awaitingReview + totals.changesRequested + totals.holding,
+    });
+
+    summaries.set(occurrence.id, {
+      occurrenceId: occurrence.id,
+      capacity: occurrence.capacity,
+      totals,
+      remaining: availability.remaining,
+      isSoldOut: availability.isSoldOut,
+      waitlistActive: waitlist.get(occurrence.id) ?? 0,
+    });
+  }
+
+  return summaries;
+}
+
+/** The occurrence plus the context the detail page's heading needs. */
+export const fetchOccurrenceForAdmin = cache(async (occurrenceId: number) => {
+  return db.query.sessionOccurrences.findFirst({
+    where: eq(sessionOccurrences.id, occurrenceId),
+    with: {
+      venue: true,
+      session: { with: { program: true } },
+    },
+  });
+});
+
+export type OccurrenceForAdmin = NonNullable<
+  Awaited<ReturnType<typeof fetchOccurrenceForAdmin>>
+>;
+
+export type { RosterSeatState };

--- a/app/lib/programs/occurrence-queries.ts
+++ b/app/lib/programs/occurrence-queries.ts
@@ -168,12 +168,37 @@ async function fetchWaitlistCounts(
 }
 
 /**
- * Seat counts for every occurrence in a list, for the admin session page.
+ * Turns one occurrence's roster into its seat counts.
  *
  * `remaining` comes from `resolveAvailability` — the same function the public
  * pages and checkout use — fed from the roster totals, so the number an admin
  * reads is the number a buyer is allowed to take.
  */
+function buildSummary(
+  occurrence: { id: number; capacity: number },
+  entries: RosterEntry[],
+  waitlistActive: number,
+): OccurrenceRosterSummary {
+  const totals = summarizeRoster(entries.map((entry) => entry.state));
+
+  const availability = resolveAvailability({
+    capacity: occurrence.capacity,
+    validTickets: totals.confirmed,
+    activeHolds:
+      totals.awaitingReview + totals.changesRequested + totals.holding,
+  });
+
+  return {
+    occurrenceId: occurrence.id,
+    capacity: occurrence.capacity,
+    totals,
+    remaining: availability.remaining,
+    isSoldOut: availability.isSoldOut,
+    waitlistActive,
+  };
+}
+
+/** Seat counts for every occurrence in a list, for the admin session page. */
 export async function fetchOccurrenceSummaries(
   occurrences: { id: number; capacity: number }[],
   options: { now?: Date } = {},
@@ -181,34 +206,60 @@ export async function fetchOccurrenceSummaries(
   const summaries = new Map<number, OccurrenceRosterSummary>();
   if (occurrences.length === 0) return summaries;
 
+  // Pinned once. Left to default, every occurrence in the list would be judged
+  // against a slightly different instant.
+  const now = options.now ?? new Date();
   const ids = occurrences.map((occurrence) => occurrence.id);
+
   const [rosters, waitlist] = await Promise.all([
-    fetchOccurrenceRosters(ids, options),
+    fetchOccurrenceRosters(ids, { now }),
     fetchWaitlistCounts(ids),
   ]);
 
   for (const occurrence of occurrences) {
-    const entries = rosters.get(occurrence.id) ?? [];
-    const totals = summarizeRoster(entries.map((entry) => entry.state));
-
-    const availability = resolveAvailability({
-      capacity: occurrence.capacity,
-      validTickets: totals.confirmed,
-      activeHolds:
-        totals.awaitingReview + totals.changesRequested + totals.holding,
-    });
-
-    summaries.set(occurrence.id, {
-      occurrenceId: occurrence.id,
-      capacity: occurrence.capacity,
-      totals,
-      remaining: availability.remaining,
-      isSoldOut: availability.isSoldOut,
-      waitlistActive: waitlist.get(occurrence.id) ?? 0,
-    });
+    summaries.set(
+      occurrence.id,
+      buildSummary(
+        occurrence,
+        rosters.get(occurrence.id) ?? [],
+        waitlist.get(occurrence.id) ?? 0,
+      ),
+    );
   }
 
   return summaries;
+}
+
+/**
+ * Both halves of one occurrence's dashboard from a single roster load.
+ *
+ * The detail page renders the counts and the list of people side by side, and
+ * they have to be the same read. Calling `fetchOccurrenceSummaries` and
+ * `fetchOccurrenceRosters` separately ran the query twice against two
+ * independently defaulted `now` values — a hold expiring in the gap would be
+ * `holding` in the badge and `released` in the table, on the same screen.
+ */
+export async function fetchOccurrenceDashboard(
+  occurrence: { id: number; capacity: number },
+  options: { now?: Date } = {},
+): Promise<{ summary: OccurrenceRosterSummary; entries: RosterEntry[] }> {
+  const now = options.now ?? new Date();
+
+  const [rosters, waitlist] = await Promise.all([
+    fetchOccurrenceRosters([occurrence.id], { now }),
+    fetchWaitlistCounts([occurrence.id]),
+  ]);
+
+  const entries = rosters.get(occurrence.id) ?? [];
+
+  return {
+    summary: buildSummary(
+      occurrence,
+      entries,
+      waitlist.get(occurrence.id) ?? 0,
+    ),
+    entries,
+  };
 }
 
 /** The occurrence plus the context the detail page's heading needs. */

--- a/app/lib/programs/review-actions.ts
+++ b/app/lib/programs/review-actions.ts
@@ -16,8 +16,10 @@ import {
   REGISTRATION_BLOCKER_LABELS,
 } from "@/app/lib/programs/registration";
 import {
+  DEFAULT_APPROVAL_AUDIT_REASON,
   REVIEW_BLOCKER_LABELS,
   REVIEW_DECISION_STATUS,
+  reviewDecisionRequiresReason,
   resolveReviewDecision,
   type ReviewDecision,
 } from "@/app/lib/programs/review";
@@ -37,16 +39,25 @@ import {
   venues,
 } from "@/db/schema";
 
-const reviewSchema = z.object({
-  purchaseId: z.number().int().positive(),
-  decision: z.enum(["approve", "reject", "request_changes"]),
-  /**
-   * Required for every decision. PRD §14: "every sensitive admin action
-   * requires a reason" — and the buyer sees this text when changes are
-   * requested, so it is the message as much as the audit record.
-   */
-  reason: z.string().trim().min(3).max(500),
-});
+const reviewSchema = z
+  .object({
+    purchaseId: z.number().int().positive(),
+    decision: z.enum(["approve", "reject", "request_changes"]),
+    /**
+     * Approval may be self-explanatory. Adverse decisions require a reason, and
+     * the buyer sees it when changes are requested.
+     */
+    reason: z.string().trim().max(500).default(""),
+  })
+  .superRefine((data, context) => {
+    if (reviewDecisionRequiresReason(data.decision) && data.reason.length < 3) {
+      context.addIssue({
+        code: "custom",
+        path: ["reason"],
+        message: "Escribe el motivo de tu decisión",
+      });
+    }
+  });
 
 export type ReviewPurchaseInput = z.input<typeof reviewSchema>;
 
@@ -242,7 +253,10 @@ export async function reviewPurchase(
         eventType: DECISION_EVENT[data.decision],
         fromStatus: purchase.status,
         toStatus,
-        reason: data.reason,
+        // Admin events must always carry a reason at the database level. A
+        // correct payment needs no message from the reviewer, so record a
+        // neutral audit description when approval was submitted blank.
+        reason: data.reason || DEFAULT_APPROVAL_AUDIT_REASON,
         changes: { ticketsIssued },
       });
 

--- a/app/lib/programs/review.test.ts
+++ b/app/lib/programs/review.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  DEFAULT_APPROVAL_AUDIT_REASON,
   REVIEW_DECISION_STATUS,
+  reviewDecisionRequiresReason,
   resolveReviewDecision,
   type ReviewSubject,
 } from "@/app/lib/programs/review";
@@ -79,4 +81,18 @@ describe("REVIEW_DECISION_STATUS", () => {
       request_changes: "changes_requested",
     });
   });
+});
+
+describe("reviewDecisionRequiresReason", () => {
+  it("allows approval without a reason", () => {
+    expect(reviewDecisionRequiresReason("approve")).toBe(false);
+    expect(DEFAULT_APPROVAL_AUDIT_REASON.trim().length).toBeGreaterThan(0);
+  });
+
+  it.each(["reject", "request_changes"] as const)(
+    "requires a reason to %s",
+    (decision) => {
+      expect(reviewDecisionRequiresReason(decision)).toBe(true);
+    },
+  );
 });

--- a/app/lib/programs/review.ts
+++ b/app/lib/programs/review.ts
@@ -12,6 +12,16 @@ import type { SessionPurchaseStatus } from "@/app/lib/programs/definitions";
 
 export type ReviewDecision = "approve" | "reject" | "request_changes";
 
+export const DEFAULT_APPROVAL_AUDIT_REASON =
+  "Pago verificado sin observaciones";
+
+/** Approval needs no explanation; adverse decisions need an audit message. */
+export function reviewDecisionRequiresReason(
+  decision: ReviewDecision,
+): boolean {
+  return decision !== "approve";
+}
+
 export type ReviewBlocker =
   | "not_payable"
   | "no_voucher"

--- a/app/lib/programs/roster.test.ts
+++ b/app/lib/programs/roster.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveAvailability } from "@/app/lib/programs/inventory";
+import type { SessionPurchaseStatus } from "@/app/lib/programs/definitions";
+import {
+  occupiesSeat,
+  resolveRosterSeatState,
+  summarizeRoster,
+  type RosterSeatInput,
+  type RosterSeatState,
+} from "@/app/lib/programs/roster";
+
+const NOW = new Date("2026-08-01T12:00:00.000Z");
+const LIVE_HOLD = new Date("2026-08-01T12:15:00.000Z");
+const LAPSED_HOLD = new Date("2026-08-01T11:45:00.000Z");
+
+function seat(overrides: Partial<RosterSeatInput> = {}): RosterSeatInput {
+  return {
+    purchaseStatus: "pending_upload",
+    ticketStatus: null,
+    holdExpiresAt: LIVE_HOLD,
+    ...overrides,
+  };
+}
+
+describe("resolveRosterSeatState", () => {
+  it("treats a valid ticket as confirmed whatever the purchase says", () => {
+    expect(
+      resolveRosterSeatState(
+        seat({ purchaseStatus: "approved", ticketStatus: "valid" }),
+        NOW,
+      ),
+    ).toBe("confirmed");
+  });
+
+  it("releases the seat when the ticket was cancelled", () => {
+    // Support cancels the ticket to free the seat; the purchase row still says
+    // `approved`, and the roster has to agree with the seat count, not the row.
+    expect(
+      resolveRosterSeatState(
+        seat({ purchaseStatus: "approved", ticketStatus: "cancelled" }),
+        NOW,
+      ),
+    ).toBe("released");
+  });
+
+  it("distinguishes the two review states", () => {
+    expect(
+      resolveRosterSeatState(
+        seat({ purchaseStatus: "under_verification", holdExpiresAt: null }),
+        NOW,
+      ),
+    ).toBe("awaiting_review");
+    expect(
+      resolveRosterSeatState(
+        seat({ purchaseStatus: "changes_requested", holdExpiresAt: null }),
+        NOW,
+      ),
+    ).toBe("changes_requested");
+  });
+
+  it("keeps a purchase under review even past its old deadline", () => {
+    // Uploading a voucher stops the clock; the seat is held by the review.
+    expect(
+      resolveRosterSeatState(
+        seat({
+          purchaseStatus: "under_verification",
+          holdExpiresAt: LAPSED_HOLD,
+        }),
+        NOW,
+      ),
+    ).toBe("awaiting_review");
+  });
+
+  it("holds only while the deadline is live", () => {
+    expect(
+      resolveRosterSeatState(seat({ holdExpiresAt: LIVE_HOLD }), NOW),
+    ).toBe("holding");
+    expect(
+      resolveRosterSeatState(seat({ holdExpiresAt: LAPSED_HOLD }), NOW),
+    ).toBe("released");
+    // Exactly at the deadline the seat is gone: the query uses `>`, not `>=`.
+    expect(resolveRosterSeatState(seat({ holdExpiresAt: NOW }), NOW)).toBe(
+      "released",
+    );
+    expect(resolveRosterSeatState(seat({ holdExpiresAt: null }), NOW)).toBe(
+      "released",
+    );
+  });
+
+  it("releases every terminal purchase state", () => {
+    for (const status of [
+      "rejected",
+      "expired",
+      "cancelled",
+    ] as SessionPurchaseStatus[]) {
+      expect(
+        resolveRosterSeatState(seat({ purchaseStatus: status }), NOW),
+      ).toBe("released");
+    }
+  });
+});
+
+describe("summarizeRoster", () => {
+  it("counts each state and sums occupancy", () => {
+    const totals = summarizeRoster([
+      "confirmed",
+      "confirmed",
+      "awaiting_review",
+      "changes_requested",
+      "holding",
+      "released",
+      "released",
+    ]);
+
+    expect(totals).toEqual({
+      confirmed: 2,
+      awaitingReview: 1,
+      changesRequested: 1,
+      holding: 1,
+      released: 2,
+      occupied: 5,
+      needsAction: 2,
+    });
+  });
+
+  it("is empty for an occurrence nobody has touched", () => {
+    expect(summarizeRoster([])).toEqual({
+      confirmed: 0,
+      awaitingReview: 0,
+      changesRequested: 0,
+      holding: 0,
+      released: 0,
+      occupied: 0,
+      needsAction: 0,
+    });
+  });
+});
+
+describe("roster occupancy reconciles with resolveAvailability", () => {
+  /**
+   * The point of the whole module. The dashboard shows a roster and a
+   * "X de Y cupos" count side by side; if they are computed from different
+   * rules they will disagree in front of an admin, and the seat count is the
+   * one people act on. This pins them together.
+   */
+  const cases: { label: string; seats: RosterSeatInput[]; capacity: number }[] =
+    [
+      {
+        label: "a full occurrence of confirmed tickets",
+        capacity: 3,
+        seats: [
+          seat({ purchaseStatus: "approved", ticketStatus: "valid" }),
+          seat({ purchaseStatus: "approved", ticketStatus: "valid" }),
+          seat({ purchaseStatus: "approved", ticketStatus: "valid" }),
+        ],
+      },
+      {
+        label: "a mix of tickets, reviews and live holds",
+        capacity: 10,
+        seats: [
+          seat({ purchaseStatus: "approved", ticketStatus: "valid" }),
+          seat({ purchaseStatus: "under_verification", holdExpiresAt: null }),
+          seat({ purchaseStatus: "changes_requested", holdExpiresAt: null }),
+          seat({ holdExpiresAt: LIVE_HOLD }),
+        ],
+      },
+      {
+        label: "abandoned and cancelled seats that must not be counted",
+        capacity: 5,
+        seats: [
+          seat({ purchaseStatus: "approved", ticketStatus: "valid" }),
+          seat({ holdExpiresAt: LAPSED_HOLD }),
+          seat({ purchaseStatus: "expired" }),
+          seat({ purchaseStatus: "approved", ticketStatus: "cancelled" }),
+        ],
+      },
+    ];
+
+  for (const { label, seats, capacity } of cases) {
+    it(label, () => {
+      const states: RosterSeatState[] = seats.map((input) =>
+        resolveRosterSeatState(input, NOW),
+      );
+      const totals = summarizeRoster(states);
+
+      // Rebuild the availability inputs the way the SQL does: valid tickets,
+      // plus lines whose purchase is under review or still holding.
+      const availability = resolveAvailability({
+        capacity,
+        validTickets: totals.confirmed,
+        activeHolds:
+          totals.awaitingReview + totals.changesRequested + totals.holding,
+      });
+
+      expect(totals.occupied).toBe(availability.occupied);
+      expect(capacity - totals.occupied).toBe(availability.remaining);
+      expect(states.filter(occupiesSeat)).toHaveLength(availability.occupied);
+    });
+  }
+});

--- a/app/lib/programs/roster.ts
+++ b/app/lib/programs/roster.ts
@@ -1,0 +1,130 @@
+import type {
+  SessionPurchaseStatus,
+  SessionTicketStatus,
+} from "@/app/lib/programs/definitions";
+
+/**
+ * What a person on an occurrence's roster is actually doing with their seat.
+ *
+ * Deliberately *not* the purchase status. A purchase left in `pending_upload`
+ * past its deadline still reads `pending_upload` in the database until the
+ * sweep runs, but its seat is already available to the next buyer — showing an
+ * admin a list of people who are not coming, and a "held" count that does not
+ * match the remaining count beside it, is worse than showing nothing.
+ *
+ * The states below partition the roster so that everything except `released`
+ * occupies exactly one seat, which is what makes the counts reconcile with
+ * `resolveAvailability`. `roster.test.ts` pins that agreement.
+ */
+export type RosterSeatState =
+  | "confirmed"
+  | "awaiting_review"
+  | "changes_requested"
+  | "holding"
+  | "released";
+
+export const ROSTER_SEAT_STATE_LABELS: Record<RosterSeatState, string> = {
+  confirmed: "Confirmado",
+  awaiting_review: "Por revisar",
+  changes_requested: "Cambios pedidos",
+  holding: "Reservando",
+  released: "Liberado",
+};
+
+/**
+ * Display order: what the admin must act on first, then what is settled, then
+ * what no longer matters. Confirmed sits at the top because on the day of the
+ * session it is the only part of the list anyone reads.
+ */
+const STATE_ORDER: Record<RosterSeatState, number> = {
+  confirmed: 0,
+  awaiting_review: 1,
+  changes_requested: 2,
+  holding: 3,
+  released: 4,
+};
+
+export function rosterStateOrder(state: RosterSeatState): number {
+  return STATE_ORDER[state];
+}
+
+export type RosterSeatInput = {
+  purchaseStatus: SessionPurchaseStatus;
+  /** Null when no ticket has been issued for this line yet. */
+  ticketStatus: SessionTicketStatus | null;
+  /** Null for free purchases, which never hold. */
+  holdExpiresAt: Date | null;
+};
+
+/**
+ * Mirrors the occupancy predicate in `fetchOccurrenceAvailability`: a valid
+ * ticket, or a purchase under review, or a `pending_upload` whose hold has not
+ * lapsed. Anything else has given the seat back.
+ *
+ * A cancelled ticket is `released` even though its purchase still says
+ * `approved` — support cancels the ticket to free the seat, and the roster has
+ * to agree with the seat count rather than with the purchase row.
+ */
+export function resolveRosterSeatState(
+  input: RosterSeatInput,
+  now: Date,
+): RosterSeatState {
+  if (input.ticketStatus === "valid") return "confirmed";
+
+  if (input.purchaseStatus === "under_verification") return "awaiting_review";
+  if (input.purchaseStatus === "changes_requested") return "changes_requested";
+
+  if (
+    input.purchaseStatus === "pending_upload" &&
+    input.holdExpiresAt !== null &&
+    input.holdExpiresAt.getTime() > now.getTime()
+  ) {
+    return "holding";
+  }
+
+  return "released";
+}
+
+/** Everything but `released` is sitting in one of the occurrence's seats. */
+export function occupiesSeat(state: RosterSeatState): boolean {
+  return state !== "released";
+}
+
+export type RosterTotals = {
+  confirmed: number;
+  awaitingReview: number;
+  changesRequested: number;
+  holding: number;
+  released: number;
+  /** Seats actually taken — the sum of everything except `released`. */
+  occupied: number;
+  /** Rows the admin has to do something about, for the "needs attention" cue. */
+  needsAction: number;
+};
+
+export function summarizeRoster(states: RosterSeatState[]): RosterTotals {
+  const totals: RosterTotals = {
+    confirmed: 0,
+    awaitingReview: 0,
+    changesRequested: 0,
+    holding: 0,
+    released: 0,
+    occupied: 0,
+    needsAction: 0,
+  };
+
+  for (const state of states) {
+    if (state === "confirmed") totals.confirmed += 1;
+    if (state === "awaiting_review") totals.awaitingReview += 1;
+    if (state === "changes_requested") totals.changesRequested += 1;
+    if (state === "holding") totals.holding += 1;
+    if (state === "released") totals.released += 1;
+    if (occupiesSeat(state)) totals.occupied += 1;
+  }
+
+  // `changes_requested` counts too: the buyer cannot move without the team
+  // looking at the replacement they were asked for.
+  totals.needsAction = totals.awaitingReview + totals.changesRequested;
+
+  return totals;
+}

--- a/app/lib/stands/group-actions.ts
+++ b/app/lib/stands/group-actions.ts
@@ -1,0 +1,217 @@
+"use server";
+
+import { eq, inArray } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { getCurrentUserProfile } from "@/app/lib/users/helpers";
+import { resolveJointAxis } from "@/app/lib/stands/groups";
+import { db } from "@/db";
+import { standGroups, stands } from "@/db/schema";
+
+type ActionResult = { success: boolean; message: string };
+/** Carries the new group id so the editor can patch its local stands */
+type GroupActionResult = ActionResult & { groupId?: number };
+
+const standIdsSchema = z.array(z.number().int().positive()).min(1);
+
+async function requireFestivalOrAdmin() {
+  const profile = await getCurrentUserProfile();
+  if (!profile) {
+    return { ok: false as const, message: "Inicia sesión para continuar." };
+  }
+  if (profile.role !== "festival_admin" && profile.role !== "admin") {
+    return {
+      ok: false as const,
+      message: "No tienes permisos para realizar esta acción.",
+    };
+  }
+  return { ok: true as const };
+}
+
+/** Drops groups that no longer have at least two members */
+async function pruneEmptyGroups(
+  tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+  groupIds: number[],
+) {
+  if (groupIds.length === 0) return;
+  const remaining = await tx
+    .select({ id: stands.id, standGroupId: stands.standGroupId })
+    .from(stands)
+    .where(inArray(stands.standGroupId, groupIds));
+
+  const counts = new Map<number, number>();
+  for (const row of remaining) {
+    if (row.standGroupId == null) continue;
+    counts.set(row.standGroupId, (counts.get(row.standGroupId) ?? 0) + 1);
+  }
+
+  const stale = groupIds.filter((id) => (counts.get(id) ?? 0) < 2);
+  if (stale.length === 0) return;
+
+  // The stands FK is ON DELETE SET NULL, so the last member is released here
+  await tx.delete(standGroups).where(inArray(standGroups.id, stale));
+}
+
+/**
+ * Declares the given stands as one physical unit. Grouping is deliberately
+ * manual: map coordinates are placed freehand, so adjacency cannot be inferred.
+ */
+export async function groupStands(
+  standIds: number[],
+): Promise<GroupActionResult> {
+  const auth = await requireFestivalOrAdmin();
+  if (!auth.ok) return { success: false, message: auth.message };
+
+  try {
+    const parsed = standIdsSchema.parse(standIds);
+    if (parsed.length < 2) {
+      return {
+        success: false,
+        message: "Selecciona al menos dos espacios para unirlos",
+      };
+    }
+
+    const members = await db.query.stands.findMany({
+      where: inArray(stands.id, parsed),
+      columns: {
+        id: true,
+        festivalSectorId: true,
+        positionLeft: true,
+        positionTop: true,
+        standGroupId: true,
+      },
+    });
+
+    if (members.length !== parsed.length) {
+      return {
+        success: false,
+        message: "No se encontraron todos los espacios",
+      };
+    }
+
+    const sectorId = members[0].festivalSectorId;
+    if (sectorId == null) {
+      return {
+        success: false,
+        message: "Los espacios deben pertenecer a un sector",
+      };
+    }
+    if (members.some((m) => m.festivalSectorId !== sectorId)) {
+      return {
+        success: false,
+        message: "Solo se pueden unir espacios del mismo sector",
+      };
+    }
+    if (members.some((m) => m.positionLeft == null || m.positionTop == null)) {
+      return {
+        success: false,
+        message: "Los espacios deben estar ubicados en el plano",
+      };
+    }
+    if (resolveJointAxis(members) === null) {
+      return {
+        success: false,
+        message:
+          "Los espacios deben estar alineados en una misma fila o columna",
+      };
+    }
+
+    const previousGroupIds = Array.from(
+      new Set(
+        members
+          .map((m) => m.standGroupId)
+          .filter((id): id is number => id != null),
+      ),
+    );
+
+    const groupId = await db.transaction(async (tx) => {
+      const [group] = await tx
+        .insert(standGroups)
+        .values({ festivalSectorId: sectorId })
+        .returning({ id: standGroups.id });
+
+      await tx
+        .update(stands)
+        .set({ standGroupId: group.id, updatedAt: new Date() })
+        .where(inArray(stands.id, parsed));
+
+      await pruneEmptyGroups(tx, previousGroupIds);
+      return group.id;
+    });
+
+    revalidatePath("/dashboard/festivals");
+    revalidatePath("/", "layout");
+
+    return { success: true, message: "Espacios unidos con éxito", groupId };
+  } catch (error) {
+    console.error("Error grouping stands", error);
+    return { success: false, message: "Error al unir los espacios" };
+  }
+}
+
+/** Releases the given stands from whatever group they belong to */
+export async function ungroupStands(standIds: number[]): Promise<ActionResult> {
+  const auth = await requireFestivalOrAdmin();
+  if (!auth.ok) return { success: false, message: auth.message };
+
+  try {
+    const parsed = standIdsSchema.parse(standIds);
+
+    const members = await db.query.stands.findMany({
+      where: inArray(stands.id, parsed),
+      columns: { id: true, standGroupId: true },
+    });
+
+    const affectedGroupIds = Array.from(
+      new Set(
+        members
+          .map((m) => m.standGroupId)
+          .filter((id): id is number => id != null),
+      ),
+    );
+
+    if (affectedGroupIds.length === 0) {
+      return {
+        success: false,
+        message: "Los espacios seleccionados no están unidos",
+      };
+    }
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(stands)
+        .set({ standGroupId: null, updatedAt: new Date() })
+        .where(inArray(stands.id, parsed));
+
+      await pruneEmptyGroups(tx, affectedGroupIds);
+    });
+
+    revalidatePath("/dashboard/festivals");
+    revalidatePath("/", "layout");
+
+    return { success: true, message: "Espacios separados con éxito" };
+  } catch (error) {
+    console.error("Error ungrouping stands", error);
+    return { success: false, message: "Error al separar los espacios" };
+  }
+}
+
+/** Clears a group entirely, releasing every stand still attached to it */
+export async function deleteStandGroup(groupId: number): Promise<ActionResult> {
+  const auth = await requireFestivalOrAdmin();
+  if (!auth.ok) return { success: false, message: auth.message };
+
+  try {
+    const parsed = z.number().int().positive().parse(groupId);
+    await db.delete(standGroups).where(eq(standGroups.id, parsed));
+
+    revalidatePath("/dashboard/festivals");
+    revalidatePath("/", "layout");
+
+    return { success: true, message: "Grupo eliminado con éxito" };
+  } catch (error) {
+    console.error("Error deleting stand group", error);
+    return { success: false, message: "Error al eliminar el grupo" };
+  }
+}

--- a/app/lib/stands/groups.test.ts
+++ b/app/lib/stands/groups.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildJointGroupPath,
+  findJointGroup,
+  formatStandsLabel,
   getJointGroupBounds,
   getStandOccupantKey,
+  getStandsProducts,
   indexJointGroupsByStandId,
   resolveJointGroups,
 } from "@/app/lib/stands/groups";
@@ -16,6 +19,9 @@ type StandOptions = {
   users?: number[];
   externals?: number[];
   rejectedUsers?: number[];
+  label?: string;
+  standNumber?: number;
+  products?: string[];
 };
 
 function stand(
@@ -27,6 +33,9 @@ function stand(
     users = [],
     externals = [],
     rejectedUsers = [],
+    label = "A",
+    standNumber = id,
+    products = [],
   }: StandOptions = {},
 ): StandWithReservationsWithParticipants {
   const reservations = [];
@@ -49,10 +58,16 @@ function stand(
 
   return {
     id,
+    label,
+    standNumber,
     standGroupId: groupId,
     positionLeft: left,
     positionTop: top,
     reservations,
+    standSubcategories: products.map((productLabel, index) => ({
+      subcategoryId: index,
+      subcategory: { label: productLabel },
+    })),
   } as unknown as StandWithReservationsWithParticipants;
 }
 
@@ -152,6 +167,79 @@ describe("resolveJointGroups", () => {
     const index = indexJointGroupsByStandId(resolveJointGroups(pair()));
     expect(index.get(1)).toBe(index.get(2));
     expect(index.get(99)).toBeUndefined();
+  });
+});
+
+describe("findJointGroup", () => {
+  const pair = () => [
+    stand(7, { groupId: 10, left: 69.8, top: 84.5, users: [7] }),
+    stand(8, { groupId: 10, left: 78.5, top: 84.5, users: [7] }),
+  ];
+
+  it("finds the group from either member", () => {
+    const stands = pair();
+    expect(findJointGroup(stands, 7)?.stands.map((s) => s.id)).toEqual([7, 8]);
+    expect(findJointGroup(stands, 8)?.stands.map((s) => s.id)).toEqual([7, 8]);
+  });
+
+  it("returns null for a stand that stands alone", () => {
+    expect(findJointGroup([...pair(), stand(9, { users: [8] })], 9)).toBeNull();
+  });
+
+  it("returns null without a selection", () => {
+    expect(findJointGroup(pair(), null)).toBeNull();
+    expect(findJointGroup(pair(), undefined)).toBeNull();
+  });
+});
+
+describe("formatStandsLabel", () => {
+  it("names a lone stand plainly", () => {
+    expect(formatStandsLabel([stand(7)])).toBe("A7");
+  });
+
+  it("joins every member of a group in order", () => {
+    expect(formatStandsLabel([stand(7), stand(8)])).toBe("A7 - A8");
+  });
+
+  it("orders numerically, not as text", () => {
+    // Members arrive in map order, which can put A10 to the left of A9
+    expect(formatStandsLabel([stand(10), stand(9)])).toBe("A9 - A10");
+  });
+
+  it("orders by label before number", () => {
+    expect(
+      formatStandsLabel([
+        stand(2, { label: "B", standNumber: 2 }),
+        stand(1, { label: "A", standNumber: 10 }),
+      ]),
+    ).toBe("A10 - B2");
+  });
+
+  it("leaves the caller's array untouched", () => {
+    const stands = [stand(10), stand(9)];
+    formatStandsLabel(stands);
+    expect(stands.map((s) => s.standNumber)).toEqual([10, 9]);
+  });
+});
+
+describe("getStandsProducts", () => {
+  it("lists a lone stand's products", () => {
+    expect(getStandsProducts([stand(7, { products: ["Stickers"] })])).toEqual([
+      "Stickers",
+    ]);
+  });
+
+  it("unions products across members without repeating", () => {
+    expect(
+      getStandsProducts([
+        stand(7, { products: ["Stickers", "Prints"] }),
+        stand(8, { products: ["Prints", "Pins"] }),
+      ]),
+    ).toEqual(["Stickers", "Prints", "Pins"]);
+  });
+
+  it("copes with a stand carrying no products", () => {
+    expect(getStandsProducts([stand(7), stand(8)])).toEqual([]);
   });
 });
 

--- a/app/lib/stands/groups.test.ts
+++ b/app/lib/stands/groups.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildJointGroupPath,
+  dedupeJointGroupMembers,
   findJointGroup,
   formatStandsLabel,
   getJointGroupBounds,
+  getPrunedGroupIds,
   getStandOccupantKey,
   getStandsProducts,
   indexJointGroupsByStandId,
@@ -167,6 +169,120 @@ describe("resolveJointGroups", () => {
     const index = indexJointGroupsByStandId(resolveJointGroups(pair()));
     expect(index.get(1)).toBe(index.get(2));
     expect(index.get(99)).toBeUndefined();
+  });
+});
+
+describe("getPrunedGroupIds", () => {
+  const member = (id: number, standGroupId: number | null) => ({
+    id,
+    standGroupId,
+  });
+
+  it("prunes a pair when one member leaves", () => {
+    // The one left behind is not in the moved set, but the server clears it
+    expect([...getPrunedGroupIds([member(7, 10), member(8, 10)], [7])]).toEqual(
+      [10],
+    );
+  });
+
+  it("keeps a group that still has two members", () => {
+    expect(
+      getPrunedGroupIds([member(7, 10), member(8, 10), member(9, 10)], [7]),
+    ).toEqual(new Set());
+  });
+
+  it("prunes when a three-member group loses two", () => {
+    expect([
+      ...getPrunedGroupIds(
+        [member(7, 10), member(8, 10), member(9, 10)],
+        [7, 8],
+      ),
+    ]).toEqual([10]);
+  });
+
+  it("prunes every group the moved stands came from", () => {
+    expect(
+      getPrunedGroupIds(
+        [member(7, 10), member(8, 10), member(9, 11), member(10, 11)],
+        [7, 9],
+      ),
+    ).toEqual(new Set([10, 11]));
+  });
+
+  it("ignores groups none of the moved stands belonged to", () => {
+    expect(
+      getPrunedGroupIds([member(7, 10), member(8, 11), member(9, 11)], [7]),
+    ).toEqual(new Set([10]));
+  });
+
+  it("prunes nothing when the moved stands were ungrouped", () => {
+    expect(
+      getPrunedGroupIds([member(7, null), member(8, 10), member(9, 10)], [7]),
+    ).toEqual(new Set());
+  });
+
+  it("prunes a group whose every member moved", () => {
+    expect([
+      ...getPrunedGroupIds([member(7, 10), member(8, 10)], [7, 8]),
+    ]).toEqual([10]);
+  });
+});
+
+describe("dedupeJointGroupMembers", () => {
+  const pair = () => [
+    stand(7, { groupId: 10, left: 69.8, top: 84.5, users: [7] }),
+    stand(8, { groupId: 10, left: 78.5, top: 84.5, users: [7] }),
+  ];
+
+  it("anchors a row to its rightmost member", () => {
+    const stands = pair();
+    const kept = dedupeJointGroupMembers(stands, resolveJointGroups(stands));
+    // 8 sits to the right of 7, so its top-right is the joined shape's corner
+    expect(kept.map((s) => s.id)).toEqual([8]);
+  });
+
+  it("anchors a column to its topmost member", () => {
+    const stands = [
+      stand(3, { groupId: 11, left: 86.35, top: 49.7, users: [7] }),
+      stand(4, { groupId: 11, left: 86.35, top: 60.2, users: [7] }),
+    ];
+    const kept = dedupeJointGroupMembers(stands, resolveJointGroups(stands));
+    expect(kept.map((s) => s.id)).toEqual([3]);
+  });
+
+  it("anchors regardless of the order members arrive in", () => {
+    const [a, b] = pair();
+    const stands = [b, a];
+    const kept = dedupeJointGroupMembers(stands, resolveJointGroups(stands));
+    expect(kept.map((s) => s.id)).toEqual([8]);
+  });
+
+  it("leaves standalone stands untouched", () => {
+    const stands = [...pair(), stand(9, { users: [8] })];
+    const kept = dedupeJointGroupMembers(stands, resolveJointGroups(stands));
+    expect(kept.map((s) => s.id)).toEqual([8, 9]);
+  });
+
+  it("keeps both members when the group does not render joined", () => {
+    // Misaligned, so MapSurface draws two separate stands
+    const stands = [
+      stand(7, { groupId: 10, left: 69.8, top: 84.5, users: [7] }),
+      stand(8, { groupId: 10, left: 78.5, top: 95, users: [7] }),
+    ];
+    const kept = dedupeJointGroupMembers(stands, resolveJointGroups(stands));
+    expect(kept.map((s) => s.id)).toEqual([7, 8]);
+  });
+
+  it("drops a non-anchor member handed over on its own", () => {
+    const stands = pair();
+    const groups = resolveJointGroups(stands);
+    // The badge overlay only passes occupied stands, never the whole map
+    expect(dedupeJointGroupMembers([stands[0]], groups)).toEqual([]);
+  });
+
+  it("returns everything when nothing is grouped", () => {
+    const stands = [stand(1, { users: [7] }), stand(2, { users: [8] })];
+    expect(dedupeJointGroupMembers(stands, [])).toEqual(stands);
   });
 });
 

--- a/app/lib/stands/groups.test.ts
+++ b/app/lib/stands/groups.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildJointGroupPath,
+  getJointGroupBounds,
+  getStandOccupantKey,
+  indexJointGroupsByStandId,
+  resolveJointGroups,
+} from "@/app/lib/stands/groups";
+import type { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+
+type StandOptions = {
+  groupId?: number | null;
+  left?: number;
+  top?: number;
+  users?: number[];
+  externals?: number[];
+  rejectedUsers?: number[];
+};
+
+function stand(
+  id: number,
+  {
+    groupId = null,
+    left = 0,
+    top = 0,
+    users = [],
+    externals = [],
+    rejectedUsers = [],
+  }: StandOptions = {},
+): StandWithReservationsWithParticipants {
+  const reservations = [];
+  if (users.length > 0 || externals.length > 0) {
+    reservations.push({
+      status: "accepted",
+      participants: users.map((userId) => ({ user: { id: userId } })),
+      externalParticipants: externals.map((externalId) => ({
+        externalParticipant: { id: externalId },
+      })),
+    });
+  }
+  if (rejectedUsers.length > 0) {
+    reservations.push({
+      status: "rejected",
+      participants: rejectedUsers.map((userId) => ({ user: { id: userId } })),
+      externalParticipants: [],
+    });
+  }
+
+  return {
+    id,
+    standGroupId: groupId,
+    positionLeft: left,
+    positionTop: top,
+    reservations,
+  } as unknown as StandWithReservationsWithParticipants;
+}
+
+describe("getStandOccupantKey", () => {
+  it("returns null for an empty stand", () => {
+    expect(getStandOccupantKey(stand(1))).toBeNull();
+  });
+
+  it("returns null when the only reservation was rejected", () => {
+    expect(getStandOccupantKey(stand(1, { rejectedUsers: [7] }))).toBeNull();
+  });
+
+  it("does not distinguish participant ordering", () => {
+    expect(getStandOccupantKey(stand(1, { users: [7, 8] }))).toBe(
+      getStandOccupantKey(stand(2, { users: [8, 7] })),
+    );
+  });
+
+  it("tells users and external participants apart", () => {
+    expect(getStandOccupantKey(stand(1, { users: [7] }))).not.toBe(
+      getStandOccupantKey(stand(2, { externals: [7] })),
+    );
+  });
+});
+
+describe("resolveJointGroups", () => {
+  const pair = (options: StandOptions = {}) => [
+    stand(1, { groupId: 10, left: 69.8, top: 84.5, users: [7], ...options }),
+    stand(2, { groupId: 10, left: 78.5, top: 84.5, users: [7], ...options }),
+  ];
+
+  it("joins a declared pair held by the same participant", () => {
+    const groups = resolveJointGroups(pair());
+    expect(groups).toHaveLength(1);
+    expect(groups[0].id).toBe(10);
+    expect(groups[0].axis).toBe("row");
+    expect(groups[0].stands.map((s) => s.id)).toEqual([1, 2]);
+  });
+
+  it("orders members along their axis regardless of input order", () => {
+    const [a, b] = pair();
+    expect(resolveJointGroups([b, a])[0].stands.map((s) => s.id)).toEqual([
+      1, 2,
+    ]);
+  });
+
+  it("detects a vertical pair as a column", () => {
+    const groups = resolveJointGroups([
+      stand(1, { groupId: 10, left: 86.35, top: 49.7, users: [7] }),
+      stand(2, { groupId: 10, left: 86.35, top: 60.2, users: [7] }),
+    ]);
+    expect(groups[0].axis).toBe("column");
+  });
+
+  it("leaves ungrouped stands alone", () => {
+    expect(
+      resolveJointGroups([
+        stand(1, { left: 0, top: 0, users: [7] }),
+        stand(2, { left: 8.7, top: 0, users: [7] }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("ignores a group whose members are held by different participants", () => {
+    const [a] = pair();
+    const b = stand(2, { groupId: 10, left: 78.5, top: 84.5, users: [8] });
+    expect(resolveJointGroups([a, b])).toEqual([]);
+  });
+
+  it("ignores a group where only one member is occupied", () => {
+    const [a] = pair();
+    const b = stand(2, { groupId: 10, left: 78.5, top: 84.5 });
+    expect(resolveJointGroups([a, b])).toEqual([]);
+  });
+
+  it("ignores a declared group that nobody occupies", () => {
+    expect(resolveJointGroups(pair({ users: [] }))).toEqual([]);
+  });
+
+  it("ignores a lone stand left in a group", () => {
+    expect(resolveJointGroups([pair()[0]])).toEqual([]);
+  });
+
+  it("ignores members that line up on neither axis", () => {
+    const [a] = pair();
+    const b = stand(2, { groupId: 10, left: 78.5, top: 95, users: [7] });
+    expect(resolveJointGroups([a, b])).toEqual([]);
+  });
+
+  it("tolerates the drift left by freehand placement", () => {
+    const a = stand(1, { groupId: 10, left: 69.8, top: 84.5, users: [7] });
+    const b = stand(2, { groupId: 10, left: 78.5, top: 84.8, users: [7] });
+    expect(resolveJointGroups([a, b])[0].axis).toBe("row");
+  });
+
+  it("indexes every member back to its group", () => {
+    const index = indexJointGroupsByStandId(resolveJointGroups(pair()));
+    expect(index.get(1)).toBe(index.get(2));
+    expect(index.get(99)).toBeUndefined();
+  });
+});
+
+describe("getJointGroupBounds", () => {
+  it("spans both members and seams halfway across the gap", () => {
+    const [group] = resolveJointGroups([
+      stand(1, { groupId: 10, left: 69.8, top: 84.5, users: [7] }),
+      stand(2, { groupId: 10, left: 78.5, top: 84.5, users: [7] }),
+    ]);
+    const bounds = getJointGroupBounds(group);
+    expect(bounds.x).toBe(69.8);
+    expect(bounds.y).toBe(84.5);
+    expect(bounds.width).toBeCloseTo(14.7, 5);
+    expect(bounds.height).toBe(6);
+    // 69.8 + 6 = 75.8 and 78.5 → midpoint 77.15
+    expect(bounds.seams[0]).toBeCloseTo(77.15, 5);
+  });
+
+  it("spans vertically for a column", () => {
+    const [group] = resolveJointGroups([
+      stand(1, { groupId: 10, left: 86.35, top: 49.7, users: [7] }),
+      stand(2, { groupId: 10, left: 86.35, top: 60.2, users: [7] }),
+    ]);
+    const bounds = getJointGroupBounds(group);
+    expect(bounds.width).toBe(6);
+    expect(bounds.height).toBeCloseTo(16.5, 5);
+    // 49.7 + 6 = 55.7 and 60.2 → midpoint 57.95
+    expect(bounds.seams[0]).toBeCloseTo(57.95, 5);
+  });
+});
+
+describe("buildJointGroupPath", () => {
+  const bounds = { x: 0, y: 0, width: 6, height: 14.7, seams: [7.35] };
+
+  it("pinches both long edges of a column at the seam", () => {
+    const path = buildJointGroupPath(bounds, "column");
+    // One notch arc per long edge, plus the four corners
+    expect(path.match(/A 0.9 0.9 0 0 0/g)).toHaveLength(2);
+    expect(path.match(/A 0.8 0.8 0 0 1/g)).toHaveLength(4);
+    expect(path.endsWith("Z")).toBe(true);
+  });
+
+  it("pinches the top and bottom edges of a row", () => {
+    const path = buildJointGroupPath(
+      { x: 0, y: 0, width: 14.7, height: 6, seams: [7.35] },
+      "row",
+    );
+    expect(path.match(/A 0.9 0.9 0 0 0/g)).toHaveLength(2);
+    expect(path).toContain("L 6.45 0");
+    expect(path).toContain("A 0.9 0.9 0 0 0 8.25 0");
+  });
+
+  it("adds a notch per seam for longer groups", () => {
+    const path = buildJointGroupPath(
+      { x: 0, y: 0, width: 6, height: 23.4, seams: [7.35, 16.05] },
+      "column",
+    );
+    expect(path.match(/A 0.9 0.9 0 0 0/g)).toHaveLength(4);
+  });
+
+  it("never rounds corners past half the shorter side", () => {
+    const path = buildJointGroupPath(
+      { x: 0, y: 0, width: 1, height: 14.7, seams: [7.35] },
+      "column",
+    );
+    expect(path).toContain("A 0.5 0.5 0 0 1");
+  });
+});

--- a/app/lib/stands/groups.ts
+++ b/app/lib/stands/groups.ts
@@ -1,5 +1,6 @@
 import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
 import { STAND_SIZE, getStandPosition } from "@/app/components/maps/map-utils";
+import { formatStandLabel } from "@/app/lib/stands/helpers";
 
 /**
  * Stands are placed freehand on the map, so two stands belonging to the same
@@ -112,6 +113,60 @@ export function indexJointGroupsByStandId(
     for (const stand of group.stands) index.set(stand.id, group);
   }
   return index;
+}
+
+/**
+ * The joint group a stand renders as part of, or null when it stands alone.
+ * Cards use this to describe the whole unit the visitor actually tapped.
+ */
+export function findJointGroup(
+  stands: StandWithReservationsWithParticipants[],
+  standId: number | null | undefined,
+): JointGroup | null {
+  if (standId == null) return null;
+  const groups = resolveJointGroups(stands);
+  return indexJointGroupsByStandId(groups).get(standId) ?? null;
+}
+
+/**
+ * How a stand or joint group is named to visitors: "A9" alone, "A9 - A10" when
+ * the stands were declared as one unit.
+ *
+ * Members arrive ordered by map position, which reads wrong in text once stand
+ * numbers reach double digits, so they are re-sorted by label then number.
+ * Sorting the formatted strings would not do: "A10" sorts before "A9".
+ */
+export function formatStandsLabel(
+  stands: StandWithReservationsWithParticipants[],
+): string {
+  return [...stands]
+    .sort((a, b) => {
+      const byLabel = (a.label ?? "").localeCompare(b.label ?? "");
+      if (byLabel !== 0) return byLabel;
+      return a.standNumber - b.standNumber;
+    })
+    .map(formatStandLabel)
+    .join(" - ");
+}
+
+/**
+ * Products across a stand or joint group. Members can carry different
+ * subcategories, so the labels are unioned and de-duplicated in map order.
+ */
+export function getStandsProducts(
+  stands: StandWithReservationsWithParticipants[],
+): string[] {
+  const seen = new Set<string>();
+  const labels: string[] = [];
+  for (const stand of stands) {
+    for (const standSubcategory of stand.standSubcategories ?? []) {
+      const label = standSubcategory.subcategory.label;
+      if (seen.has(label)) continue;
+      seen.add(label);
+      labels.push(label);
+    }
+  }
+  return labels;
 }
 
 export type JointGroupBounds = {

--- a/app/lib/stands/groups.ts
+++ b/app/lib/stands/groups.ts
@@ -1,0 +1,222 @@
+import { StandWithReservationsWithParticipants } from "@/app/api/stands/definitions";
+import { STAND_SIZE, getStandPosition } from "@/app/components/maps/map-utils";
+
+/**
+ * Stands are placed freehand on the map, so two stands belonging to the same
+ * participant sit no closer than two unrelated neighbours. Grouping is always
+ * an explicit admin decision (stands.standGroupId); geometry is only used to
+ * lay the joined shape out, never to decide that stands belong together.
+ */
+
+export type JointAxis = "row" | "column";
+
+export type JointGroup = {
+  id: number;
+  /** Ordered along the group's axis, left to right or top to bottom */
+  stands: StandWithReservationsWithParticipants[];
+  axis: JointAxis;
+};
+
+/** Positions come from freehand dragging, so exact equality is too strict */
+const ALIGNMENT_TOLERANCE = 0.5;
+
+/**
+ * Identifies who occupies a stand, counting both registered users and external
+ * participants. Returns null when nobody holds it.
+ */
+export function getStandOccupantKey(
+  stand: StandWithReservationsWithParticipants,
+): string | null {
+  const occupants = (stand.reservations ?? [])
+    .filter((reservation) => reservation.status !== "rejected")
+    .flatMap((reservation) => [
+      ...reservation.participants.map((p) => `user-${p.user.id}`),
+      ...(reservation.externalParticipants ?? []).map(
+        ({ externalParticipant }) => `external-${externalParticipant.id}`,
+      ),
+    ]);
+
+  if (occupants.length === 0) return null;
+  return Array.from(new Set(occupants)).sort().join("|");
+}
+
+/**
+ * The axis a set of stands lines up on, or null when they form neither a single
+ * row nor a single column. A group that lines up on neither can never be drawn
+ * as one clean outline, so admins are stopped from creating one.
+ */
+export function resolveJointAxis(
+  stands: { positionLeft: number | null; positionTop: number | null }[],
+): JointAxis | null {
+  const positions = stands.map(getStandPosition);
+  const sameTop = positions.every(
+    (p) => Math.abs(p.top - positions[0].top) <= ALIGNMENT_TOLERANCE,
+  );
+  if (sameTop) return "row";
+
+  const sameLeft = positions.every(
+    (p) => Math.abs(p.left - positions[0].left) <= ALIGNMENT_TOLERANCE,
+  );
+  if (sameLeft) return "column";
+
+  return null;
+}
+
+/**
+ * The declared groups that should currently render as one joined stand: every
+ * member is held by exactly the same participants, and the members line up in a
+ * single row or column so the joined outline is a clean rectangle.
+ */
+export function resolveJointGroups(
+  stands: StandWithReservationsWithParticipants[],
+): JointGroup[] {
+  const byGroupId = new Map<number, StandWithReservationsWithParticipants[]>();
+  for (const stand of stands) {
+    if (stand.standGroupId == null) continue;
+    const members = byGroupId.get(stand.standGroupId) ?? [];
+    members.push(stand);
+    byGroupId.set(stand.standGroupId, members);
+  }
+
+  const groups: JointGroup[] = [];
+  for (const [id, members] of byGroupId) {
+    if (members.length < 2) continue;
+
+    const occupantKey = getStandOccupantKey(members[0]);
+    if (occupantKey === null) continue;
+    const sharedOccupants = members.every(
+      (stand) => getStandOccupantKey(stand) === occupantKey,
+    );
+    if (!sharedOccupants) continue;
+
+    const axis = resolveJointAxis(members);
+    if (axis === null) continue;
+
+    const ordered = [...members].sort((a, b) =>
+      axis === "row"
+        ? getStandPosition(a).left - getStandPosition(b).left
+        : getStandPosition(a).top - getStandPosition(b).top,
+    );
+    groups.push({ id, stands: ordered, axis });
+  }
+
+  return groups;
+}
+
+/** Maps every grouped stand id to the joint group it renders as part of */
+export function indexJointGroupsByStandId(
+  groups: JointGroup[],
+): Map<number, JointGroup> {
+  const index = new Map<number, JointGroup>();
+  for (const group of groups) {
+    for (const stand of group.stands) index.set(stand.id, group);
+  }
+  return index;
+}
+
+export type JointGroupBounds = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  /** Positions along the group's axis where two members meet */
+  seams: number[];
+};
+
+export function getJointGroupBounds(group: JointGroup): JointGroupBounds {
+  const positions = group.stands.map(getStandPosition);
+  const first = positions[0];
+
+  const seams: number[] = [];
+  for (let i = 0; i < positions.length - 1; i++) {
+    const end =
+      (group.axis === "row" ? positions[i].left : positions[i].top) +
+      STAND_SIZE;
+    const nextStart =
+      group.axis === "row" ? positions[i + 1].left : positions[i + 1].top;
+    // Members do not touch, so the seam sits halfway across the gap
+    seams.push((end + nextStart) / 2);
+  }
+
+  const last = positions[positions.length - 1];
+  return group.axis === "row"
+    ? {
+        x: first.left,
+        y: first.top,
+        width: last.left + STAND_SIZE - first.left,
+        height: STAND_SIZE,
+        seams,
+      }
+    : {
+        x: first.left,
+        y: first.top,
+        width: STAND_SIZE,
+        height: last.top + STAND_SIZE - first.top,
+        seams,
+      };
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+/**
+ * Outline of a joined stand: a rounded rectangle over the whole group with a
+ * concave notch pinching both long edges wherever two members meet.
+ */
+export function buildJointGroupPath(
+  bounds: JointGroupBounds,
+  axis: JointAxis,
+  { cornerRadius = 0.8, notchRadius = 0.9 } = {},
+): string {
+  const { x, y, width, height, seams } = bounds;
+  const r = Math.min(cornerRadius, width / 2, height / 2);
+  const n = notchRadius;
+  const right = x + width;
+  const bottom = y + height;
+  const parts: string[] = [];
+  const ascending = [...seams].sort((a, b) => a - b);
+  const descending = [...ascending].reverse();
+
+  // Corners run clockwise (sweep 1); notches curve back into the shape (sweep 0)
+  if (axis === "column") {
+    parts.push(`M ${round(x + r)} ${round(y)}`);
+    parts.push(`L ${round(right - r)} ${round(y)}`);
+    parts.push(`A ${r} ${r} 0 0 1 ${round(right)} ${round(y + r)}`);
+    for (const seam of ascending) {
+      parts.push(`L ${round(right)} ${round(seam - n)}`);
+      parts.push(`A ${n} ${n} 0 0 0 ${round(right)} ${round(seam + n)}`);
+    }
+    parts.push(`L ${round(right)} ${round(bottom - r)}`);
+    parts.push(`A ${r} ${r} 0 0 1 ${round(right - r)} ${round(bottom)}`);
+    parts.push(`L ${round(x + r)} ${round(bottom)}`);
+    parts.push(`A ${r} ${r} 0 0 1 ${round(x)} ${round(bottom - r)}`);
+    for (const seam of descending) {
+      parts.push(`L ${round(x)} ${round(seam + n)}`);
+      parts.push(`A ${n} ${n} 0 0 0 ${round(x)} ${round(seam - n)}`);
+    }
+    parts.push(`L ${round(x)} ${round(y + r)}`);
+    parts.push(`A ${r} ${r} 0 0 1 ${round(x + r)} ${round(y)}`);
+  } else {
+    parts.push(`M ${round(x + r)} ${round(y)}`);
+    for (const seam of ascending) {
+      parts.push(`L ${round(seam - n)} ${round(y)}`);
+      parts.push(`A ${n} ${n} 0 0 0 ${round(seam + n)} ${round(y)}`);
+    }
+    parts.push(`L ${round(right - r)} ${round(y)}`);
+    parts.push(`A ${r} ${r} 0 0 1 ${round(right)} ${round(y + r)}`);
+    parts.push(`L ${round(right)} ${round(bottom - r)}`);
+    parts.push(`A ${r} ${r} 0 0 1 ${round(right - r)} ${round(bottom)}`);
+    for (const seam of descending) {
+      parts.push(`L ${round(seam + n)} ${round(bottom)}`);
+      parts.push(`A ${n} ${n} 0 0 0 ${round(seam - n)} ${round(bottom)}`);
+    }
+    parts.push(`L ${round(x + r)} ${round(bottom)}`);
+    parts.push(`A ${r} ${r} 0 0 1 ${round(x)} ${round(bottom - r)}`);
+    parts.push(`L ${round(x)} ${round(y + r)}`);
+    parts.push(`A ${r} ${r} 0 0 1 ${round(x + r)} ${round(y)}`);
+  }
+
+  parts.push("Z");
+  return parts.join(" ");
+}

--- a/app/lib/stands/groups.ts
+++ b/app/lib/stands/groups.ts
@@ -115,6 +115,84 @@ export function indexJointGroupsByStandId(
   return index;
 }
 
+/** Minimal stand shape needed to reason about group membership */
+type StandGroupMembership = {
+  id: number;
+  standGroupId: number | null;
+};
+
+/**
+ * Groups that fall below two members once the given stands move out of them,
+ * and so cease to exist.
+ *
+ * Mirrors the server's pruneEmptyGroups: it deletes such a group, and the
+ * ON DELETE SET NULL foreign key clears standGroupId on whichever member
+ * stayed behind. Callers holding stands in local state need the same answer to
+ * avoid leaving a stand pointing at a group that was just deleted.
+ */
+export function getPrunedGroupIds(
+  stands: StandGroupMembership[],
+  movedStandIds: Iterable<number>,
+): Set<number> {
+  const moved = new Set(movedStandIds);
+
+  const priorGroupIds = new Set<number>();
+  for (const stand of stands) {
+    if (moved.has(stand.id) && stand.standGroupId != null) {
+      priorGroupIds.add(stand.standGroupId);
+    }
+  }
+
+  const survivors = new Map<number, number>();
+  for (const stand of stands) {
+    if (moved.has(stand.id) || stand.standGroupId == null) continue;
+    if (!priorGroupIds.has(stand.standGroupId)) continue;
+    survivors.set(
+      stand.standGroupId,
+      (survivors.get(stand.standGroupId) ?? 0) + 1,
+    );
+  }
+
+  return new Set(
+    Array.from(priorGroupIds).filter(
+      (groupId) => (survivors.get(groupId) ?? 0) < 2,
+    ),
+  );
+}
+
+/**
+ * The member whose own top-right corner is also the joined shape's: the
+ * rightmost stand of a row, the topmost of a column. Members arrive ordered
+ * along the axis, so an overlay anchored to this stand lands on the corner of
+ * the whole unit rather than somewhere along its middle.
+ */
+function getJointGroupAnchor(
+  group: JointGroup,
+): StandWithReservationsWithParticipants {
+  return group.axis === "row"
+    ? group.stands[group.stands.length - 1]
+    : group.stands[0];
+}
+
+/**
+ * Keeps one representative stand per joint group and leaves ungrouped stands
+ * alone. Overlays that decorate individual stands need this: a joined group is
+ * drawn as a single shape, so one marker per member would render twice on it.
+ *
+ * `jointGroups` should come from the same list the map renders, so the overlay
+ * and the outlines can never disagree about what is joined.
+ */
+export function dedupeJointGroupMembers(
+  stands: StandWithReservationsWithParticipants[],
+  jointGroups: JointGroup[],
+): StandWithReservationsWithParticipants[] {
+  const index = indexJointGroupsByStandId(jointGroups);
+  return stands.filter((stand) => {
+    const group = index.get(stand.id);
+    return !group || getJointGroupAnchor(group).id === stand.id;
+  });
+}
+
 /**
  * The joint group a stand renders as part of, or null when it stands alone.
  * Cards use this to describe the whole unit the visitor actually tapped.

--- a/app/lib/users/actions.ts
+++ b/app/lib/users/actions.ts
@@ -1,6 +1,9 @@
 "use server";
 
-import { getPostHogClient } from "@/app/lib/posthog-server";
+import {
+  getPostHogClient,
+  POSTHOG_SHUTDOWN_TIMEOUT_MS,
+} from "@/app/lib/posthog-server";
 import { POSTHOG_EVENTS } from "@/app/lib/posthog-events";
 import { fetchAdminUsers, fetchUserProfileById } from "@/app/api/users/actions";
 import {
@@ -166,7 +169,7 @@ export async function createUserProfile(user: NewUser) {
             category: user.category,
           },
         });
-        await posthog.shutdown();
+        await posthog.shutdown(POSTHOG_SHUTDOWN_TIMEOUT_MS);
       } catch (telemetryError) {
         console.error(
           "PostHog telemetry failed (createUserProfile)",

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -568,6 +568,34 @@ export const standOrientationEnum = pgEnum("stand_orientation", [
   "landscape",
 ]);
 export const standZoneEnum = pgEnum("stand_zone", ["main", "secondary"]);
+// An admin-declared set of physically adjoining stands. Grouping is never
+// inferred from coordinates: map positions are placed freehand, so the gap
+// between a joined pair and two unrelated neighbours is indistinguishable.
+// Today a group only changes how the map draws and selects its members; the
+// stands stay independently reservable.
+export const standGroups = pgTable(
+  "stand_groups",
+  {
+    id: serial("id").primaryKey(),
+    festivalSectorId: integer("festival_sector_id")
+      .notNull()
+      .references(() => festivalSectors.id, { onDelete: "cascade" }),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (standGroups) => [
+    index("stand_groups_festival_sector_id_idx").on(
+      standGroups.festivalSectorId,
+    ),
+  ],
+);
+export const standGroupsRelations = relations(standGroups, ({ many, one }) => ({
+  stands: many(stands),
+  festivalSector: one(festivalSectors, {
+    fields: [standGroups.festivalSectorId],
+    references: [festivalSectors.id],
+  }),
+}));
 export const stands = pgTable(
   "stands",
   {
@@ -596,12 +624,16 @@ export const stands = pgTable(
       { onDelete: "cascade" },
     ),
     qrCodeId: integer("qr_code_id").references(() => qrCodes.id),
+    standGroupId: integer("stand_group_id").references(() => standGroups.id, {
+      onDelete: "set null",
+    }),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
   (stands) => [
     index("stand_label_idx").on(stands.label),
     index("stands_festival_sector_id_idx").on(stands.festivalSectorId),
+    index("stands_stand_group_id_idx").on(stands.standGroupId),
   ],
 );
 export const standRelations = relations(stands, ({ many, one }) => ({
@@ -617,6 +649,10 @@ export const standRelations = relations(stands, ({ many, one }) => ({
   qrCode: one(qrCodes, {
     fields: [stands.qrCodeId],
     references: [qrCodes.id],
+  }),
+  standGroup: one(standGroups, {
+    fields: [stands.standGroupId],
+    references: [standGroups.id],
   }),
   festivalActivityVotes: many(festivalActivityVotes),
   holds: many(standHolds),

--- a/drizzle/0224_careful_red_shift.sql
+++ b/drizzle/0224_careful_red_shift.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "stand_groups" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"festival_sector_id" integer NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "stands" ADD COLUMN "stand_group_id" integer;--> statement-breakpoint
+ALTER TABLE "stand_groups" ADD CONSTRAINT "stand_groups_festival_sector_id_festival_sectors_id_fk" FOREIGN KEY ("festival_sector_id") REFERENCES "public"."festival_sectors"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "stand_groups_festival_sector_id_idx" ON "stand_groups" USING btree ("festival_sector_id");--> statement-breakpoint
+ALTER TABLE "stands" ADD CONSTRAINT "stands_stand_group_id_stand_groups_id_fk" FOREIGN KEY ("stand_group_id") REFERENCES "public"."stand_groups"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "stands_stand_group_id_idx" ON "stands" USING btree ("stand_group_id");

--- a/drizzle/meta/0224_snapshot.json
+++ b/drizzle/meta/0224_snapshot.json
@@ -1,0 +1,12134 @@
+{
+  "id": "fc28fe2b-13cd-4377-b70b-d398b2518381",
+  "prevId": "f663ec0c-477c-495a-9d19-e67c5c4ff5e8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "badges_festival_id_festivals_id_fk": {
+          "name": "badges_festival_id_festivals_id_fk",
+          "tableFrom": "badges",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cart_items": {
+      "name": "cart_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_variant_id": {
+          "name": "product_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "product_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'purchase'"
+        },
+        "rental_festival_id": {
+          "name": "rental_festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rental_reservation_id": {
+          "name": "rental_reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cart_items_cart_id_idx": {
+          "name": "cart_items_cart_id_idx",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cart_items_product_id_idx": {
+          "name": "cart_items_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cart_items_product_variant_id_idx": {
+          "name": "cart_items_product_variant_id_idx",
+          "columns": [
+            {
+              "expression": "product_variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cart_items_rental_festival_id_idx": {
+          "name": "cart_items_rental_festival_id_idx",
+          "columns": [
+            {
+              "expression": "rental_festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cart_items_rental_reservation_id_idx": {
+          "name": "cart_items_rental_reservation_id_idx",
+          "columns": [
+            {
+              "expression": "rental_reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cart_items_cart_product_base_unique": {
+          "name": "cart_items_cart_product_base_unique",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transaction_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rental_festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rental_reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cart_items\".\"product_variant_id\" IS NULL AND \"cart_items\".\"rental_festival_id\" IS NOT NULL AND \"cart_items\".\"rental_reservation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cart_items_cart_product_base_purchase_unique": {
+          "name": "cart_items_cart_product_base_purchase_unique",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transaction_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cart_items\".\"product_variant_id\" IS NULL AND \"cart_items\".\"rental_festival_id\" IS NULL AND \"cart_items\".\"rental_reservation_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cart_items_cart_product_variant_unique": {
+          "name": "cart_items_cart_product_variant_unique",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transaction_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rental_festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rental_reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cart_items\".\"product_variant_id\" IS NOT NULL AND \"cart_items\".\"rental_festival_id\" IS NOT NULL AND \"cart_items\".\"rental_reservation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cart_items_cart_product_variant_purchase_unique": {
+          "name": "cart_items_cart_product_variant_purchase_unique",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transaction_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cart_items\".\"product_variant_id\" IS NOT NULL AND \"cart_items\".\"rental_festival_id\" IS NULL AND \"cart_items\".\"rental_reservation_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cart_items_cart_id_carts_id_fk": {
+          "name": "cart_items_cart_id_carts_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "carts",
+          "columnsFrom": [
+            "cart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cart_items_product_id_products_id_fk": {
+          "name": "cart_items_product_id_products_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cart_items_product_variant_product_fk": {
+          "name": "cart_items_product_variant_product_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "product_variant_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "id",
+            "product_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cart_items_rental_reservation_festival_fk": {
+          "name": "cart_items_rental_reservation_festival_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "rental_reservation_id",
+            "rental_festival_id"
+          ],
+          "columnsTo": [
+            "id",
+            "festival_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cart_items_quantity_positive": {
+          "name": "cart_items_quantity_positive",
+          "value": "\"cart_items\".\"quantity\" > 0"
+        },
+        "cart_items_rental_context_required": {
+          "name": "cart_items_rental_context_required",
+          "value": "(\n        \"cart_items\".\"transaction_type\" != 'rental'\n        AND \"cart_items\".\"rental_festival_id\" IS NULL\n        AND \"cart_items\".\"rental_reservation_id\" IS NULL\n      ) OR (\n        \"cart_items\".\"transaction_type\" = 'rental'\n        AND \"cart_items\".\"rental_festival_id\" IS NOT NULL\n        AND \"cart_items\".\"rental_reservation_id\" IS NOT NULL\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.carts": {
+      "name": "carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "carts_user_id_users_id_fk": {
+          "name": "carts_user_id_users_id_fk",
+          "tableFrom": "carts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "carts_user_id_unique": {
+          "name": "carts_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collaborators": {
+      "name": "collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identification_number": {
+          "name": "identification_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collaborators_attendance_logs": {
+      "name": "collaborators_attendance_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reservation_collaborator_id": {
+          "name": "reservation_collaborator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_date_id": {
+          "name": "festival_date_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collaborators_attendance_logs_reservation_collaborator_id_reservation_collaborators_id_fk": {
+          "name": "collaborators_attendance_logs_reservation_collaborator_id_reservation_collaborators_id_fk",
+          "tableFrom": "collaborators_attendance_logs",
+          "tableTo": "reservation_collaborators",
+          "columnsFrom": [
+            "reservation_collaborator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collaborators_attendance_logs_festival_date_id_festival_dates_id_fk": {
+          "name": "collaborators_attendance_logs_festival_date_id_festival_dates_id_fk",
+          "tableFrom": "collaborators_attendance_logs",
+          "tableTo": "festival_dates",
+          "columnsFrom": [
+            "festival_date_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coupon_book_print_sessions": {
+      "name": "coupon_book_print_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "coupon_book_print_sessions_expires_at_idx": {
+          "name": "coupon_book_print_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.disciplinary_notification_jobs": {
+      "name": "disciplinary_notification_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deduplication_key": {
+          "name": "deduplication_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_kind": {
+          "name": "notification_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "disciplinary_notification_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "disciplinary_notification_jobs_deduplication_key_unique": {
+          "name": "disciplinary_notification_jobs_deduplication_key_unique",
+          "columns": [
+            {
+              "expression": "deduplication_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disciplinary_notification_jobs_status_next_attempt_idx": {
+          "name": "disciplinary_notification_jobs_status_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disciplinary_notification_jobs_entity_idx": {
+          "name": "disciplinary_notification_jobs_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "disciplinary_notification_jobs_user_id_users_id_fk": {
+          "name": "disciplinary_notification_jobs_user_id_users_id_fk",
+          "tableFrom": "disciplinary_notification_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discount_codes": {
+      "name": "discount_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_unit": {
+          "name": "discount_unit",
+          "type": "discount_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_uses": {
+          "name": "current_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discount_codes_festival_id_festivals_id_fk": {
+          "name": "discount_codes_festival_id_festivals_id_fk",
+          "tableFrom": "discount_codes",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "discount_codes_user_id_users_id_fk": {
+          "name": "discount_codes_user_id_users_id_fk",
+          "tableFrom": "discount_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discount_codes_code_unique": {
+          "name": "discount_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_participants": {
+      "name": "external_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "external_participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_category_label": {
+          "name": "custom_category_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_participants_display_name_idx": {
+          "name": "external_participants_display_name_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_participants_created_by_user_id_users_id_fk": {
+          "name": "external_participants_created_by_user_id_users_id_fk",
+          "tableFrom": "external_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flag_user_targets": {
+      "name": "feature_flag_user_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flag_id": {
+          "name": "flag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flag_user_targets_user_id_idx": {
+          "name": "feature_flag_user_targets_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_flag_user_targets_flag_id_feature_flags_id_fk": {
+          "name": "feature_flag_user_targets_flag_id_feature_flags_id_fk",
+          "tableFrom": "feature_flag_user_targets",
+          "tableTo": "feature_flags",
+          "columnsFrom": [
+            "flag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feature_flag_user_targets_user_id_users_id_fk": {
+          "name": "feature_flag_user_targets_user_id_users_id_fk",
+          "tableFrom": "feature_flag_user_targets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feature_flag_user_targets_created_by_user_id_users_id_fk": {
+          "name": "feature_flag_user_targets_created_by_user_id_users_id_fk",
+          "tableFrom": "feature_flag_user_targets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flag_user_targets_flag_id_user_id_unique": {
+          "name": "feature_flag_user_targets_flag_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flag_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "feature_flag_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hidden'"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feature_flags_updated_by_user_id_users_id_fk": {
+          "name": "feature_flags_updated_by_user_id_users_id_fk",
+          "tableFrom": "feature_flags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activities": {
+      "name": "festival_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_start_date": {
+          "name": "registration_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_end_date": {
+          "name": "registration_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promotional_art_url": {
+          "name": "promotional_art_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitors_description": {
+          "name": "visitors_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "festival_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stamp_passport'"
+        },
+        "activity_prize_url": {
+          "name": "activity_prize_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allows_voting": {
+          "name": "allows_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "voting_start_date": {
+          "name": "voting_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voting_end_date": {
+          "name": "voting_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_type": {
+          "name": "proof_type",
+          "type": "proof_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_upload_limit_date": {
+          "name": "proof_upload_limit_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "access_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "waitlist_window_minutes": {
+          "name": "waitlist_window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activities_festival_id_festivals_id_fk": {
+          "name": "festival_activities_festival_id_festivals_id_fk",
+          "tableFrom": "festival_activities",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proof_upload_limit_required": {
+          "name": "proof_upload_limit_required",
+          "value": "(\"festival_activities\".\"proof_type\" IS NULL) OR (\"festival_activities\".\"proof_upload_limit_date\" IS NOT NULL)"
+        },
+        "festival_activities_waitlist_window_minutes_positive": {
+          "name": "festival_activities_waitlist_window_minutes_positive",
+          "value": "\"festival_activities\".\"waitlist_window_minutes\" IS NULL OR \"festival_activities\".\"waitlist_window_minutes\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_coupon_book_configs": {
+      "name": "festival_activity_coupon_book_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_coupon_book_configs_activity_id_festival_activities_id_fk": {
+          "name": "festival_activity_coupon_book_configs_activity_id_festival_activities_id_fk",
+          "tableFrom": "festival_activity_coupon_book_configs",
+          "tableTo": "festival_activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_coupon_book_configs_created_by_user_id_users_id_fk": {
+          "name": "festival_activity_coupon_book_configs_created_by_user_id_users_id_fk",
+          "tableFrom": "festival_activity_coupon_book_configs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "festival_activity_coupon_book_configs_updated_by_user_id_users_id_fk": {
+          "name": "festival_activity_coupon_book_configs_updated_by_user_id_users_id_fk",
+          "tableFrom": "festival_activity_coupon_book_configs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "festival_activity_coupon_book_configs_activity_id_unique": {
+          "name": "festival_activity_coupon_book_configs_activity_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "activity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "festival_activity_coupon_book_configs_revision_positive": {
+          "name": "festival_activity_coupon_book_configs_revision_positive",
+          "value": "\"festival_activity_coupon_book_configs\".\"revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_details": {
+      "name": "festival_activity_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coupon_book_header_image_url": {
+          "name": "coupon_book_header_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participation_limit": {
+          "name": "participation_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_details_activity_id_festival_activities_id_fk": {
+          "name": "festival_activity_details_activity_id_festival_activities_id_fk",
+          "tableFrom": "festival_activity_details",
+          "tableTo": "festival_activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_participant_proofs": {
+      "name": "festival_activity_participant_proofs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participation_id": {
+          "name": "participation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promo_highlight": {
+          "name": "promo_highlight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_description": {
+          "name": "promo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_conditions": {
+          "name": "promo_conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_status": {
+          "name": "proof_status",
+          "type": "proof_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "admin_feedback": {
+          "name": "admin_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_participant_proofs_participation_id_festival_activity_participants_id_fk": {
+          "name": "festival_activity_participant_proofs_participation_id_festival_activity_participants_id_fk",
+          "tableFrom": "festival_activity_participant_proofs",
+          "tableTo": "festival_activity_participants",
+          "columnsFrom": [
+            "participation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_participants": {
+      "name": "festival_activity_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "details_id": {
+          "name": "details_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removal_reason": {
+          "name": "removal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_participants_details_id_festival_activity_details_id_fk": {
+          "name": "festival_activity_participants_details_id_festival_activity_details_id_fk",
+          "tableFrom": "festival_activity_participants",
+          "tableTo": "festival_activity_details",
+          "columnsFrom": [
+            "details_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_participants_user_id_users_id_fk": {
+          "name": "festival_activity_participants_user_id_users_id_fk",
+          "tableFrom": "festival_activity_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "festival_activity_participants_details_id_user_id_unique": {
+          "name": "festival_activity_participants_details_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "details_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_votes": {
+      "name": "festival_activity_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_variant_id": {
+          "name": "activity_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votable_type": {
+          "name": "votable_type",
+          "type": "votable_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_votes_voter_id_users_id_fk": {
+          "name": "festival_activity_votes_voter_id_users_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_votes_activity_variant_id_festival_activity_details_id_fk": {
+          "name": "festival_activity_votes_activity_variant_id_festival_activity_details_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "festival_activity_details",
+          "columnsFrom": [
+            "activity_variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_votes_stand_id_stands_id_fk": {
+          "name": "festival_activity_votes_stand_id_stands_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_votes_participant_id_festival_activity_participants_id_fk": {
+          "name": "festival_activity_votes_participant_id_festival_activity_participants_id_fk",
+          "tableFrom": "festival_activity_votes",
+          "tableTo": "festival_activity_participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_voter_activity": {
+          "name": "unique_voter_activity",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_id",
+            "activity_variant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_activity_waitlist": {
+      "name": "festival_activity_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notified_for_detail_id": {
+          "name": "notified_for_detail_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "festival_activity_waitlist_activity_id_festival_activities_id_fk": {
+          "name": "festival_activity_waitlist_activity_id_festival_activities_id_fk",
+          "tableFrom": "festival_activity_waitlist",
+          "tableTo": "festival_activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_waitlist_user_id_users_id_fk": {
+          "name": "festival_activity_waitlist_user_id_users_id_fk",
+          "tableFrom": "festival_activity_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "festival_activity_waitlist_notified_for_detail_id_festival_activity_details_id_fk": {
+          "name": "festival_activity_waitlist_notified_for_detail_id_festival_activity_details_id_fk",
+          "tableFrom": "festival_activity_waitlist",
+          "tableTo": "festival_activity_details",
+          "columnsFrom": [
+            "notified_for_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "festival_activity_waitlist_activity_id_user_id_unique": {
+          "name": "festival_activity_waitlist_activity_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "activity_id",
+            "user_id"
+          ]
+        },
+        "festival_activity_waitlist_activity_id_position_unique": {
+          "name": "festival_activity_waitlist_activity_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "activity_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "festival_activity_waitlist_position_check": {
+          "name": "festival_activity_waitlist_position_check",
+          "value": "\"festival_activity_waitlist\".\"position\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.festival_dates": {
+      "name": "festival_dates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "festival_dates_festival_id_idx": {
+          "name": "festival_dates_festival_id_idx",
+          "columns": [
+            {
+              "expression": "festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "festival_dates_festival_id_festivals_id_fk": {
+          "name": "festival_dates_festival_id_festivals_id_fk",
+          "tableFrom": "festival_dates",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_sectors": {
+      "name": "festival_sectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_url": {
+          "name": "map_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_in_festival": {
+          "name": "order_in_festival",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mascot_url": {
+          "name": "mascot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_origin_x": {
+          "name": "map_origin_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_origin_y": {
+          "name": "map_origin_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_width": {
+          "name": "map_width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_height": {
+          "name": "map_height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "festival_sector_name_idx": {
+          "name": "festival_sector_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "festival_sectors_festival_id_festivals_id_fk": {
+          "name": "festival_sectors_festival_id_festivals_id_fk",
+          "tableFrom": "festival_sectors",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festival_status_events": {
+      "name": "festival_status_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "festival_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "festival_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "festival_status_events_festival_id_created_at_idx": {
+          "name": "festival_status_events_festival_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "festival_status_events_festival_id_festivals_id_fk": {
+          "name": "festival_status_events_festival_id_festivals_id_fk",
+          "tableFrom": "festival_status_events",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "festival_status_events_actor_user_id_users_id_fk": {
+          "name": "festival_status_events_actor_user_id_users_id_fk",
+          "tableFrom": "festival_status_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.festivals": {
+      "name": "festivals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label": {
+          "name": "location_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_url": {
+          "name": "location_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "festival_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maps_version": {
+          "name": "maps_version",
+          "type": "festival_map_version",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        },
+        "public_registration": {
+          "name": "public_registration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_day_registration": {
+          "name": "event_day_registration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "keep_store_open": {
+          "name": "keep_store_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reservations_start_date": {
+          "name": "reservations_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "general_map_url": {
+          "name": "general_map_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mascot_url": {
+          "name": "mascot_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_type": {
+          "name": "festival_type",
+          "type": "festival_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'glitter'"
+        },
+        "illustration_payment_qr_code_url": {
+          "name": "illustration_payment_qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gastronomy_payment_qr_code_url": {
+          "name": "gastronomy_payment_qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrepreneurship_payment_qr_code_url": {
+          "name": "entrepreneurship_payment_qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "illustration_stand_url": {
+          "name": "illustration_stand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gastronomy_stand_url": {
+          "name": "gastronomy_stand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrepreneurship_stand_url": {
+          "name": "entrepreneurship_stand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_code": {
+          "name": "festival_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_banner_url": {
+          "name": "festival_banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms_and_conditions_url": {
+          "name": "terms_and_conditions_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_url": {
+          "name": "poster_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "festivals_name_unique": {
+          "name": "festivals_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.infraction_events": {
+      "name": "infraction_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "infraction_id": {
+          "name": "infraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "infraction_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "infraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "infraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "infraction_events_infraction_id_created_at_idx": {
+          "name": "infraction_events_infraction_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "infraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "infraction_events_infraction_id_infractions_id_fk": {
+          "name": "infraction_events_infraction_id_infractions_id_fk",
+          "tableFrom": "infraction_events",
+          "tableTo": "infractions",
+          "columnsFrom": [
+            "infraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "infraction_events_actor_user_id_users_id_fk": {
+          "name": "infraction_events_actor_user_id_users_id_fk",
+          "tableFrom": "infraction_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.infraction_evidence": {
+      "name": "infraction_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "infraction_id": {
+          "name": "infraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_user_id": {
+          "name": "added_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "infraction_evidence_infraction_id_created_at_idx": {
+          "name": "infraction_evidence_infraction_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "infraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "infraction_evidence_infraction_id_infractions_id_fk": {
+          "name": "infraction_evidence_infraction_id_infractions_id_fk",
+          "tableFrom": "infraction_evidence",
+          "tableTo": "infractions",
+          "columnsFrom": [
+            "infraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "infraction_evidence_added_by_user_id_users_id_fk": {
+          "name": "infraction_evidence_added_by_user_id_users_id_fk",
+          "tableFrom": "infraction_evidence",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.infraction_notes": {
+      "name": "infraction_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "infraction_id": {
+          "name": "infraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "infraction_notes_infraction_id_created_at_idx": {
+          "name": "infraction_notes_infraction_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "infraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "infraction_notes_infraction_id_infractions_id_fk": {
+          "name": "infraction_notes_infraction_id_infractions_id_fk",
+          "tableFrom": "infraction_notes",
+          "tableTo": "infractions",
+          "columnsFrom": [
+            "infraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "infraction_notes_author_user_id_users_id_fk": {
+          "name": "infraction_notes_author_user_id_users_id_fk",
+          "tableFrom": "infraction_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.infraction_types": {
+      "name": "infraction_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "infraction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'low'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "infraction_types_label_unique": {
+          "name": "infraction_types_label_unique",
+          "columns": [
+            {
+              "expression": "lower(\"label\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "infraction_types_active_label_idx": {
+          "name": "infraction_types_active_label_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "infraction_types_code_unique": {
+          "name": "infraction_types_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "infraction_types_archive_state_check": {
+          "name": "infraction_types_archive_state_check",
+          "value": "\n        (\n          \"infraction_types\".\"active\" = true\n          AND \"infraction_types\".\"archived_at\" IS NULL\n        )\n        OR\n        (\n          \"infraction_types\".\"active\" = false\n          AND \"infraction_types\".\"archived_at\" IS NOT NULL\n        )\n      "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.infractions": {
+      "name": "infractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handled": {
+          "name": "handled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "infraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_gave_notice": {
+          "name": "user_gave_notice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gave_notice_at": {
+          "name": "gave_notice_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_notes": {
+          "name": "resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_by_user_id": {
+          "name": "voided_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "infractions_user_id_created_at_idx": {
+          "name": "infractions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "infractions_festival_id_created_at_idx": {
+          "name": "infractions_festival_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "infractions_type_id_created_at_idx": {
+          "name": "infractions_type_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "infractions_status_created_at_idx": {
+          "name": "infractions_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "infractions_user_gave_notice_created_at_idx": {
+          "name": "infractions_user_gave_notice_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_gave_notice",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "infractions_user_id_users_id_fk": {
+          "name": "infractions_user_id_users_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "infractions_type_id_infraction_types_id_fk": {
+          "name": "infractions_type_id_infraction_types_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "infraction_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "infractions_festival_id_festivals_id_fk": {
+          "name": "infractions_festival_id_festivals_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "infractions_created_by_user_id_users_id_fk": {
+          "name": "infractions_created_by_user_id_users_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "infractions_resolved_by_user_id_users_id_fk": {
+          "name": "infractions_resolved_by_user_id_users_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "infractions_voided_by_user_id_users_id_fk": {
+          "name": "infractions_voided_by_user_id_users_id_fk",
+          "tableFrom": "infractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "infractions_idempotency_key_unique": {
+          "name": "infractions_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "original_amount": {
+          "name": "original_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_code_id": {
+          "name": "discount_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_user_id_users_id_fk": {
+          "name": "invoices_user_id_users_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_reservation_id_stand_reservations_id_fk": {
+          "name": "invoices_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_discount_code_id_discount_codes_id_fk": {
+          "name": "invoices_discount_code_id_discount_codes_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "discount_codes",
+          "columnsFrom": [
+            "discount_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.live_acts": {
+      "name": "live_acts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "act_name": {
+          "name": "act_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "live_act_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_link": {
+          "name": "resource_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "live_act_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "admin_notes": {
+          "name": "admin_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_elements": {
+      "name": "map_elements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "map_element_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_position": {
+          "name": "label_position",
+          "type": "map_element_label_position",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bottom'"
+        },
+        "label_font_size": {
+          "name": "label_font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "label_font_weight": {
+          "name": "label_font_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "show_icon": {
+          "name": "show_icon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "position_left": {
+          "name": "position_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "position_top": {
+          "name": "position_top",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "width": {
+          "name": "width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "height": {
+          "name": "height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "festival_sector_id": {
+          "name": "festival_sector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "map_elements_sector_idx": {
+          "name": "map_elements_sector_idx",
+          "columns": [
+            {
+              "expression": "festival_sector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_elements_festival_sector_id_festival_sectors_id_fk": {
+          "name": "map_elements_festival_sector_id_festival_sectors_id_fk",
+          "tableFrom": "map_elements",
+          "tableTo": "festival_sectors",
+          "columnsFrom": [
+            "festival_sector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_templates": {
+      "name": "map_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_data": {
+          "name": "template_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_festival_id": {
+          "name": "created_from_festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "map_templates_created_by_user_id_users_id_fk": {
+          "name": "map_templates_created_by_user_id_users_id_fk",
+          "tableFrom": "map_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "map_templates_created_from_festival_id_festivals_id_fk": {
+          "name": "map_templates_created_from_festival_id_festivals_id_fk",
+          "tableFrom": "map_templates",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "created_from_festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketing_banners": {
+      "name": "marketing_banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url_tablet": {
+          "name": "image_url_tablet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url_mobile": {
+          "name": "image_url_mobile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "marketing_banner_audience",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "open_in_new_tab": {
+          "name": "open_in_new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "marketing_banners_sort_order_idx": {
+          "name": "marketing_banners_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "marketing_banners_is_visible_idx": {
+          "name": "marketing_banners_is_visible_idx",
+          "columns": [
+            {
+              "expression": "is_visible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_items": {
+      "name": "order_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_variant_id": {
+          "name": "product_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_variant_label": {
+          "name": "product_variant_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_at_purchase": {
+          "name": "price_at_purchase",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "product_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'purchase'"
+        },
+        "rental_content_sections_snapshot": {
+          "name": "rental_content_sections_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rental_stock_mode_snapshot": {
+          "name": "rental_stock_mode_snapshot",
+          "type": "product_rental_stock_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rental_festival_id": {
+          "name": "rental_festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rental_reservation_id": {
+          "name": "rental_reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rental_returned_quantity": {
+          "name": "rental_returned_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_items_order_id_idx": {
+          "name": "order_items_order_id_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_items_product_id_idx": {
+          "name": "order_items_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_variant_product_fk": {
+          "name": "order_items_product_variant_product_fk",
+          "tableFrom": "order_items",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "product_variant_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "id",
+            "product_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "order_items_rental_reservation_festival_fk": {
+          "name": "order_items_rental_reservation_festival_fk",
+          "tableFrom": "order_items",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "rental_reservation_id",
+            "rental_festival_id"
+          ],
+          "columnsTo": [
+            "id",
+            "festival_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_items_rental_context_required": {
+          "name": "order_items_rental_context_required",
+          "value": "(\n        \"order_items\".\"transaction_type\" != 'rental'\n        AND \"order_items\".\"rental_content_sections_snapshot\" IS NULL\n        AND \"order_items\".\"rental_stock_mode_snapshot\" IS NULL\n        AND \"order_items\".\"rental_festival_id\" IS NULL\n        AND \"order_items\".\"rental_reservation_id\" IS NULL\n        AND \"order_items\".\"rental_returned_quantity\" = 0\n      ) OR (\n        \"order_items\".\"transaction_type\" = 'rental'\n        AND \"order_items\".\"rental_festival_id\" IS NOT NULL\n        AND \"order_items\".\"rental_reservation_id\" IS NOT NULL\n        AND \"order_items\".\"rental_stock_mode_snapshot\" IS NOT NULL\n      )"
+        },
+        "order_items_rental_returned_quantity_valid": {
+          "name": "order_items_rental_returned_quantity_valid",
+          "value": "\"order_items\".\"rental_returned_quantity\" >= 0 AND \"order_items\".\"rental_returned_quantity\" <= \"order_items\".\"quantity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_phone": {
+          "name": "guest_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_order_token": {
+          "name": "guest_order_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_voucher_url": {
+          "name": "payment_voucher_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voucher_submitted_at": {
+          "name": "voucher_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_due_date": {
+          "name": "payment_due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + interval '2 days'"
+        },
+        "payment_reminder1_sent_at": {
+          "name": "payment_reminder1_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder2_sent_at": {
+          "name": "payment_reminder2_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder3_sent_at": {
+          "name": "payment_reminder3_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder1_claimed_at": {
+          "name": "payment_reminder1_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder2_claimed_at": {
+          "name": "payment_reminder2_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_reminder3_claimed_at": {
+          "name": "payment_reminder3_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "orders_user_id_users_id_fk": {
+          "name": "orders_user_id_users_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orders_guest_order_token_unique": {
+          "name": "orders_guest_order_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "guest_order_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "orders_identity_check": {
+          "name": "orders_identity_check",
+          "value": "(\n\t\t\t\t(\"orders\".\"user_id\" IS NOT NULL AND \"orders\".\"guest_name\" IS NULL AND \"orders\".\"guest_email\" IS NULL AND \"orders\".\"guest_phone\" IS NULL AND \"orders\".\"guest_order_token\" IS NULL)\n\t\t\t\tOR\n\t\t\t\t(\"orders\".\"user_id\" IS NULL AND length(trim(\"orders\".\"guest_name\")) > 0 AND length(trim(\"orders\".\"guest_email\")) > 0 AND length(trim(\"orders\".\"guest_phone\")) > 0 AND length(trim(\"orders\".\"guest_order_token\")) > 0)\n\t\t\t)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.participant_products": {
+      "name": "participant_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participation_id": {
+          "name": "participation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_status": {
+          "name": "submission_status",
+          "type": "submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "submission_feedback": {
+          "name": "submission_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_products_user_id_users_id_fk": {
+          "name": "participant_products_user_id_users_id_fk",
+          "tableFrom": "participant_products",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participant_products_participation_id_participations_id_fk": {
+          "name": "participant_products_participation_id_participations_id_fk",
+          "tableFrom": "participant_products",
+          "tableTo": "participations",
+          "columnsFrom": [
+            "participation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voucher_url": {
+          "name": "voucher_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_user_deletions": {
+      "name": "pending_user_deletions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_deleted_at": {
+          "name": "clerk_deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_deleted_at": {
+          "name": "local_deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_user_deletions_clerk_id_idx": {
+          "name": "pending_user_deletions_clerk_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_user_deletions_reconcile_idx": {
+          "name": "pending_user_deletions_reconcile_idx",
+          "columns": [
+            {
+              "expression": "clerk_deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_user_deletions_user_id_users_id_fk": {
+          "name": "pending_user_deletions_user_id_users_id_fk",
+          "tableFrom": "pending_user_deletions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_content_sections": {
+      "name": "product_content_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_variant_id": {
+          "name": "product_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "product_content_section_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "items": {
+          "name": "items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_context": {
+          "name": "display_context",
+          "type": "product_content_section_display_context",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_content_sections_product_id_idx": {
+          "name": "product_content_sections_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_content_sections_variant_id_idx": {
+          "name": "product_content_sections_variant_id_idx",
+          "columns": [
+            {
+              "expression": "product_variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_content_sections_product_sort_idx": {
+          "name": "product_content_sections_product_sort_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_content_sections_product_id_products_id_fk": {
+          "name": "product_content_sections_product_id_products_id_fk",
+          "tableFrom": "product_content_sections",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_content_sections_product_variant_product_fk": {
+          "name": "product_content_sections_product_variant_product_fk",
+          "tableFrom": "product_content_sections",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "product_variant_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "id",
+            "product_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_images": {
+      "name": "product_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_status": {
+          "name": "upload_status",
+          "type": "product_image_upload_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_images_product_id_idx": {
+          "name": "product_images_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_option_values": {
+      "name": "product_option_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_option_values_option_id_idx": {
+          "name": "product_option_values_option_id_idx",
+          "columns": [
+            {
+              "expression": "option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_option_values_option_id_id_unique": {
+          "name": "product_option_values_option_id_id_unique",
+          "columns": [
+            {
+              "expression": "option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_option_values_option_id_product_options_id_fk": {
+          "name": "product_option_values_option_id_product_options_id_fk",
+          "tableFrom": "product_option_values",
+          "tableTo": "product_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_option_values_option_value_unique": {
+          "name": "product_option_values_option_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "option_id",
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_options": {
+      "name": "product_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector_display": {
+          "name": "selector_display",
+          "type": "product_option_selector_display",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dropdown'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_options_product_id_idx": {
+          "name": "product_options_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_options_id_product_id_unique": {
+          "name": "product_options_id_product_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_options_product_id_products_id_fk": {
+          "name": "product_options_product_id_products_id_fk",
+          "tableFrom": "product_options",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_options_product_name_unique": {
+          "name": "product_options_product_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "product_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_variant_option_values": {
+      "name": "product_variant_option_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_value_id": {
+          "name": "option_value_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_variant_option_values_product_id_idx": {
+          "name": "product_variant_option_values_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_variant_option_values_variant_id_idx": {
+          "name": "product_variant_option_values_variant_id_idx",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_variant_option_values_option_id_idx": {
+          "name": "product_variant_option_values_option_id_idx",
+          "columns": [
+            {
+              "expression": "option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_variant_option_values_option_value_id_idx": {
+          "name": "product_variant_option_values_option_value_id_idx",
+          "columns": [
+            {
+              "expression": "option_value_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_variant_option_values_product_id_products_id_fk": {
+          "name": "product_variant_option_values_product_id_products_id_fk",
+          "tableFrom": "product_variant_option_values",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_variant_option_values_variant_id_product_variants_id_fk": {
+          "name": "product_variant_option_values_variant_id_product_variants_id_fk",
+          "tableFrom": "product_variant_option_values",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_variant_option_values_option_id_product_options_id_fk": {
+          "name": "product_variant_option_values_option_id_product_options_id_fk",
+          "tableFrom": "product_variant_option_values",
+          "tableTo": "product_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_variant_option_values_option_value_id_product_option_values_id_fk": {
+          "name": "product_variant_option_values_option_value_id_product_option_values_id_fk",
+          "tableFrom": "product_variant_option_values",
+          "tableTo": "product_option_values",
+          "columnsFrom": [
+            "option_value_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_variant_option_values_option_value_pair_fk": {
+          "name": "product_variant_option_values_option_value_pair_fk",
+          "tableFrom": "product_variant_option_values",
+          "tableTo": "product_option_values",
+          "columnsFrom": [
+            "option_id",
+            "option_value_id"
+          ],
+          "columnsTo": [
+            "option_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_variant_option_values_variant_product_fk": {
+          "name": "product_variant_option_values_variant_product_fk",
+          "tableFrom": "product_variant_option_values",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "id",
+            "product_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_variant_option_values_option_product_fk": {
+          "name": "product_variant_option_values_option_product_fk",
+          "tableFrom": "product_variant_option_values",
+          "tableTo": "product_options",
+          "columnsFrom": [
+            "option_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "id",
+            "product_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_variant_option_unique": {
+          "name": "product_variant_option_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_id",
+            "option_id"
+          ]
+        },
+        "product_variant_option_value_unique": {
+          "name": "product_variant_option_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_id",
+            "option_value_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_variants": {
+      "name": "product_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rental_stock": {
+          "name": "rental_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_variants_product_id_idx": {
+          "name": "product_variants_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_variants_visible_idx": {
+          "name": "product_variants_visible_idx",
+          "columns": [
+            {
+              "expression": "is_visible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_variants_id_product_id_unique": {
+          "name": "product_variants_id_product_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_variants_product_id_products_id_fk": {
+          "name": "product_variants_product_id_products_id_fk",
+          "tableFrom": "product_variants",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "store_category": {
+          "name": "store_category",
+          "type": "product_store_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'merch'"
+        },
+        "available_date": {
+          "name": "available_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "discount_unit": {
+          "name": "discount_unit",
+          "type": "discount_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "product_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "is_purchasable": {
+          "name": "is_purchasable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_rentable": {
+          "name": "is_rentable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rental_price": {
+          "name": "rental_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rental_stock_mode": {
+          "name": "rental_stock_mode",
+          "type": "product_rental_stock_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shared'"
+        },
+        "rental_stock": {
+          "name": "rental_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_subcategories": {
+      "name": "profile_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subcategory_id": {
+          "name": "subcategory_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_subcategories_profile_id_users_id_fk": {
+          "name": "profile_subcategories_profile_id_users_id_fk",
+          "tableFrom": "profile_subcategories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_subcategories_subcategory_id_subcategories_id_fk": {
+          "name": "profile_subcategories_subcategory_id_subcategories_id_fk",
+          "tableFrom": "profile_subcategories",
+          "tableTo": "subcategories",
+          "columnsFrom": [
+            "subcategory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_tags": {
+      "name": "profile_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_tags_profile_id_users_id_fk": {
+          "name": "profile_tags_profile_id_users_id_fk",
+          "tableFrom": "profile_tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_tags_tag_id_tags_id_fk": {
+          "name": "profile_tags_tag_id_tags_id_fk",
+          "tableFrom": "profile_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program_sessions": {
+      "name": "program_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "session_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "learning_outcomes": {
+          "name": "learning_outcomes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "skill_level": {
+          "name": "skill_level",
+          "type": "session_skill_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience": {
+          "name": "audience",
+          "type": "session_audience",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "public_price": {
+          "name": "public_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "participant_price": {
+          "name": "participant_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "program_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "program_sessions_program_id_status_idx": {
+          "name": "program_sessions_program_id_status_idx",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "program_sessions_program_id_programs_id_fk": {
+          "name": "program_sessions_program_id_programs_id_fk",
+          "tableFrom": "program_sessions",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_sessions_venue_id_venues_id_fk": {
+          "name": "program_sessions_venue_id_venues_id_fk",
+          "tableFrom": "program_sessions",
+          "tableTo": "venues",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "program_sessions_program_id_slug_unique": {
+          "name": "program_sessions_program_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "program_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "program_sessions_public_price_positive": {
+          "name": "program_sessions_public_price_positive",
+          "value": "\"program_sessions\".\"public_price\" >= 0"
+        },
+        "program_sessions_participant_price_valid": {
+          "name": "program_sessions_participant_price_valid",
+          "value": "\"program_sessions\".\"participant_price\" IS NULL\n        OR (\"program_sessions\".\"participant_price\" >= 0 AND \"program_sessions\".\"participant_price\" <= \"program_sessions\".\"public_price\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.program_settings": {
+      "name": "program_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_participant_discount_type": {
+          "name": "default_participant_discount_type",
+          "type": "participant_discount_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percent'"
+        },
+        "default_participant_discount_value": {
+          "name": "default_participant_discount_value",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "default_hold_minutes": {
+          "name": "default_hold_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_occurrence_capacity": {
+          "name": "default_occurrence_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "default_waitlist_invitation_window_minutes": {
+          "name": "default_waitlist_invitation_window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1440
+        },
+        "attendee_cancellation_cutoff_hours": {
+          "name": "attendee_cancellation_cutoff_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 48
+        },
+        "bank_qr_image_url": {
+          "name": "bank_qr_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_refund_policy_version": {
+          "name": "no_refund_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "program_settings_key_unique": {
+          "name": "program_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "program_settings_positive_durations": {
+          "name": "program_settings_positive_durations",
+          "value": "\"program_settings\".\"default_hold_minutes\" > 0\n        AND \"program_settings\".\"default_occurrence_capacity\" > 0\n        AND \"program_settings\".\"default_waitlist_invitation_window_minutes\" > 0\n        AND \"program_settings\".\"attendee_cancellation_cutoff_hours\" > 0"
+        },
+        "program_settings_discount_range": {
+          "name": "program_settings_discount_range",
+          "value": "\"program_settings\".\"default_participant_discount_value\" >= 0\n        AND (\"program_settings\".\"default_participant_discount_type\" <> 'percent'\n             OR \"program_settings\".\"default_participant_discount_value\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "program_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_venue_id": {
+          "name": "default_venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_discount_type": {
+          "name": "participant_discount_type",
+          "type": "participant_discount_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_discount_value": {
+          "name": "participant_discount_value",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waitlist_invitation_window_minutes": {
+          "name": "waitlist_invitation_window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hold_minutes": {
+          "name": "hold_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "programs_status_idx": {
+          "name": "programs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "programs_festival_id_idx": {
+          "name": "programs_festival_id_idx",
+          "columns": [
+            {
+              "expression": "festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "programs_festival_id_festivals_id_fk": {
+          "name": "programs_festival_id_festivals_id_fk",
+          "tableFrom": "programs",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "programs_default_venue_id_venues_id_fk": {
+          "name": "programs_default_venue_id_venues_id_fk",
+          "tableFrom": "programs",
+          "tableTo": "venues",
+          "columnsFrom": [
+            "default_venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "programs_slug_unique": {
+          "name": "programs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "programs_date_range_valid": {
+          "name": "programs_date_range_valid",
+          "value": "\"programs\".\"end_date\" IS NULL OR \"programs\".\"start_date\" IS NULL OR \"programs\".\"end_date\" >= \"programs\".\"start_date\""
+        },
+        "programs_discount_pair_complete": {
+          "name": "programs_discount_pair_complete",
+          "value": "(\"programs\".\"participant_discount_type\" IS NULL AND \"programs\".\"participant_discount_value\" IS NULL)\n        OR (\"programs\".\"participant_discount_type\" IS NOT NULL AND \"programs\".\"participant_discount_value\" IS NOT NULL)"
+        },
+        "programs_discount_range": {
+          "name": "programs_discount_range",
+          "value": "\"programs\".\"participant_discount_value\" IS NULL\n        OR (\"programs\".\"participant_discount_value\" >= 0\n            AND (\"programs\".\"participant_discount_type\" <> 'percent'\n                 OR \"programs\".\"participant_discount_value\" <= 100))"
+        },
+        "programs_positive_overrides": {
+          "name": "programs_positive_overrides",
+          "value": "(\"programs\".\"waitlist_invitation_window_minutes\" IS NULL OR \"programs\".\"waitlist_invitation_window_minutes\" > 0)\n        AND (\"programs\".\"hold_minutes\" IS NULL OR \"programs\".\"hold_minutes\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.qr_codes": {
+      "name": "qr_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qr_code_url": {
+          "name": "qr_code_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_return_logs": {
+      "name": "rental_return_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_item_id": {
+          "name": "order_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_variant_id": {
+          "name": "product_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity_returned": {
+          "name": "quantity_returned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_status": {
+          "name": "condition_status",
+          "type": "rental_return_condition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_restored": {
+          "name": "stock_restored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_pool": {
+          "name": "stock_pool",
+          "type": "product_rental_stock_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_by_user_id": {
+          "name": "processed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_returned_quantity": {
+          "name": "previous_returned_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_returned_quantity": {
+          "name": "new_returned_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name_snapshot": {
+          "name": "product_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_label_snapshot": {
+          "name": "variant_label_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name_snapshot": {
+          "name": "customer_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_return_logs_order_item_id_idx": {
+          "name": "rental_return_logs_order_item_id_idx",
+          "columns": [
+            {
+              "expression": "order_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rental_return_logs_order_id_idx": {
+          "name": "rental_return_logs_order_id_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rental_return_logs_product_id_idx": {
+          "name": "rental_return_logs_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rental_return_logs_created_at_idx": {
+          "name": "rental_return_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rental_return_logs_order_item_id_order_items_id_fk": {
+          "name": "rental_return_logs_order_item_id_order_items_id_fk",
+          "tableFrom": "rental_return_logs",
+          "tableTo": "order_items",
+          "columnsFrom": [
+            "order_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "rental_return_logs_order_id_orders_id_fk": {
+          "name": "rental_return_logs_order_id_orders_id_fk",
+          "tableFrom": "rental_return_logs",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "rental_return_logs_product_id_products_id_fk": {
+          "name": "rental_return_logs_product_id_products_id_fk",
+          "tableFrom": "rental_return_logs",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "rental_return_logs_processed_by_user_id_users_id_fk": {
+          "name": "rental_return_logs_processed_by_user_id_users_id_fk",
+          "tableFrom": "rental_return_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "processed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "rental_return_logs_product_variant_product_fk": {
+          "name": "rental_return_logs_product_variant_product_fk",
+          "tableFrom": "rental_return_logs",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "product_variant_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "id",
+            "product_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rental_return_logs_quantity_positive": {
+          "name": "rental_return_logs_quantity_positive",
+          "value": "\"rental_return_logs\".\"quantity_returned\" > 0"
+        },
+        "rental_return_logs_stock_restored_non_negative": {
+          "name": "rental_return_logs_stock_restored_non_negative",
+          "value": "\"rental_return_logs\".\"stock_restored\" >= 0"
+        },
+        "rental_return_logs_stock_restored_lte_quantity": {
+          "name": "rental_return_logs_stock_restored_lte_quantity",
+          "value": "\"rental_return_logs\".\"stock_restored\" <= \"rental_return_logs\".\"quantity_returned\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reservation_collaborators": {
+      "name": "reservation_collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collaborator_id": {
+          "name": "collaborator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reservation_collaborators_reservation_id_stand_reservations_id_fk": {
+          "name": "reservation_collaborators_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "reservation_collaborators",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reservation_collaborators_collaborator_id_collaborators_id_fk": {
+          "name": "reservation_collaborators_collaborator_id_collaborators_id_fk",
+          "tableFrom": "reservation_collaborators",
+          "tableTo": "collaborators",
+          "columnsFrom": [
+            "collaborator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reservation_external_participants": {
+      "name": "reservation_external_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_participant_id": {
+          "name": "external_participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reservation_external_participants_reservation_id_idx": {
+          "name": "reservation_external_participants_reservation_id_idx",
+          "columns": [
+            {
+              "expression": "reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reservation_external_participants_external_participant_id_external_participants_id_fk": {
+          "name": "reservation_external_participants_external_participant_id_external_participants_id_fk",
+          "tableFrom": "reservation_external_participants",
+          "tableTo": "external_participants",
+          "columnsFrom": [
+            "external_participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reservation_external_participants_reservation_id_stand_reservations_id_fk": {
+          "name": "reservation_external_participants_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "reservation_external_participants",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reservation_external_participants_unique": {
+          "name": "reservation_external_participants_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_participant_id",
+            "reservation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participations": {
+      "name": "participations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_stamp": {
+          "name": "has_stamp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participations_user_id_users_id_fk": {
+          "name": "participations_user_id_users_id_fk",
+          "tableFrom": "participations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participations_reservation_id_stand_reservations_id_fk": {
+          "name": "participations_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "participations",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participations_user_reservation_unique": {
+          "name": "participations_user_reservation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "reservation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sanction_events": {
+      "name": "sanction_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sanction_id": {
+          "name": "sanction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "sanction_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "sanction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "sanction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sanction_events_sanction_id_created_at_idx": {
+          "name": "sanction_events_sanction_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "sanction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sanction_events_sanction_id_sanctions_id_fk": {
+          "name": "sanction_events_sanction_id_sanctions_id_fk",
+          "tableFrom": "sanction_events",
+          "tableTo": "sanctions",
+          "columnsFrom": [
+            "sanction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sanction_events_actor_user_id_users_id_fk": {
+          "name": "sanction_events_actor_user_id_users_id_fk",
+          "tableFrom": "sanction_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sanction_festivals": {
+      "name": "sanction_festivals",
+      "schema": "",
+      "columns": {
+        "sanction_id": {
+          "name": "sanction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qualified_at": {
+          "name": "qualified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_eligible_at": {
+          "name": "reservation_eligible_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_access_notification_queued_at": {
+          "name": "reservation_access_notification_queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counted_at": {
+          "name": "counted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_end_at": {
+          "name": "festival_end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counts_toward_duration": {
+          "name": "counts_toward_duration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "excluded_reason": {
+          "name": "excluded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sanction_festivals_sanction_id_counted_at_idx": {
+          "name": "sanction_festivals_sanction_id_counted_at_idx",
+          "columns": [
+            {
+              "expression": "sanction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sanction_festivals_festival_id_idx": {
+          "name": "sanction_festivals_festival_id_idx",
+          "columns": [
+            {
+              "expression": "festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sanction_festivals_sanction_id_sanctions_id_fk": {
+          "name": "sanction_festivals_sanction_id_sanctions_id_fk",
+          "tableFrom": "sanction_festivals",
+          "tableTo": "sanctions",
+          "columnsFrom": [
+            "sanction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sanction_festivals_festival_id_festivals_id_fk": {
+          "name": "sanction_festivals_festival_id_festivals_id_fk",
+          "tableFrom": "sanction_festivals",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sanction_festivals_sanction_id_festival_id_unique": {
+          "name": "sanction_festivals_sanction_id_festival_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sanction_id",
+            "festival_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sanction_festivals_exclusion_reason_check": {
+          "name": "sanction_festivals_exclusion_reason_check",
+          "value": "(\n        (\"sanction_festivals\".\"counts_toward_duration\" = true AND \"sanction_festivals\".\"excluded_reason\" IS NULL)\n        OR\n        (\"sanction_festivals\".\"counts_toward_duration\" = false AND NULLIF(BTRIM(\"sanction_festivals\".\"excluded_reason\"), '') IS NOT NULL)\n      )"
+        },
+        "sanction_festivals_count_snapshot_check": {
+          "name": "sanction_festivals_count_snapshot_check",
+          "value": "(\n        (\"sanction_festivals\".\"counted_at\" IS NULL AND \"sanction_festivals\".\"festival_end_at\" IS NULL)\n        OR\n        (\"sanction_festivals\".\"counted_at\" IS NOT NULL AND \"sanction_festivals\".\"festival_end_at\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sanction_infractions": {
+      "name": "sanction_infractions",
+      "schema": "",
+      "columns": {
+        "sanction_id": {
+          "name": "sanction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infraction_id": {
+          "name": "infraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_by_user_id": {
+          "name": "linked_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sanction_infractions_infraction_id_unique": {
+          "name": "sanction_infractions_infraction_id_unique",
+          "columns": [
+            {
+              "expression": "infraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sanction_infractions_sanction_id_idx": {
+          "name": "sanction_infractions_sanction_id_idx",
+          "columns": [
+            {
+              "expression": "sanction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sanction_infractions_sanction_id_sanctions_id_fk": {
+          "name": "sanction_infractions_sanction_id_sanctions_id_fk",
+          "tableFrom": "sanction_infractions",
+          "tableTo": "sanctions",
+          "columnsFrom": [
+            "sanction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sanction_infractions_infraction_id_infractions_id_fk": {
+          "name": "sanction_infractions_infraction_id_infractions_id_fk",
+          "tableFrom": "sanction_infractions",
+          "tableTo": "infractions",
+          "columnsFrom": [
+            "infraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sanction_infractions_linked_by_user_id_users_id_fk": {
+          "name": "sanction_infractions_linked_by_user_id_users_id_fk",
+          "tableFrom": "sanction_infractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sanction_infractions_sanction_id_infraction_id_unique": {
+          "name": "sanction_infractions_sanction_id_infraction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sanction_id",
+            "infraction_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sanctions": {
+      "name": "sanctions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infraction_id": {
+          "name": "infraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "sanction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sanction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_scope": {
+          "name": "festival_scope",
+          "type": "sanction_festival_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "validity_duration": {
+          "name": "validity_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validity_unit": {
+          "name": "validity_unit",
+          "type": "duration_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'indefinitely'"
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_delay_minutes": {
+          "name": "reservation_delay_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_unit": {
+          "name": "duration_unit",
+          "type": "duration_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'indefinitely'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sanctions_user_id_status_idx": {
+          "name": "sanctions_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sanctions_festival_scope_status_idx": {
+          "name": "sanctions_festival_scope_status_idx",
+          "columns": [
+            {
+              "expression": "festival_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sanctions_ends_at_idx": {
+          "name": "sanctions_ends_at_idx",
+          "columns": [
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sanctions_user_id_users_id_fk": {
+          "name": "sanctions_user_id_users_id_fk",
+          "tableFrom": "sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sanctions_infraction_id_infractions_id_fk": {
+          "name": "sanctions_infraction_id_infractions_id_fk",
+          "tableFrom": "sanctions",
+          "tableTo": "infractions",
+          "columnsFrom": [
+            "infraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sanctions_created_by_user_id_users_id_fk": {
+          "name": "sanctions_created_by_user_id_users_id_fk",
+          "tableFrom": "sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sanctions_approved_by_user_id_users_id_fk": {
+          "name": "sanctions_approved_by_user_id_users_id_fk",
+          "tableFrom": "sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sanctions_revoked_by_user_id_users_id_fk": {
+          "name": "sanctions_revoked_by_user_id_users_id_fk",
+          "tableFrom": "sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sanctions_validity_configuration_check": {
+          "name": "sanctions_validity_configuration_check",
+          "value": "\n        (\n          \"sanctions\".\"validity_unit\" = 'indefinitely'\n          AND \"sanctions\".\"validity_duration\" IS NULL\n          AND \"sanctions\".\"ends_at\" IS NULL\n        )\n        OR\n        (\n          \"sanctions\".\"validity_unit\" = 'festivals'\n          AND \"sanctions\".\"validity_duration\" > 0\n          AND \"sanctions\".\"ends_at\" IS NULL\n        )\n        OR\n        (\n          \"sanctions\".\"validity_unit\" IN ('minutes', 'hours', 'days', 'months', 'years')\n          AND \"sanctions\".\"validity_duration\" > 0\n          AND \"sanctions\".\"ends_at\" > \"sanctions\".\"starts_at\"\n        )\n      "
+        },
+        "sanctions_reservation_delay_configuration_check": {
+          "name": "sanctions_reservation_delay_configuration_check",
+          "value": "\n        (\n          \"sanctions\".\"type\" = 'reservation_delay'\n          AND \"sanctions\".\"reservation_delay_minutes\" > 0\n        )\n        OR\n        (\n          \"sanctions\".\"type\" <> 'reservation_delay'\n          AND \"sanctions\".\"reservation_delay_minutes\" IS NULL\n        )\n      "
+        },
+        "sanctions_revocation_configuration_check": {
+          "name": "sanctions_revocation_configuration_check",
+          "value": "\n        (\n          \"sanctions\".\"status\" = 'revoked'\n          AND \"sanctions\".\"revoked_by_user_id\" IS NOT NULL\n          AND \"sanctions\".\"revoked_at\" IS NOT NULL\n          AND NULLIF(BTRIM(\"sanctions\".\"revocation_reason\"), '') IS NOT NULL\n        )\n        OR\n        (\n          \"sanctions\".\"status\" <> 'revoked'\n          AND \"sanctions\".\"revoked_by_user_id\" IS NULL\n          AND \"sanctions\".\"revoked_at\" IS NULL\n          AND \"sanctions\".\"revocation_reason\" IS NULL\n        )\n      "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "scheduled_task_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'profile_creation'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_time": {
+          "name": "reminder_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ran_after_due_date": {
+          "name": "ran_after_due_date",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_tasks_profile_id_users_id_fk": {
+          "name": "scheduled_tasks_profile_id_users_id_fk",
+          "tableFrom": "scheduled_tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_tasks_reservation_id_stand_reservations_id_fk": {
+          "name": "scheduled_tasks_reservation_id_stand_reservations_id_fk",
+          "tableFrom": "scheduled_tasks",
+          "tableTo": "stand_reservations",
+          "columnsFrom": [
+            "reservation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_attendances": {
+      "name": "session_attendances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrence_id": {
+          "name": "occurrence_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_in_at": {
+          "name": "checked_in_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "operator_user_id": {
+          "name": "operator_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "attendance_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'qr_scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_attendances_occurrence_idx": {
+          "name": "session_attendances_occurrence_idx",
+          "columns": [
+            {
+              "expression": "occurrence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_attendances_operator_user_id_users_id_fk": {
+          "name": "session_attendances_operator_user_id_users_id_fk",
+          "tableFrom": "session_attendances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "operator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "session_attendances_ticket_occurrence_fk": {
+          "name": "session_attendances_ticket_occurrence_fk",
+          "tableFrom": "session_attendances",
+          "tableTo": "session_tickets",
+          "columnsFrom": [
+            "ticket_id",
+            "occurrence_id"
+          ],
+          "columnsTo": [
+            "id",
+            "occurrence_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_attendances_ticket_id_unique": {
+          "name": "session_attendances_ticket_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ticket_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_occurrence_schedule_changes": {
+      "name": "session_occurrence_schedule_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "occurrence_id": {
+          "name": "occurrence_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_starts_at": {
+          "name": "from_starts_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_ends_at": {
+          "name": "from_ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_starts_at": {
+          "name": "to_starts_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_ends_at": {
+          "name": "to_ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_venue_id": {
+          "name": "from_venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_venue_id": {
+          "name": "to_venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_room": {
+          "name": "from_room",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_room": {
+          "name": "to_room",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_occurrence_schedule_changes_occurrence_idx": {
+          "name": "session_occurrence_schedule_changes_occurrence_idx",
+          "columns": [
+            {
+              "expression": "occurrence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_occurrence_schedule_changes_occurrence_id_session_occurrences_id_fk": {
+          "name": "session_occurrence_schedule_changes_occurrence_id_session_occurrences_id_fk",
+          "tableFrom": "session_occurrence_schedule_changes",
+          "tableTo": "session_occurrences",
+          "columnsFrom": [
+            "occurrence_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_occurrence_schedule_changes_from_venue_id_venues_id_fk": {
+          "name": "session_occurrence_schedule_changes_from_venue_id_venues_id_fk",
+          "tableFrom": "session_occurrence_schedule_changes",
+          "tableTo": "venues",
+          "columnsFrom": [
+            "from_venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "session_occurrence_schedule_changes_to_venue_id_venues_id_fk": {
+          "name": "session_occurrence_schedule_changes_to_venue_id_venues_id_fk",
+          "tableFrom": "session_occurrence_schedule_changes",
+          "tableTo": "venues",
+          "columnsFrom": [
+            "to_venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "session_occurrence_schedule_changes_actor_user_id_users_id_fk": {
+          "name": "session_occurrence_schedule_changes_actor_user_id_users_id_fk",
+          "tableFrom": "session_occurrence_schedule_changes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_occurrences": {
+      "name": "session_occurrences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room": {
+          "name": "room",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "sales_start_at": {
+          "name": "sales_start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_end_at": {
+          "name": "sales_end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_closed_at": {
+          "name": "sales_closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "occurrence_lifecycle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_reason": {
+          "name": "cancelled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rescheduled_at": {
+          "name": "rescheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_occurrences_session_id_starts_at_idx": {
+          "name": "session_occurrences_session_id_starts_at_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_occurrences_lifecycle_starts_at_idx": {
+          "name": "session_occurrences_lifecycle_starts_at_idx",
+          "columns": [
+            {
+              "expression": "lifecycle_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_occurrences_session_id_program_sessions_id_fk": {
+          "name": "session_occurrences_session_id_program_sessions_id_fk",
+          "tableFrom": "session_occurrences",
+          "tableTo": "program_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_occurrences_venue_id_venues_id_fk": {
+          "name": "session_occurrences_venue_id_venues_id_fk",
+          "tableFrom": "session_occurrences",
+          "tableTo": "venues",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_occurrences_id_session_id_unique": {
+          "name": "session_occurrences_id_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_occurrences_time_range_valid": {
+          "name": "session_occurrences_time_range_valid",
+          "value": "\"session_occurrences\".\"ends_at\" > \"session_occurrences\".\"starts_at\""
+        },
+        "session_occurrences_capacity_positive": {
+          "name": "session_occurrences_capacity_positive",
+          "value": "\"session_occurrences\".\"capacity\" > 0"
+        },
+        "session_occurrences_sales_window_valid": {
+          "name": "session_occurrences_sales_window_valid",
+          "value": "\"session_occurrences\".\"sales_end_at\" IS NULL OR \"session_occurrences\".\"sales_start_at\" IS NULL OR \"session_occurrences\".\"sales_end_at\" >= \"session_occurrences\".\"sales_start_at\""
+        },
+        "session_occurrences_cancelled_consistent": {
+          "name": "session_occurrences_cancelled_consistent",
+          "value": "\"session_occurrences\".\"lifecycle_status\" <> 'cancelled' OR \"session_occurrences\".\"cancelled_at\" IS NOT NULL"
+        },
+        "session_occurrences_completed_consistent": {
+          "name": "session_occurrences_completed_consistent",
+          "value": "\"session_occurrences\".\"lifecycle_status\" <> 'completed' OR \"session_occurrences\".\"completed_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_purchase_events": {
+      "name": "session_purchase_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "purchase_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "session_purchase_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "session_purchase_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "session_purchase_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_purchase_events_purchase_created_idx": {
+          "name": "session_purchase_events_purchase_created_idx",
+          "columns": [
+            {
+              "expression": "purchase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_purchase_events_purchase_id_session_purchases_id_fk": {
+          "name": "session_purchase_events_purchase_id_session_purchases_id_fk",
+          "tableFrom": "session_purchase_events",
+          "tableTo": "session_purchases",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_purchase_events_actor_user_id_users_id_fk": {
+          "name": "session_purchase_events_actor_user_id_users_id_fk",
+          "tableFrom": "session_purchase_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_purchase_events_admin_needs_reason": {
+          "name": "session_purchase_events_admin_needs_reason",
+          "value": "\"session_purchase_events\".\"actor_type\" <> 'admin' OR (\"session_purchase_events\".\"reason\" IS NOT NULL AND length(trim(\"session_purchase_events\".\"reason\")) > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_purchase_lines": {
+      "name": "session_purchase_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrence_id": {
+          "name": "occurrence_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "purchase_line_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual_session'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_basis": {
+          "name": "price_basis",
+          "type": "participant_eligibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_snapshot": {
+          "name": "pricing_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_title_snapshot": {
+          "name": "session_title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrence_starts_at_snapshot": {
+          "name": "occurrence_starts_at_snapshot",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_purchase_lines_occurrence_idx": {
+          "name": "session_purchase_lines_occurrence_idx",
+          "columns": [
+            {
+              "expression": "occurrence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_purchase_lines_purchase_idx": {
+          "name": "session_purchase_lines_purchase_idx",
+          "columns": [
+            {
+              "expression": "purchase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_purchase_lines_purchase_id_session_purchases_id_fk": {
+          "name": "session_purchase_lines_purchase_id_session_purchases_id_fk",
+          "tableFrom": "session_purchase_lines",
+          "tableTo": "session_purchases",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_purchase_lines_occurrence_session_fk": {
+          "name": "session_purchase_lines_occurrence_session_fk",
+          "tableFrom": "session_purchase_lines",
+          "tableTo": "session_occurrences",
+          "columnsFrom": [
+            "occurrence_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "id",
+            "session_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_purchase_lines_purchase_id_occurrence_id_unique": {
+          "name": "session_purchase_lines_purchase_id_occurrence_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "purchase_id",
+            "occurrence_id"
+          ]
+        },
+        "session_purchase_lines_id_occurrence_id_unique": {
+          "name": "session_purchase_lines_id_occurrence_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "occurrence_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_purchase_lines_price_positive": {
+          "name": "session_purchase_lines_price_positive",
+          "value": "\"session_purchase_lines\".\"unit_price\" >= 0"
+        },
+        "session_purchase_lines_pass_line_free": {
+          "name": "session_purchase_lines_pass_line_free",
+          "value": "\"session_purchase_lines\".\"source\" <> 'pass_session' OR \"session_purchase_lines\".\"unit_price\" = 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_purchase_vouchers": {
+      "name": "session_purchase_vouchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_user_id": {
+          "name": "uploaded_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_via": {
+          "name": "uploaded_via",
+          "type": "purchase_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_purchase_vouchers_purchase_id_session_purchases_id_fk": {
+          "name": "session_purchase_vouchers_purchase_id_session_purchases_id_fk",
+          "tableFrom": "session_purchase_vouchers",
+          "tableTo": "session_purchases",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_purchase_vouchers_uploaded_by_user_id_users_id_fk": {
+          "name": "session_purchase_vouchers_uploaded_by_user_id_users_id_fk",
+          "tableFrom": "session_purchase_vouchers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_purchase_vouchers_purchase_version_unique": {
+          "name": "session_purchase_vouchers_purchase_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "purchase_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_purchase_vouchers_version_positive": {
+          "name": "session_purchase_vouchers_version_positive",
+          "value": "\"session_purchase_vouchers\".\"version\" >= 1"
+        },
+        "session_purchase_vouchers_file_present": {
+          "name": "session_purchase_vouchers_file_present",
+          "value": "length(trim(\"session_purchase_vouchers\".\"file_url\")) > 0"
+        },
+        "session_purchase_vouchers_uploaded_via_valid": {
+          "name": "session_purchase_vouchers_uploaded_via_valid",
+          "value": "\"session_purchase_vouchers\".\"uploaded_via\" IN ('buyer', 'admin')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_purchases": {
+      "name": "session_purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_phone": {
+          "name": "guest_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_gender": {
+          "name": "guest_gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_birthdate": {
+          "name": "guest_birthdate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_revoked_at": {
+          "name": "access_token_revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "session_purchase_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_upload'"
+        },
+        "payment_mode": {
+          "name": "payment_mode",
+          "type": "session_purchase_payment_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyer_eligibility": {
+          "name": "buyer_eligibility",
+          "type": "participant_eligibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eligibility_evaluated_at": {
+          "name": "eligibility_evaluated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eligibility_snapshot": {
+          "name": "eligibility_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal_amount": {
+          "name": "subtotal_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_expires_at": {
+          "name": "hold_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voucher_submitted_at": {
+          "name": "voucher_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_refund_policy_version": {
+          "name": "no_refund_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "no_refund_policy_accepted_at": {
+          "name": "no_refund_policy_accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_purchases_status_hold_expires_idx": {
+          "name": "session_purchases_status_hold_expires_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_purchases_user_created_idx": {
+          "name": "session_purchases_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_purchases_program_status_idx": {
+          "name": "session_purchases_program_status_idx",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_purchases_program_id_programs_id_fk": {
+          "name": "session_purchases_program_id_programs_id_fk",
+          "tableFrom": "session_purchases",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "session_purchases_user_id_users_id_fk": {
+          "name": "session_purchases_user_id_users_id_fk",
+          "tableFrom": "session_purchases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_purchases_access_token_hash_unique": {
+          "name": "session_purchases_access_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_hash"
+          ]
+        },
+        "session_purchases_idempotency_key_unique": {
+          "name": "session_purchases_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_purchases_identity_check": {
+          "name": "session_purchases_identity_check",
+          "value": "(\n        (\"session_purchases\".\"user_id\" IS NOT NULL AND \"session_purchases\".\"guest_name\" IS NULL AND \"session_purchases\".\"guest_email\" IS NULL AND \"session_purchases\".\"guest_phone\" IS NULL)\n        OR\n        (\"session_purchases\".\"user_id\" IS NULL\n         AND \"session_purchases\".\"guest_name\" IS NOT NULL AND length(trim(\"session_purchases\".\"guest_name\")) > 0\n         AND \"session_purchases\".\"guest_email\" IS NOT NULL AND length(trim(\"session_purchases\".\"guest_email\")) > 0\n         AND \"session_purchases\".\"guest_phone\" IS NOT NULL AND length(trim(\"session_purchases\".\"guest_phone\")) > 0)\n      )"
+        },
+        "session_purchases_amounts_valid": {
+          "name": "session_purchases_amounts_valid",
+          "value": "\"session_purchases\".\"subtotal_amount\" >= 0 AND \"session_purchases\".\"total_amount\" >= 0 AND \"session_purchases\".\"total_amount\" <= \"session_purchases\".\"subtotal_amount\""
+        },
+        "session_purchases_free_has_no_hold": {
+          "name": "session_purchases_free_has_no_hold",
+          "value": "\"session_purchases\".\"payment_mode\" <> 'free' OR (\"session_purchases\".\"total_amount\" = 0 AND \"session_purchases\".\"hold_expires_at\" IS NULL)"
+        },
+        "session_purchases_paid_has_hold": {
+          "name": "session_purchases_paid_has_hold",
+          "value": "\"session_purchases\".\"payment_mode\" <> 'bank_qr' OR \"session_purchases\".\"hold_expires_at\" IS NOT NULL"
+        },
+        "session_purchases_terminal_timestamps": {
+          "name": "session_purchases_terminal_timestamps",
+          "value": "(\"session_purchases\".\"status\" <> 'approved' OR \"session_purchases\".\"approved_at\" IS NOT NULL)\n        AND (\"session_purchases\".\"status\" <> 'rejected' OR \"session_purchases\".\"rejected_at\" IS NOT NULL)\n        AND (\"session_purchases\".\"status\" <> 'expired' OR \"session_purchases\".\"expired_at\" IS NOT NULL)\n        AND (\"session_purchases\".\"status\" <> 'cancelled' OR \"session_purchases\".\"cancelled_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_speakers": {
+      "name": "session_speakers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker_id": {
+          "name": "speaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_speakers_session_id_program_sessions_id_fk": {
+          "name": "session_speakers_session_id_program_sessions_id_fk",
+          "tableFrom": "session_speakers",
+          "tableTo": "program_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_speakers_speaker_id_speakers_id_fk": {
+          "name": "session_speakers_speaker_id_speakers_id_fk",
+          "tableFrom": "session_speakers",
+          "tableTo": "speakers",
+          "columnsFrom": [
+            "speaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_speakers_session_id_speaker_id_unique": {
+          "name": "session_speakers_session_id_speaker_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id",
+            "speaker_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_tickets": {
+      "name": "session_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "purchase_line_id": {
+          "name": "purchase_line_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrence_id": {
+          "name": "occurrence_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_ticket_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'valid'"
+        },
+        "attendee_user_id": {
+          "name": "attendee_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendee_name": {
+          "name": "attendee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendee_email": {
+          "name": "attendee_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_reason": {
+          "name": "cancelled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_actor_type": {
+          "name": "cancelled_by_actor_type",
+          "type": "purchase_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_tickets_occurrence_attendee_user_idx": {
+          "name": "session_tickets_occurrence_attendee_user_idx",
+          "columns": [
+            {
+              "expression": "occurrence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attendee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"session_tickets\".\"status\" = 'valid' AND \"session_tickets\".\"attendee_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_tickets_occurrence_attendee_email_idx": {
+          "name": "session_tickets_occurrence_attendee_email_idx",
+          "columns": [
+            {
+              "expression": "occurrence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"attendee_email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"session_tickets\".\"status\" = 'valid'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_tickets_occurrence_status_idx": {
+          "name": "session_tickets_occurrence_status_idx",
+          "columns": [
+            {
+              "expression": "occurrence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_tickets_attendee_user_id_users_id_fk": {
+          "name": "session_tickets_attendee_user_id_users_id_fk",
+          "tableFrom": "session_tickets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "attendee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "session_tickets_line_occurrence_fk": {
+          "name": "session_tickets_line_occurrence_fk",
+          "tableFrom": "session_tickets",
+          "tableTo": "session_purchase_lines",
+          "columnsFrom": [
+            "purchase_line_id",
+            "occurrence_id"
+          ],
+          "columnsTo": [
+            "id",
+            "occurrence_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_tickets_purchase_line_id_unique": {
+          "name": "session_tickets_purchase_line_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "purchase_line_id"
+          ]
+        },
+        "session_tickets_code_unique": {
+          "name": "session_tickets_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        },
+        "session_tickets_id_occurrence_id_unique": {
+          "name": "session_tickets_id_occurrence_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "occurrence_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_tickets_cancelled_consistent": {
+          "name": "session_tickets_cancelled_consistent",
+          "value": "\"session_tickets\".\"status\" <> 'cancelled' OR \"session_tickets\".\"cancelled_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_waitlist_entries": {
+      "name": "session_waitlist_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "occurrence_id": {
+          "name": "occurrence_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_phone": {
+          "name": "guest_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_entry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_waitlist_entries_occurrence_user_idx": {
+          "name": "session_waitlist_entries_occurrence_user_idx",
+          "columns": [
+            {
+              "expression": "occurrence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"session_waitlist_entries\".\"status\" <> 'removed' AND \"session_waitlist_entries\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_waitlist_entries_occurrence_email_idx": {
+          "name": "session_waitlist_entries_occurrence_email_idx",
+          "columns": [
+            {
+              "expression": "occurrence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"guest_email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"session_waitlist_entries\".\"status\" <> 'removed' AND \"session_waitlist_entries\".\"guest_email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_waitlist_entries_occurrence_status_idx": {
+          "name": "session_waitlist_entries_occurrence_status_idx",
+          "columns": [
+            {
+              "expression": "occurrence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_waitlist_entries_occurrence_id_session_occurrences_id_fk": {
+          "name": "session_waitlist_entries_occurrence_id_session_occurrences_id_fk",
+          "tableFrom": "session_waitlist_entries",
+          "tableTo": "session_occurrences",
+          "columnsFrom": [
+            "occurrence_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_waitlist_entries_user_id_users_id_fk": {
+          "name": "session_waitlist_entries_user_id_users_id_fk",
+          "tableFrom": "session_waitlist_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_waitlist_entries_identity_check": {
+          "name": "session_waitlist_entries_identity_check",
+          "value": "(\n        (\"session_waitlist_entries\".\"user_id\" IS NOT NULL AND \"session_waitlist_entries\".\"guest_name\" IS NULL AND \"session_waitlist_entries\".\"guest_email\" IS NULL AND \"session_waitlist_entries\".\"guest_phone\" IS NULL)\n        OR\n        (\"session_waitlist_entries\".\"user_id\" IS NULL\n         AND \"session_waitlist_entries\".\"guest_name\" IS NOT NULL AND length(trim(\"session_waitlist_entries\".\"guest_name\")) > 0\n         AND \"session_waitlist_entries\".\"guest_email\" IS NOT NULL AND length(trim(\"session_waitlist_entries\".\"guest_email\")) > 0\n         AND \"session_waitlist_entries\".\"guest_phone\" IS NOT NULL AND length(trim(\"session_waitlist_entries\".\"guest_phone\")) > 0)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_waitlist_invitations": {
+      "name": "session_waitlist_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "waitlist_entry_id": {
+          "name": "waitlist_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sent'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "converted_at": {
+          "name": "converted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_waitlist_invitations_live_idx": {
+          "name": "session_waitlist_invitations_live_idx",
+          "columns": [
+            {
+              "expression": "waitlist_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"session_waitlist_invitations\".\"status\" = 'sent'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_waitlist_invitations_status_expires_idx": {
+          "name": "session_waitlist_invitations_status_expires_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_waitlist_invitations_waitlist_entry_id_session_waitlist_entries_id_fk": {
+          "name": "session_waitlist_invitations_waitlist_entry_id_session_waitlist_entries_id_fk",
+          "tableFrom": "session_waitlist_invitations",
+          "tableTo": "session_waitlist_entries",
+          "columnsFrom": [
+            "waitlist_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_waitlist_invitations_invited_by_user_id_users_id_fk": {
+          "name": "session_waitlist_invitations_invited_by_user_id_users_id_fk",
+          "tableFrom": "session_waitlist_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "session_waitlist_invitations_purchase_id_session_purchases_id_fk": {
+          "name": "session_waitlist_invitations_purchase_id_session_purchases_id_fk",
+          "tableFrom": "session_waitlist_invitations",
+          "tableTo": "session_purchases",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_waitlist_invitations_token_hash_unique": {
+          "name": "session_waitlist_invitations_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_waitlist_invitations_reason_present": {
+          "name": "session_waitlist_invitations_reason_present",
+          "value": "length(trim(\"session_waitlist_invitations\".\"reason\")) > 0"
+        },
+        "session_waitlist_invitations_terminal_timestamps": {
+          "name": "session_waitlist_invitations_terminal_timestamps",
+          "value": "(\"session_waitlist_invitations\".\"status\" <> 'converted' OR \"session_waitlist_invitations\".\"converted_at\" IS NOT NULL)\n        AND (\"session_waitlist_invitations\".\"status\" <> 'revoked' OR \"session_waitlist_invitations\".\"revoked_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.speakers": {
+      "name": "speakers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_name": {
+          "name": "public_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stand_groups": {
+      "name": "stand_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "festival_sector_id": {
+          "name": "festival_sector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stand_groups_festival_sector_id_idx": {
+          "name": "stand_groups_festival_sector_id_idx",
+          "columns": [
+            {
+              "expression": "festival_sector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stand_groups_festival_sector_id_festival_sectors_id_fk": {
+          "name": "stand_groups_festival_sector_id_festival_sectors_id_fk",
+          "tableFrom": "stand_groups",
+          "tableTo": "festival_sectors",
+          "columnsFrom": [
+            "festival_sector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stand_holds": {
+      "name": "stand_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stand_holds_stand_idx": {
+          "name": "stand_holds_stand_idx",
+          "columns": [
+            {
+              "expression": "stand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stand_holds_user_festival_idx": {
+          "name": "stand_holds_user_festival_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stand_holds_stand_id_stands_id_fk": {
+          "name": "stand_holds_stand_id_stands_id_fk",
+          "tableFrom": "stand_holds",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stand_holds_user_id_users_id_fk": {
+          "name": "stand_holds_user_id_users_id_fk",
+          "tableFrom": "stand_holds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stand_holds_festival_id_festivals_id_fk": {
+          "name": "stand_holds_festival_id_festivals_id_fk",
+          "tableFrom": "stand_holds",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stand_reservations": {
+      "name": "stand_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "reservation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "reservation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_reservation'"
+        },
+        "reveal_at": {
+          "name": "reveal_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stand_reservations_id_festival_id_unique": {
+          "name": "stand_reservations_id_festival_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "festival_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stand_reservations_stand_id_stands_id_fk": {
+          "name": "stand_reservations_stand_id_stands_id_fk",
+          "tableFrom": "stand_reservations",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stand_subcategories": {
+      "name": "stand_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stand_id": {
+          "name": "stand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subcategory_id": {
+          "name": "subcategory_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stand_subcategories_stand_id_stands_id_fk": {
+          "name": "stand_subcategories_stand_id_stands_id_fk",
+          "tableFrom": "stand_subcategories",
+          "tableTo": "stands",
+          "columnsFrom": [
+            "stand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stand_subcategories_subcategory_id_subcategories_id_fk": {
+          "name": "stand_subcategories_subcategory_id_subcategories_id_fk",
+          "tableFrom": "stand_subcategories",
+          "tableTo": "subcategories",
+          "columnsFrom": [
+            "subcategory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stands": {
+      "name": "stands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "stand_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "orientation": {
+          "name": "orientation",
+          "type": "stand_orientation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'landscape'"
+        },
+        "stand_number": {
+          "name": "stand_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stand_category": {
+          "name": "stand_category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'illustration'"
+        },
+        "zone": {
+          "name": "zone",
+          "type": "stand_zone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "width": {
+          "name": "width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_left": {
+          "name": "position_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_top": {
+          "name": "position_top",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "participation_type": {
+          "name": "participation_type",
+          "type": "participation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "festival_sector_id": {
+          "name": "festival_sector_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qr_code_id": {
+          "name": "qr_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stand_group_id": {
+          "name": "stand_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stand_label_idx": {
+          "name": "stand_label_idx",
+          "columns": [
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stands_festival_sector_id_idx": {
+          "name": "stands_festival_sector_id_idx",
+          "columns": [
+            {
+              "expression": "festival_sector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stands_stand_group_id_idx": {
+          "name": "stands_stand_group_id_idx",
+          "columns": [
+            {
+              "expression": "stand_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stands_festival_sector_id_festival_sectors_id_fk": {
+          "name": "stands_festival_sector_id_festival_sectors_id_fk",
+          "tableFrom": "stands",
+          "tableTo": "festival_sectors",
+          "columnsFrom": [
+            "festival_sector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stands_qr_code_id_qr_codes_id_fk": {
+          "name": "stands_qr_code_id_qr_codes_id_fk",
+          "tableFrom": "stands",
+          "tableTo": "qr_codes",
+          "columnsFrom": [
+            "qr_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stands_stand_group_id_stand_groups_id_fk": {
+          "name": "stands_stand_group_id_stand_groups_id_fk",
+          "tableFrom": "stands",
+          "tableTo": "stand_groups",
+          "columnsFrom": [
+            "stand_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_cleanup_jobs": {
+      "name": "storage_cleanup_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "storage_cleanup_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_cleanup_jobs_status_next_attempt_idx": {
+          "name": "storage_cleanup_jobs_status_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storage_cleanup_jobs_entity_idx": {
+          "name": "storage_cleanup_jobs_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_settings": {
+      "name": "store_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "section": {
+          "name": "section",
+          "type": "store_section",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "store_status_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "closed_title": {
+          "name": "closed_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_message": {
+          "name": "closed_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "store_settings_section_unique": {
+          "name": "store_settings_section_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "section"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subcategories": {
+      "name": "subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tickets": {
+      "name": "tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ticket_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_event_day_creation": {
+          "name": "is_event_day_creation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_visitors": {
+          "name": "number_of_visitors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "ticket_number": {
+          "name": "ticket_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_in_at": {
+          "name": "checked_in_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_badges_user_id_users_id_fk": {
+          "name": "user_badges_user_id_users_id_fk",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_badges_id_fk": {
+          "name": "user_badges_badge_id_badges_id_fk",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_requests": {
+      "name": "user_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "festival_id": {
+          "name": "festival_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "user_request_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'become_artist'"
+        },
+        "status": {
+          "name": "status",
+          "type": "participation_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_requests_user_id_users_id_fk": {
+          "name": "user_requests_user_id_users_id_fk",
+          "tableFrom": "user_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_requests_festival_id_festivals_id_fk": {
+          "name": "user_requests_festival_id_festivals_id_fk",
+          "tableFrom": "user_requests",
+          "tableTo": "festivals",
+          "columnsFrom": [
+            "festival_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_socials": {
+      "name": "user_socials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "user_social_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_socials_user_id_users_id_fk": {
+          "name": "user_socials_user_id_users_id_fk",
+          "tableFrom": "user_socials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_status_events": {
+      "name": "user_status_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_status_events_user_id_users_id_fk": {
+          "name": "user_status_events_user_id_users_id_fk",
+          "tableFrom": "user_status_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_status_events_created_by_user_id_users_id_fk": {
+          "name": "user_status_events_created_by_user_id_users_id_fk",
+          "tableFrom": "user_status_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthdate": {
+          "name": "birthdate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "category": {
+          "name": "category",
+          "type": "user_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'undisclosed'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BO'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "should_submit_products": {
+          "name": "should_submit_products",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "participation_type": {
+          "name": "participation_type",
+          "type": "participation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "display_name_idx": {
+          "name": "display_name_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venues": {
+      "name": "venues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label": {
+          "name": "location_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_url": {
+          "name": "location_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.visitors": {
+      "name": "visitors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_discovery": {
+          "name": "event_discovery",
+          "type": "event_discovery",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'undisclosed'"
+        },
+        "birthdate": {
+          "name": "birthdate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "visitors_email_unique": {
+          "name": "visitors_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_level": {
+      "name": "access_level",
+      "schema": "public",
+      "values": [
+        "public",
+        "festival_participants_only"
+      ]
+    },
+    "public.attendance_method": {
+      "name": "attendance_method",
+      "schema": "public",
+      "values": [
+        "qr_scan",
+        "manual_code"
+      ]
+    },
+    "public.disciplinary_notification_job_status": {
+      "name": "disciplinary_notification_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.discount_unit": {
+      "name": "discount_unit",
+      "schema": "public",
+      "values": [
+        "percentage",
+        "amount"
+      ]
+    },
+    "public.duration_unit": {
+      "name": "duration_unit",
+      "schema": "public",
+      "values": [
+        "minutes",
+        "hours",
+        "days",
+        "months",
+        "years",
+        "festivals",
+        "indefinitely"
+      ]
+    },
+    "public.event_discovery": {
+      "name": "event_discovery",
+      "schema": "public",
+      "values": [
+        "facebook",
+        "instagram",
+        "tiktok",
+        "cba",
+        "friends",
+        "participant_invitation",
+        "casual",
+        "la_rota",
+        "other"
+      ]
+    },
+    "public.external_participant_type": {
+      "name": "external_participant_type",
+      "schema": "public",
+      "values": [
+        "institution",
+        "social_organization",
+        "sponsor",
+        "partner",
+        "public_entity",
+        "invited_brand",
+        "other"
+      ]
+    },
+    "public.feature_flag_visibility": {
+      "name": "feature_flag_visibility",
+      "schema": "public",
+      "values": [
+        "hidden",
+        "admin_only",
+        "public"
+      ]
+    },
+    "public.festival_activity_type": {
+      "name": "festival_activity_type",
+      "schema": "public",
+      "values": [
+        "stamp_passport",
+        "sticker_print",
+        "best_stand",
+        "festival_sticker",
+        "coupon_book",
+        "sticker_hunt"
+      ]
+    },
+    "public.festival_map_version": {
+      "name": "festival_map_version",
+      "schema": "public",
+      "values": [
+        "v1",
+        "v2",
+        "v3"
+      ]
+    },
+    "public.festival_status": {
+      "name": "festival_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "active",
+        "archived"
+      ]
+    },
+    "public.festival_type": {
+      "name": "festival_type",
+      "schema": "public",
+      "values": [
+        "glitter",
+        "twinkler",
+        "festicker"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "non_binary",
+        "other",
+        "undisclosed"
+      ]
+    },
+    "public.infraction_event_type": {
+      "name": "infraction_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "edited",
+        "review_started",
+        "resolved",
+        "voided",
+        "reopened",
+        "sanction_linked",
+        "duplicate_confirmed"
+      ]
+    },
+    "public.infraction_severity": {
+      "name": "infraction_severity",
+      "schema": "public",
+      "values": [
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ]
+    },
+    "public.infraction_status": {
+      "name": "infraction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "under_review",
+        "resolved",
+        "voided"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "paid",
+        "cancelled"
+      ]
+    },
+    "public.live_act_category": {
+      "name": "live_act_category",
+      "schema": "public",
+      "values": [
+        "music",
+        "dance",
+        "talk"
+      ]
+    },
+    "public.live_act_status": {
+      "name": "live_act_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "backlog",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.map_element_label_position": {
+      "name": "map_element_label_position",
+      "schema": "public",
+      "values": [
+        "left",
+        "right",
+        "top",
+        "bottom"
+      ]
+    },
+    "public.map_element_type": {
+      "name": "map_element_type",
+      "schema": "public",
+      "values": [
+        "entrance",
+        "stage",
+        "door",
+        "bathroom",
+        "label",
+        "custom",
+        "stairs"
+      ]
+    },
+    "public.marketing_banner_audience": {
+      "name": "marketing_banner_audience",
+      "schema": "public",
+      "values": [
+        "all",
+        "public_only",
+        "participants_only"
+      ]
+    },
+    "public.occurrence_lifecycle_status": {
+      "name": "occurrence_lifecycle_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "payment_verification",
+        "processing",
+        "paid",
+        "delivered",
+        "cancelled"
+      ]
+    },
+    "public.participant_discount_type": {
+      "name": "participant_discount_type",
+      "schema": "public",
+      "values": [
+        "percent",
+        "fixed"
+      ]
+    },
+    "public.participant_eligibility": {
+      "name": "participant_eligibility",
+      "schema": "public",
+      "values": [
+        "active_participant",
+        "public"
+      ]
+    },
+    "public.participation_type": {
+      "name": "participation_type",
+      "schema": "public",
+      "values": [
+        "standard",
+        "live_activity"
+      ]
+    },
+    "public.product_content_section_display_context": {
+      "name": "product_content_section_display_context",
+      "schema": "public",
+      "values": [
+        "all",
+        "purchase",
+        "rental"
+      ]
+    },
+    "public.product_content_section_format": {
+      "name": "product_content_section_format",
+      "schema": "public",
+      "values": [
+        "free_text",
+        "bullet_list"
+      ]
+    },
+    "public.product_image_upload_status": {
+      "name": "product_image_upload_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active"
+      ]
+    },
+    "public.product_option_selector_display": {
+      "name": "product_option_selector_display",
+      "schema": "public",
+      "values": [
+        "dropdown",
+        "image",
+        "button"
+      ]
+    },
+    "public.product_rental_stock_mode": {
+      "name": "product_rental_stock_mode",
+      "schema": "public",
+      "values": [
+        "shared",
+        "separate"
+      ]
+    },
+    "public.product_status": {
+      "name": "product_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "presale",
+        "sale"
+      ]
+    },
+    "public.product_store_category": {
+      "name": "product_store_category",
+      "schema": "public",
+      "values": [
+        "merch",
+        "supplies"
+      ]
+    },
+    "public.product_transaction_type": {
+      "name": "product_transaction_type",
+      "schema": "public",
+      "values": [
+        "purchase",
+        "rental"
+      ]
+    },
+    "public.program_status": {
+      "name": "program_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.proof_status": {
+      "name": "proof_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected_resubmit",
+        "rejected_removed"
+      ]
+    },
+    "public.proof_type": {
+      "name": "proof_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "text",
+        "both"
+      ]
+    },
+    "public.purchase_actor_type": {
+      "name": "purchase_actor_type",
+      "schema": "public",
+      "values": [
+        "buyer",
+        "admin",
+        "system"
+      ]
+    },
+    "public.purchase_line_source": {
+      "name": "purchase_line_source",
+      "schema": "public",
+      "values": [
+        "individual_session",
+        "pass_session"
+      ]
+    },
+    "public.rental_return_condition": {
+      "name": "rental_return_condition",
+      "schema": "public",
+      "values": [
+        "good",
+        "damaged",
+        "missing_parts",
+        "lost",
+        "other"
+      ]
+    },
+    "public.participation_request_status": {
+      "name": "participation_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.user_request_type": {
+      "name": "user_request_type",
+      "schema": "public",
+      "values": [
+        "festival_participation",
+        "become_artist"
+      ]
+    },
+    "public.reservation_source": {
+      "name": "reservation_source",
+      "schema": "public",
+      "values": [
+        "user_reservation",
+        "admin_assignment"
+      ]
+    },
+    "public.reservation_status": {
+      "name": "reservation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verification_payment",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.sanction_event_type": {
+      "name": "sanction_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "approved",
+        "activated",
+        "edited",
+        "extended",
+        "scope_changed",
+        "infractions_changed",
+        "festival_excluded",
+        "festival_restored",
+        "reservation_eligibility_changed",
+        "expired",
+        "revoked"
+      ]
+    },
+    "public.sanction_festival_scope": {
+      "name": "sanction_festival_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "glitter",
+        "festicker",
+        "twinkler"
+      ]
+    },
+    "public.sanction_status": {
+      "name": "sanction_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "active",
+        "expired",
+        "revoked"
+      ]
+    },
+    "public.sanction_type": {
+      "name": "sanction_type",
+      "schema": "public",
+      "values": [
+        "ban",
+        "warning",
+        "reservation_delay"
+      ]
+    },
+    "public.scheduled_task_type": {
+      "name": "scheduled_task_type",
+      "schema": "public",
+      "values": [
+        "profile_creation",
+        "stand_reservation"
+      ]
+    },
+    "public.session_audience": {
+      "name": "session_audience",
+      "schema": "public",
+      "values": [
+        "all",
+        "participants_only",
+        "public_only"
+      ]
+    },
+    "public.session_purchase_event_type": {
+      "name": "session_purchase_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "voucher_uploaded",
+        "voucher_replaced",
+        "changes_requested",
+        "approved",
+        "rejected",
+        "cancelled_by_buyer",
+        "cancelled_by_admin",
+        "expired",
+        "ticket_issued",
+        "ticket_cancelled",
+        "adjusted",
+        "link_resent",
+        "emails_resent",
+        "refund_requested",
+        "refund_resolved",
+        "upgrade_initiated",
+        "upgrade_completed"
+      ]
+    },
+    "public.session_purchase_payment_mode": {
+      "name": "session_purchase_payment_mode",
+      "schema": "public",
+      "values": [
+        "bank_qr",
+        "free"
+      ]
+    },
+    "public.session_purchase_status": {
+      "name": "session_purchase_status",
+      "schema": "public",
+      "values": [
+        "pending_upload",
+        "under_verification",
+        "changes_requested",
+        "approved",
+        "rejected",
+        "expired",
+        "cancelled"
+      ]
+    },
+    "public.session_skill_level": {
+      "name": "session_skill_level",
+      "schema": "public",
+      "values": [
+        "beginner",
+        "intermediate",
+        "advanced"
+      ]
+    },
+    "public.session_ticket_status": {
+      "name": "session_ticket_status",
+      "schema": "public",
+      "values": [
+        "valid",
+        "cancelled"
+      ]
+    },
+    "public.session_type": {
+      "name": "session_type",
+      "schema": "public",
+      "values": [
+        "talk",
+        "workshop"
+      ]
+    },
+    "public.stand_orientation": {
+      "name": "stand_orientation",
+      "schema": "public",
+      "values": [
+        "portrait",
+        "landscape"
+      ]
+    },
+    "public.stand_status": {
+      "name": "stand_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "held",
+        "reserved",
+        "confirmed",
+        "disabled"
+      ]
+    },
+    "public.stand_zone": {
+      "name": "stand_zone",
+      "schema": "public",
+      "values": [
+        "main",
+        "secondary"
+      ]
+    },
+    "public.storage_cleanup_job_status": {
+      "name": "storage_cleanup_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.store_section": {
+      "name": "store_section",
+      "schema": "public",
+      "values": [
+        "merch",
+        "supplies"
+      ]
+    },
+    "public.store_status_mode": {
+      "name": "store_status_mode",
+      "schema": "public",
+      "values": [
+        "auto",
+        "open",
+        "closed"
+      ]
+    },
+    "public.submission_status": {
+      "name": "submission_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.ticket_status": {
+      "name": "ticket_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "checked_in"
+      ]
+    },
+    "public.user_category": {
+      "name": "user_category",
+      "schema": "public",
+      "values": [
+        "none",
+        "illustration",
+        "gastronomy",
+        "entrepreneurship",
+        "new_artist"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "artist",
+        "user",
+        "festival_admin"
+      ]
+    },
+    "public.user_social_type": {
+      "name": "user_social_type",
+      "schema": "public",
+      "values": [
+        "instagram",
+        "facebook",
+        "tiktok",
+        "twitter",
+        "youtube"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "verified",
+        "pending",
+        "rejected",
+        "banned",
+        "paused"
+      ]
+    },
+    "public.votable_type": {
+      "name": "votable_type",
+      "schema": "public",
+      "values": [
+        "participant",
+        "stand"
+      ]
+    },
+    "public.waitlist_entry_status": {
+      "name": "waitlist_entry_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "invited",
+        "converted",
+        "removed"
+      ]
+    },
+    "public.waitlist_invitation_status": {
+      "name": "waitlist_invitation_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "converted",
+        "expired",
+        "revoked"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1569,6 +1569,13 @@
       "when": 1785455294987,
       "tag": "0223_tired_katie_power",
       "breakpoints": true
+    },
+    {
+      "idx": 224,
+      "version": "7",
+      "when": 1785531704244,
+      "tag": "0224_careful_red_shift",
+      "breakpoints": true
     }
   ]
 }

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -13,7 +13,10 @@ if (getClientEnv().NEXT_PUBLIC_VERCEL_ENV === "production") {
     before_send: (event) => {
       if (!event?.properties) return event;
       try {
-        return { ...event, properties: redactEventProperties(event.properties) };
+        return {
+          ...event,
+          properties: redactEventProperties(event.properties),
+        };
       } catch (error) {
         // Dropped rather than sent through: if redaction failed we cannot say
         // the URL is clean, and losing one event beats shipping a credential.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added occurrence dashboards with seat availability, attendee rosters, ticket details, holds, waitlists, and review indicators.
  * Added support for grouping adjoining stands, including admin controls, visual outlines, grouped labels, products, and reservations.
  * Improved festival, public, and user maps with shared zooming, grouped stand rendering, activity badges, and mobile pinch guidance.
* **Bug Fixes**
  * Approval reviews may now omit a reason, while other decisions still require one.
  * Standardized stand and venue labels by removing unnecessary “#” prefixes.
* **Tests**
  * Expanded coverage for rosters, reviews, stand groups, maps, and participant activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->