### PR TITLE
feat(programs): add program-level enrollments roster dashboard

### DIFF
--- a/app/components/dashboard/programs/enrollments/occurrence-rollup-row.tsx
+++ b/app/components/dashboard/programs/enrollments/occurrence-rollup-row.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { DateTime } from "luxon";
+import { useState } from "react";
+
+import { ChevronRight } from "lucide-react";
+
+import OccurrenceRosterTable from "@/app/components/dashboard/programs/occurrence-roster-table";
+import ProgramStatusBadge from "@/app/components/programs/program-status-badge";
+import { formatDate } from "@/app/lib/formatters";
+import type {
+  ProgramStatus,
+  SessionStatus,
+} from "@/app/lib/programs/definitions";
+import type { RosterEntry } from "@/app/lib/programs/occurrence-queries";
+import type { OccurrenceRollup } from "@/app/lib/programs/program-roster";
+import { resolveOccurrenceState } from "@/app/lib/programs/state";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  rollup: OccurrenceRollup;
+  programStatus: ProgramStatus;
+  sessionStatus: SessionStatus;
+  /** Pinned server-side (invariant 1); never re-derived here. */
+  now: Date;
+  /** This occurrence's own entries, unfiltered — the toggle is applied here. */
+  entries: RosterEntry[];
+  showReleased: boolean;
+  /** Sets the global session+occurrence filter — the "drill in" affordance. */
+  onSelect: () => void;
+};
+
+/**
+ * One occurrence, collapsed to its seat-count line or expanded to its people
+ * (§5.5). Expanding is a local peek: it does not touch the global filter,
+ * which is instead set by clicking the row's own label via `onSelect`.
+ */
+export default function OccurrenceRollupRow({
+  rollup,
+  programStatus,
+  sessionStatus,
+  now,
+  entries,
+  showReleased,
+  onSelect,
+}: Props) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const resolved = resolveOccurrenceState(
+    {
+      programStatus,
+      sessionStatus,
+      lifecycleStatus: rollup.lifecycleStatus,
+      salesStartAt: rollup.salesStartAt,
+      salesEndAt: rollup.salesEndAt,
+      salesClosedAt: rollup.salesClosedAt,
+      rescheduledAt: rollup.rescheduledAt,
+    },
+    now,
+  );
+
+  const visibleEntries = showReleased
+    ? entries
+    : entries.filter((entry) => entry.state !== "released");
+
+  return (
+    <li className="rounded-lg border border-border/70">
+      <div className="flex flex-wrap items-center justify-between gap-2 p-3">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setIsExpanded((prev) => !prev)}
+            aria-label={isExpanded ? "Ocultar inscritos" : "Ver inscritos"}
+            aria-expanded={isExpanded}
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+          >
+            <ChevronRight
+              className={cn(
+                "h-4 w-4 transition-transform",
+                isExpanded && "rotate-90",
+              )}
+            />
+          </button>
+          <button
+            type="button"
+            onClick={onSelect}
+            className="text-left font-medium hover:underline"
+          >
+            {formatDate(rollup.startsAt).toLocaleString(DateTime.DATETIME_MED)}
+            {rollup.venueName ? ` · ${rollup.venueName}` : ""}
+            {rollup.room ? ` · ${rollup.room}` : ""}
+          </button>
+          <ProgramStatusBadge
+            state={resolved.state}
+            wasRescheduled={resolved.wasRescheduled}
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-1.5 text-sm">
+          <span>
+            {rollup.totals.occupied}/{rollup.capacity} ocupados ·{" "}
+            {rollup.isSoldOut ? "Sin cupos" : `${rollup.remaining} libres`}
+            {rollup.waitlistActive > 0
+              ? ` · ${rollup.waitlistActive} en lista`
+              : ""}
+          </span>
+          {rollup.totals.released > 0 ? (
+            <span className="text-xs text-muted-foreground">
+              [{rollup.totals.released}{" "}
+              {rollup.totals.released === 1 ? "liberado" : "liberados"}]
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      {isExpanded ? (
+        <div className="border-t border-border/70 p-3">
+          <OccurrenceRosterTable entries={visibleEntries} />
+        </div>
+      ) : null}
+    </li>
+  );
+}

--- a/app/components/dashboard/programs/enrollments/program-roster-summary.tsx
+++ b/app/components/dashboard/programs/enrollments/program-roster-summary.tsx
@@ -1,0 +1,72 @@
+import { ROSTER_SEAT_STATE_LABELS, type RosterTotals } from "@/app/lib/programs/roster";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  totals: RosterTotals;
+  showReleased: boolean;
+  onToggleReleased: () => void;
+};
+
+const TILES: {
+  key: "confirmed" | "awaitingReview" | "changesRequested" | "holding" | "released";
+  label: string;
+}[] = [
+  { key: "confirmed", label: ROSTER_SEAT_STATE_LABELS.confirmed },
+  { key: "awaitingReview", label: ROSTER_SEAT_STATE_LABELS.awaiting_review },
+  { key: "changesRequested", label: ROSTER_SEAT_STATE_LABELS.changes_requested },
+  { key: "holding", label: ROSTER_SEAT_STATE_LABELS.holding },
+  { key: "released", label: ROSTER_SEAT_STATE_LABELS.released },
+];
+
+/**
+ * The five state tiles, always for the whole program regardless of the
+ * session/occurrence filter (§5.3) — the constant frame of reference the
+ * filtered view below is read against.
+ *
+ * The Liberado tile is the only interactive one: released rows are hidden by
+ * default everywhere below, and this tile is the control that reveals them.
+ * A hidden state whose count is displayed nowhere else would be a dead end,
+ * so the tile that reports the number is the thing you press to see the rows
+ * (§5.7).
+ */
+export default function ProgramRosterSummary({
+  totals,
+  showReleased,
+  onToggleReleased,
+}: Props) {
+  return (
+    <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+      {TILES.map(({ key, label }) => {
+        const value = totals[key];
+
+        if (key !== "released") {
+          return (
+            <div key={key} className="rounded-lg border border-border/70 p-3">
+              <p className="text-2xl font-semibold">{value}</p>
+              <p className="text-xs text-muted-foreground">{label}</p>
+            </div>
+          );
+        }
+
+        return (
+          <button
+            key={key}
+            type="button"
+            onClick={onToggleReleased}
+            aria-pressed={showReleased}
+            className={cn(
+              "rounded-lg border p-3 text-left transition-colors hover:bg-muted/50",
+              showReleased ? "border-primary bg-muted/30" : "border-border/70",
+            )}
+          >
+            <p className="text-2xl font-semibold">{value}</p>
+            <p className="text-xs text-muted-foreground">{label}</p>
+            <p className="mt-1 text-[11px] font-medium text-primary">
+              {showReleased ? "Ocultar filas" : "Mostrar filas"}
+            </p>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/components/dashboard/programs/enrollments/program-roster-view.test.tsx
+++ b/app/components/dashboard/programs/enrollments/program-roster-view.test.tsx
@@ -1,0 +1,247 @@
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ProgramRosterView from "@/app/components/dashboard/programs/enrollments/program-roster-view";
+import type {
+  ProgramRoster,
+  ProgramRosterOccurrence,
+  ProgramRosterSession,
+  RosterEntry,
+} from "@/app/lib/programs/occurrence-queries";
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  // jsdom has neither of these; Radix's Select opens on pointerdown and
+  // scrolls the highlighted option into view when it does.
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+  Element.prototype.releasePointerCapture = vi.fn();
+});
+
+function session(overrides: Partial<ProgramRosterSession> = {}): ProgramRosterSession {
+  return {
+    id: 10,
+    title: "Taller A",
+    type: "workshop",
+    status: "published",
+    ...overrides,
+  };
+}
+
+function occurrence(
+  overrides: Partial<ProgramRosterOccurrence> = {},
+): ProgramRosterOccurrence {
+  return {
+    occurrenceId: 1,
+    sessionId: 10,
+    startsAt: new Date("2026-08-10T18:00:00.000Z"),
+    endsAt: new Date("2026-08-10T20:00:00.000Z"),
+    capacity: 2,
+    venueName: "Sala 1",
+    room: null,
+    lifecycleStatus: "scheduled",
+    rescheduledAt: null,
+    salesStartAt: null,
+    salesEndAt: null,
+    salesClosedAt: null,
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<RosterEntry> = {}): RosterEntry {
+  return {
+    lineId: 1,
+    purchaseId: 100,
+    occurrenceId: 1,
+    state: "confirmed",
+    attendeeName: "Ana Gómez",
+    attendeeEmail: "ana@example.com",
+    attendeePhone: null,
+    isGuest: false,
+    ticketCode: "ABC123",
+    unitPrice: 70,
+    promoCode: null,
+    promoPartnerName: null,
+    isFree: false,
+    holdExpiresAt: null,
+    createdAt: new Date("2026-07-30T15:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function roster(overrides: Partial<ProgramRoster> = {}): ProgramRoster {
+  return {
+    now: new Date("2026-08-01T12:00:00.000Z"),
+    programStatus: "published",
+    sessions: [
+      session({ id: 10, title: "Taller A" }),
+      session({ id: 20, title: "Charla B", type: "talk" }),
+    ],
+    occurrences: [
+      occurrence({ occurrenceId: 1, sessionId: 10, startsAt: new Date("2026-08-10T18:00:00.000Z") }),
+      occurrence({ occurrenceId: 2, sessionId: 10, startsAt: new Date("2026-08-11T18:00:00.000Z") }),
+      occurrence({
+        occurrenceId: 3,
+        sessionId: 20,
+        startsAt: new Date("2026-08-09T10:00:00.000Z"),
+        capacity: 3,
+      }),
+    ],
+    entries: [
+      entry({ lineId: 1, occurrenceId: 1, state: "confirmed", attendeeName: "Ana Gómez", purchaseId: 100 }),
+      entry({ lineId: 2, occurrenceId: 1, state: "released", attendeeName: "Carlos Pérez", purchaseId: 101 }),
+      entry({ lineId: 3, occurrenceId: 2, state: "holding", attendeeName: "Beto Ruiz", purchaseId: 102 }),
+      entry({ lineId: 4, occurrenceId: 3, state: "confirmed", attendeeName: "Deb Soto", purchaseId: 103 }),
+    ],
+    waitlistByOccurrence: { 1: 2 },
+    ...overrides,
+  };
+}
+
+async function openSelect(trigger: HTMLElement) {
+  fireEvent.click(trigger);
+  return within(document.body).findByRole("listbox");
+}
+
+describe("ProgramRosterView", () => {
+  it("shows the program-wide tiles regardless of filter", () => {
+    render(<ProgramRosterView roster={roster()} />);
+    // 2 confirmed, 1 holding, 1 released across the whole program.
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("Confirmado")).toBeTruthy();
+    expect(screen.getByText("Liberado")).toBeTruthy();
+  });
+
+  it("groups by session at the program level, ordered by earliest occurrence", () => {
+    render(<ProgramRosterView roster={roster()} />);
+    const rows = screen.getAllByRole("listitem");
+    // Charla B's only occurrence starts before either of Taller A's.
+    expect(within(rows[0]).getByText("Charla B")).toBeTruthy();
+    expect(within(rows[1]).getByText("Taller A")).toBeTruthy();
+  });
+
+  it("drills into a session's occurrences when its row is clicked, then into its people", () => {
+    render(<ProgramRosterView roster={roster()} />);
+
+    fireEvent.click(screen.getByText("Taller A"));
+    // Now at occurrence level: two occurrence rows, no session list.
+    expect(screen.queryByText("Charla B")).toBeNull();
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+
+    const [firstOccurrence] = screen.getAllByRole("listitem");
+    fireEvent.click(
+      within(firstOccurrence).getByRole("button", { name: /10 ago 2026/ }),
+    );
+
+    // Now at the flat roster for that one occurrence.
+    expect(screen.getByText("Ana Gómez")).toBeTruthy();
+  });
+
+  it("cascades: changing the session clears a previously selected occurrence", async () => {
+    render(<ProgramRosterView roster={roster()} />);
+
+    const [sessionTrigger, occurrenceTrigger] = screen.getAllByRole("combobox");
+
+    let listbox = await openSelect(sessionTrigger);
+    fireEvent.click(within(listbox).getByText("Taller A"));
+
+    listbox = await openSelect(occurrenceTrigger);
+    fireEvent.click(within(listbox).getAllByRole("option")[1]); // first real occurrence option
+
+    // Flat roster for the selected occurrence is now showing.
+    expect(screen.getByText("Ana Gómez")).toBeTruthy();
+
+    // Switching session must not leave the stale occurrence selected —
+    // otherwise "session + unrelated occurrence" would be representable.
+    listbox = await openSelect(sessionTrigger);
+    fireEvent.click(within(listbox).getByText("Charla B"));
+
+    expect(sessionTrigger.textContent).toMatch(/Charla B/);
+    expect(occurrenceTrigger.textContent).toMatch(/Todos los horarios/);
+  });
+
+  it("hides released rows by default and reveals them via the Liberado tile", () => {
+    render(<ProgramRosterView roster={roster()} />);
+
+    fireEvent.click(screen.getByText("Taller A"));
+    const [firstOccurrence] = screen.getAllByRole("listitem");
+    fireEvent.click(within(firstOccurrence).getByRole("button", { name: "Ver inscritos" }));
+
+    expect(screen.getByText("Ana Gómez")).toBeTruthy();
+    expect(screen.queryByText("Carlos Pérez")).toBeNull();
+
+    fireEvent.click(screen.getByText("Liberado"));
+
+    expect(screen.getByText("Carlos Pérez")).toBeTruthy();
+  });
+
+  it("keeps the headline occupied count excluding released regardless of the toggle", () => {
+    render(<ProgramRosterView roster={roster()} />);
+    // Taller A: 1 confirmed + 1 holding occupied, 1 released, capacity 4.
+    expect(screen.getByText(/2\/4 ocupados/)).toBeTruthy();
+    expect(screen.getByText(/\[1 liberado\]/)).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Liberado"));
+    // Toggling the tile reveals rows elsewhere; the rollup headline is
+    // unaffected because `occupied` never counted released to begin with.
+    expect(screen.getByText(/2\/4 ocupados/)).toBeTruthy();
+  });
+
+  it("flattens the view when searching and shows Sesión/Horario columns", () => {
+    render(<ProgramRosterView roster={roster()} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Nombre, correo/i), {
+      target: { value: "gómez" },
+    });
+
+    expect(screen.getByRole("columnheader", { name: "Sesión" })).toBeTruthy();
+    expect(screen.getByRole("columnheader", { name: "Horario" })).toBeTruthy();
+    expect(screen.getByText("Ana Gómez")).toBeTruthy();
+    expect(screen.queryByText("Beto Ruiz")).toBeNull();
+  });
+
+  it("search matches by purchase id and spans released rows regardless of the toggle", () => {
+    render(<ProgramRosterView roster={roster()} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Nombre, correo/i), {
+      target: { value: "#101" },
+    });
+
+    // 101 belongs to the released entry, hidden everywhere else by default.
+    expect(screen.getByText("Carlos Pérez")).toBeTruthy();
+  });
+
+  it("shows 'sin resultados' when a search matches nothing", () => {
+    render(<ProgramRosterView roster={roster()} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Nombre, correo/i), {
+      target: { value: "nadie-existe" },
+    });
+
+    expect(screen.getByText(/Sin resultados para/)).toBeTruthy();
+  });
+
+  it("shows the no-sessions empty state", () => {
+    render(<ProgramRosterView roster={roster({ sessions: [], occurrences: [], entries: [] })} />);
+    expect(screen.getByText(/Todavía no hay sesiones en este programa/)).toBeTruthy();
+  });
+
+  it("shows the no-enrollments empty state when sessions exist but nobody signed up", () => {
+    render(<ProgramRosterView roster={roster({ entries: [] })} />);
+    expect(screen.getByText(/Todavía nadie se inscribió a este programa/)).toBeTruthy();
+  });
+
+  it("shows the empty-session state when a selected session has zero entries", () => {
+    render(
+      <ProgramRosterView
+        roster={roster({
+          entries: [entry({ lineId: 1, occurrenceId: 3, state: "confirmed" })],
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Taller A"));
+    expect(screen.getByText(/Nadie se inscribió a esta sesión todavía/)).toBeTruthy();
+  });
+});

--- a/app/components/dashboard/programs/enrollments/program-roster-view.tsx
+++ b/app/components/dashboard/programs/enrollments/program-roster-view.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { DateTime } from "luxon";
+import { useMemo, useState } from "react";
+
+import OccurrenceRollupRow from "@/app/components/dashboard/programs/enrollments/occurrence-rollup-row";
+import ProgramRosterSummary from "@/app/components/dashboard/programs/enrollments/program-roster-summary";
+import RosterLevelFilters from "@/app/components/dashboard/programs/enrollments/roster-level-filters";
+import SessionRollupRow from "@/app/components/dashboard/programs/enrollments/session-rollup-row";
+import OccurrenceRosterTable, {
+  type RosterOccurrenceContext,
+} from "@/app/components/dashboard/programs/occurrence-roster-table";
+import { formatDate } from "@/app/lib/formatters";
+import type { ProgramRoster } from "@/app/lib/programs/occurrence-queries";
+import {
+  buildOccurrenceRollups,
+  buildSessionRollups,
+  groupEntriesByOccurrence,
+  matchesRosterSearch,
+  type OccurrenceRollup,
+} from "@/app/lib/programs/program-roster";
+import { summarizeRoster } from "@/app/lib/programs/roster";
+
+type Props = {
+  roster: ProgramRoster;
+};
+
+/**
+ * Owns every piece of client state for the program enrollments dashboard —
+ * filter, search, and the released-rows toggle — and does all grouping over
+ * `roster.entries` via `summarizeRoster`/`buildOccurrenceRollups`/
+ * `buildSessionRollups` (invariant 3: one load, so a group's count and its
+ * expanded contents can never diverge).
+ *
+ * State lives here rather than in the URL: the load-all approach exists to
+ * make filtering instant, and re-running a server component on every click
+ * would spend exactly the benefit it was chosen for (§7.4).
+ */
+export default function ProgramRosterView({ roster }: Props) {
+  const [sessionFilter, setSessionFilter] = useState<number | null>(null);
+  const [occurrenceFilter, setOccurrenceFilter] = useState<number | null>(
+    null,
+  );
+  const [search, setSearch] = useState("");
+  const [showReleased, setShowReleased] = useState(false);
+
+  // A stale occurrence id from another session must never survive a session
+  // change (§5.2).
+  function handleSessionChange(sessionId: number | null) {
+    setSessionFilter(sessionId);
+    setOccurrenceFilter(null);
+  }
+
+  const entriesByOccurrenceId = useMemo(
+    () => groupEntriesByOccurrence(roster.entries),
+    [roster.entries],
+  );
+
+  const occurrenceRollups = useMemo(
+    () =>
+      buildOccurrenceRollups(
+        roster.occurrences,
+        roster.entries,
+        roster.waitlistByOccurrence,
+      ),
+    [roster.occurrences, roster.entries, roster.waitlistByOccurrence],
+  );
+
+  const sessionRollups = useMemo(
+    () => buildSessionRollups(roster.sessions, occurrenceRollups),
+    [roster.sessions, occurrenceRollups],
+  );
+
+  const occurrenceRollupsBySession = useMemo(() => {
+    const map = new Map<number, OccurrenceRollup[]>();
+    for (const rollup of occurrenceRollups) {
+      const group = map.get(rollup.sessionId);
+      if (group) {
+        group.push(rollup);
+      } else {
+        map.set(rollup.sessionId, [rollup]);
+      }
+    }
+    return map;
+  }, [occurrenceRollups]);
+
+  const occurrenceContext = useMemo<RosterOccurrenceContext>(() => {
+    const sessionTitleById = new Map(
+      roster.sessions.map((session) => [session.id, session.title]),
+    );
+    const context: RosterOccurrenceContext = new Map();
+    for (const occurrence of roster.occurrences) {
+      context.set(occurrence.occurrenceId, {
+        sessionTitle: sessionTitleById.get(occurrence.sessionId) ?? "—",
+        occurrenceLabel: formatDate(occurrence.startsAt).toLocaleString(
+          DateTime.DATETIME_MED,
+        ),
+      });
+    }
+    return context;
+  }, [roster.sessions, roster.occurrences]);
+
+  const tileTotals = useMemo(
+    () => summarizeRoster(roster.entries.map((entry) => entry.state)),
+    [roster.entries],
+  );
+
+  const isSearching = search.trim().length > 0;
+
+  // Session/occurrence filters still scope a search (§5.8).
+  const scopedEntries = useMemo(() => {
+    if (occurrenceFilter !== null) {
+      return roster.entries.filter(
+        (entry) => entry.occurrenceId === occurrenceFilter,
+      );
+    }
+    if (sessionFilter !== null) {
+      const occurrenceIdsInSession = new Set(
+        roster.occurrences
+          .filter((occurrence) => occurrence.sessionId === sessionFilter)
+          .map((occurrence) => occurrence.occurrenceId),
+      );
+      return roster.entries.filter((entry) =>
+        occurrenceIdsInSession.has(entry.occurrenceId),
+      );
+    }
+    return roster.entries;
+  }, [roster.entries, roster.occurrences, sessionFilter, occurrenceFilter]);
+
+  // Search spans every state, including released, regardless of the toggle
+  // (§5.8) — a support request about a dead checkout is exactly when someone
+  // needs to be findable.
+  const searchResults = useMemo(() => {
+    if (!isSearching) return [];
+    return scopedEntries.filter((entry) => matchesRosterSearch(entry, search));
+  }, [scopedEntries, search, isSearching]);
+
+  const occurrenceOptions = useMemo(() => {
+    if (sessionFilter === null) return [];
+    return roster.occurrences
+      .filter((occurrence) => occurrence.sessionId === sessionFilter)
+      .slice()
+      .sort((a, b) => a.startsAt.getTime() - b.startsAt.getTime());
+  }, [roster.occurrences, sessionFilter]);
+
+  const selectedSessionRollup =
+    sessionFilter !== null
+      ? (sessionRollups.find((rollup) => rollup.sessionId === sessionFilter) ??
+        null)
+      : null;
+
+  const selectedOccurrenceRollup =
+    occurrenceFilter !== null
+      ? (occurrenceRollups.find(
+          (rollup) => rollup.occurrenceId === occurrenceFilter,
+        ) ?? null)
+      : null;
+
+  const occurrenceRollupsForSelectedSession =
+    sessionFilter !== null
+      ? (occurrenceRollupsBySession.get(sessionFilter) ?? [])
+      : [];
+
+  const visibleScopedEntries = showReleased
+    ? scopedEntries
+    : scopedEntries.filter((entry) => entry.state !== "released");
+
+  return (
+    <div className="space-y-6">
+      <ProgramRosterSummary
+        totals={tileTotals}
+        showReleased={showReleased}
+        onToggleReleased={() => setShowReleased((prev) => !prev)}
+      />
+
+      <RosterLevelFilters
+        sessions={roster.sessions}
+        occurrences={occurrenceOptions}
+        sessionFilter={sessionFilter}
+        occurrenceFilter={occurrenceFilter}
+        search={search}
+        onSessionChange={handleSessionChange}
+        onOccurrenceChange={setOccurrenceFilter}
+        onSearchChange={setSearch}
+      />
+
+      {isSearching ? (
+        searchResults.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Sin resultados para &quot;{search}&quot;.
+          </p>
+        ) : (
+          <OccurrenceRosterTable
+            entries={searchResults}
+            occurrenceContext={occurrenceContext}
+          />
+        )
+      ) : selectedSessionRollup && selectedOccurrenceRollup ? (
+        <OccurrenceRosterTable entries={visibleScopedEntries} />
+      ) : selectedSessionRollup ? (
+        selectedSessionRollup.totals.occupied +
+          selectedSessionRollup.totals.released ===
+        0 ? (
+          <p className="text-sm text-muted-foreground">
+            Nadie se inscribió a esta sesión todavía.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {occurrenceRollupsForSelectedSession.map((rollup) => (
+              <OccurrenceRollupRow
+                key={rollup.occurrenceId}
+                rollup={rollup}
+                programStatus={roster.programStatus}
+                sessionStatus={selectedSessionRollup.status}
+                now={roster.now}
+                entries={entriesByOccurrenceId.get(rollup.occurrenceId) ?? []}
+                showReleased={showReleased}
+                onSelect={() => setOccurrenceFilter(rollup.occurrenceId)}
+              />
+            ))}
+          </ul>
+        )
+      ) : roster.sessions.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Todavía no hay sesiones en este programa.
+        </p>
+      ) : roster.entries.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Todavía nadie se inscribió a este programa.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {sessionRollups.map((rollup) => (
+            <SessionRollupRow
+              key={rollup.sessionId}
+              rollup={rollup}
+              programStatus={roster.programStatus}
+              now={roster.now}
+              occurrenceRollups={
+                occurrenceRollupsBySession.get(rollup.sessionId) ?? []
+              }
+              entriesByOccurrenceId={entriesByOccurrenceId}
+              showReleased={showReleased}
+              onSelectSession={() => handleSessionChange(rollup.sessionId)}
+              onSelectOccurrence={(occurrenceId) => {
+                setSessionFilter(rollup.sessionId);
+                setOccurrenceFilter(occurrenceId);
+              }}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/components/dashboard/programs/enrollments/roster-level-filters.tsx
+++ b/app/components/dashboard/programs/enrollments/roster-level-filters.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { DateTime } from "luxon";
+
+import { Input } from "@/app/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/app/components/ui/select";
+import { formatDate } from "@/app/lib/formatters";
+
+const ALL_SESSIONS = "all";
+const ALL_OCCURRENCES = "all";
+
+type Props = {
+  sessions: { id: number; title: string }[];
+  /** Already scoped to the selected session — empty and disabled otherwise. */
+  occurrences: { occurrenceId: number; startsAt: Date }[];
+  sessionFilter: number | null;
+  occurrenceFilter: number | null;
+  search: string;
+  onSessionChange: (sessionId: number | null) => void;
+  onOccurrenceChange: (occurrenceId: number | null) => void;
+  onSearchChange: (value: string) => void;
+};
+
+/**
+ * The filter selects the grouping level (§5.2): session, then, scoped to it,
+ * occurrence. This is one of the two affordances that write to that state —
+ * clicking a rollup row's header is the other, and both land on the same
+ * `sessionFilter`/`occurrenceFilter` values owned by the parent.
+ */
+export default function RosterLevelFilters({
+  sessions,
+  occurrences,
+  sessionFilter,
+  occurrenceFilter,
+  search,
+  onSessionChange,
+  onOccurrenceChange,
+  onSearchChange,
+}: Props) {
+  return (
+    <div className="flex flex-wrap items-end gap-3">
+      <div className="w-full max-w-xs space-y-1">
+        <label
+          htmlFor="roster-session-filter"
+          className="text-xs font-medium text-muted-foreground"
+        >
+          Sesión
+        </label>
+        <Select
+          value={sessionFilter === null ? ALL_SESSIONS : String(sessionFilter)}
+          onValueChange={(value) =>
+            onSessionChange(value === ALL_SESSIONS ? null : Number(value))
+          }
+        >
+          <SelectTrigger id="roster-session-filter">
+            <SelectValue placeholder="Todas las sesiones" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_SESSIONS}>Todas las sesiones</SelectItem>
+            {sessions.map((session) => (
+              <SelectItem key={session.id} value={String(session.id)}>
+                {session.title}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="w-full max-w-xs space-y-1">
+        <label
+          htmlFor="roster-occurrence-filter"
+          className="text-xs font-medium text-muted-foreground"
+        >
+          Horario
+        </label>
+        <Select
+          value={
+            occurrenceFilter === null ? ALL_OCCURRENCES : String(occurrenceFilter)
+          }
+          onValueChange={(value) =>
+            onOccurrenceChange(value === ALL_OCCURRENCES ? null : Number(value))
+          }
+          disabled={sessionFilter === null}
+        >
+          <SelectTrigger id="roster-occurrence-filter">
+            <SelectValue placeholder="Todos los horarios" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_OCCURRENCES}>Todos los horarios</SelectItem>
+            {occurrences.map((occurrence) => (
+              <SelectItem
+                key={occurrence.occurrenceId}
+                value={String(occurrence.occurrenceId)}
+              >
+                {formatDate(occurrence.startsAt).toLocaleString(
+                  DateTime.DATETIME_MED,
+                )}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="w-full max-w-sm flex-1 space-y-1">
+        <label
+          htmlFor="roster-search-filter"
+          className="text-xs font-medium text-muted-foreground"
+        >
+          Buscar
+        </label>
+        <Input
+          id="roster-search-filter"
+          placeholder="Nombre, correo, código o compra…"
+          value={search}
+          onChange={(event) => onSearchChange(event.target.value)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/components/dashboard/programs/enrollments/session-rollup-row.tsx
+++ b/app/components/dashboard/programs/enrollments/session-rollup-row.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+
+import { ChevronRight } from "lucide-react";
+
+import OccurrenceRollupRow from "@/app/components/dashboard/programs/enrollments/occurrence-rollup-row";
+import {
+  SESSION_TYPE_LABELS,
+  type ProgramStatus,
+} from "@/app/lib/programs/definitions";
+import type { RosterEntry } from "@/app/lib/programs/occurrence-queries";
+import type {
+  OccurrenceRollup,
+  SessionRollup,
+} from "@/app/lib/programs/program-roster";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  rollup: SessionRollup;
+  programStatus: ProgramStatus;
+  /** Pinned server-side (invariant 1); never re-derived here. */
+  now: Date;
+  /** This session's own occurrence rollups, already chronologically ordered. */
+  occurrenceRollups: OccurrenceRollup[];
+  entriesByOccurrenceId: Map<number, RosterEntry[]>;
+  showReleased: boolean;
+  /** Sets the global session filter — the "drill in" affordance. */
+  onSelectSession: () => void;
+  /** Sets session + occurrence at once, skipping the intermediate level. */
+  onSelectOccurrence: (occurrenceId: number) => void;
+};
+
+/**
+ * One session, collapsed to its seat-count line or expanded to its
+ * occurrences (§5.4). Expanding is a local peek: it does not touch the
+ * global filter, which is instead set by clicking the row's own label via
+ * `onSelectSession`.
+ */
+export default function SessionRollupRow({
+  rollup,
+  programStatus,
+  now,
+  occurrenceRollups,
+  entriesByOccurrenceId,
+  showReleased,
+  onSelectSession,
+  onSelectOccurrence,
+}: Props) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <li className="rounded-lg border border-border/70">
+      <div className="flex flex-wrap items-center justify-between gap-2 p-3">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setIsExpanded((prev) => !prev)}
+            aria-label={isExpanded ? "Ocultar horarios" : "Ver horarios"}
+            aria-expanded={isExpanded}
+            disabled={rollup.occurrenceCount === 0}
+            className="shrink-0 text-muted-foreground hover:text-foreground disabled:opacity-30"
+          >
+            <ChevronRight
+              className={cn(
+                "h-4 w-4 transition-transform",
+                isExpanded && "rotate-90",
+              )}
+            />
+          </button>
+          <button
+            type="button"
+            onClick={onSelectSession}
+            className="text-left font-medium hover:underline"
+          >
+            {rollup.title}
+          </button>
+          <span className="text-xs text-muted-foreground">
+            {SESSION_TYPE_LABELS[rollup.type]}
+          </span>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-1.5 text-sm">
+          <span>
+            {rollup.occurrenceCount}{" "}
+            {rollup.occurrenceCount === 1 ? "horario" : "horarios"} ·{" "}
+            {rollup.totals.occupied}/{rollup.capacity} ocupados ·{" "}
+            {rollup.isSoldOut ? "Sin cupos" : `${rollup.remaining} libres`}
+            {rollup.waitlistActive > 0
+              ? ` · ${rollup.waitlistActive} en lista`
+              : ""}
+          </span>
+          {rollup.totals.released > 0 ? (
+            <span className="text-xs text-muted-foreground">
+              [{rollup.totals.released}{" "}
+              {rollup.totals.released === 1 ? "liberado" : "liberados"}]
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      {isExpanded && occurrenceRollups.length > 0 ? (
+        <ul className="space-y-2 border-t border-border/70 p-3">
+          {occurrenceRollups.map((occurrenceRollup) => (
+            <OccurrenceRollupRow
+              key={occurrenceRollup.occurrenceId}
+              rollup={occurrenceRollup}
+              programStatus={programStatus}
+              sessionStatus={rollup.status}
+              now={now}
+              entries={
+                entriesByOccurrenceId.get(occurrenceRollup.occurrenceId) ?? []
+              }
+              showReleased={showReleased}
+              onSelect={() =>
+                onSelectOccurrence(occurrenceRollup.occurrenceId)
+              }
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}

--- a/app/components/dashboard/programs/occurrence-roster-table.test.tsx
+++ b/app/components/dashboard/programs/occurrence-roster-table.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import OccurrenceRosterTable from "@/app/components/dashboard/programs/occurrence-roster-table";
@@ -15,6 +21,7 @@ function entry(overrides: Partial<RosterEntry> = {}): RosterEntry {
   return {
     lineId: 1,
     purchaseId: 100,
+    occurrenceId: 71,
     state: "confirmed",
     attendeeName: "Ana Quiroga",
     attendeeEmail: "ana@example.com",
@@ -165,6 +172,63 @@ describe("OccurrenceRosterTable", () => {
     expect(
       container.querySelector('a[href*="/programs/purchases/"]'),
     ).toBeNull();
+  });
+
+  it("omits the Sesión and Horario columns when rows never span occurrences", () => {
+    render(<OccurrenceRosterTable entries={[entry()]} />);
+    expect(screen.queryByText("Sesión")).toBeNull();
+    expect(screen.queryByText("Horario")).toBeNull();
+  });
+
+  it("shows Sesión and Horario only when given occurrence context", () => {
+    const occurrenceContext = new Map([
+      [71, { sessionTitle: "Taller A", occurrenceLabel: "12 mar 2026, 18:00" }],
+    ]);
+
+    render(
+      <OccurrenceRosterTable
+        entries={[entry({ occurrenceId: 71 })]}
+        occurrenceContext={occurrenceContext}
+      />,
+    );
+
+    expect(screen.getByText("Sesión")).toBeTruthy();
+    expect(screen.getByText("Taller A")).toBeTruthy();
+    expect(screen.getByText("12 mar 2026, 18:00")).toBeTruthy();
+  });
+
+  it("falls back to a dash when a row's occurrence is missing from the context", () => {
+    render(
+      <OccurrenceRosterTable
+        entries={[entry({ occurrenceId: 999 })]}
+        occurrenceContext={new Map()}
+      />,
+    );
+
+    expect(screen.getAllByText("—")).toHaveLength(2);
+  });
+
+  it("hides pagination controls when everything fits on one page", () => {
+    render(<OccurrenceRosterTable entries={[entry()]} />);
+    expect(screen.queryByText("Anterior")).toBeNull();
+    expect(screen.queryByText("Siguiente")).toBeNull();
+  });
+
+  it("paginates once a roster exceeds one page", () => {
+    const entries = Array.from({ length: 51 }, (_, i) =>
+      entry({ lineId: i, attendeeName: `Persona ${i}` }),
+    );
+
+    render(<OccurrenceRosterTable entries={entries} />);
+
+    expect(screen.getByText("Persona 0")).toBeTruthy();
+    expect(screen.queryByText("Persona 50")).toBeNull();
+    expect(screen.getByText(/Página 1 de 2/)).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Siguiente"));
+
+    expect(screen.getByText("Persona 50")).toBeTruthy();
+    expect(screen.queryByText("Persona 0")).toBeNull();
   });
 });
 

--- a/app/components/dashboard/programs/occurrence-roster-table.tsx
+++ b/app/components/dashboard/programs/occurrence-roster-table.tsx
@@ -1,6 +1,18 @@
+"use client";
+"use no memo";
+
 import { DateTime } from "luxon";
+import { useMemo } from "react";
+
+import {
+  type ColumnDef,
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
 
 import { Badge, type BadgeVariant } from "@/app/components/ui/badge";
+import { Button } from "@/app/components/ui/button";
 import { formatDate } from "@/app/lib/formatters";
 import type { RosterEntry } from "@/app/lib/programs/occurrence-queries";
 import { formatMoney } from "@/app/lib/programs/pricing";
@@ -17,20 +29,55 @@ const STATE_VARIANT: Record<RosterSeatState, BadgeVariant> = {
   released: "outline",
 };
 
+/** Large enough that a single occurrence's roster never paginates in practice. */
+const PAGE_SIZE = 50;
+
+/** Where each row's occurrence lives, keyed by `RosterEntry.occurrenceId`. */
+export type RosterOccurrenceContext = Map<
+  number,
+  { sessionTitle: string; occurrenceLabel: string }
+>;
+
 type Props = {
   entries: RosterEntry[];
+  /**
+   * Present only when rows can span more than one occurrence — a
+   * program-wide search result, never a single occurrence's own roster
+   * (§5.6). Its presence, not the row count, decides whether the Sesión and
+   * Horario columns render.
+   */
+  occurrenceContext?: RosterOccurrenceContext;
 };
 
 /**
- * Who has a seat in one occurrence.
+ * Who has a seat in one occurrence, or in a set of occurrences when the
+ * caller supplies `occurrenceContext`.
  *
  * Released rows are kept rather than filtered out. They are the record of
  * people who started and did not finish — the drop-off between "reservando"
  * and "confirmado" is the first place to look when a payment step is failing,
  * and an admin chasing a specific person needs to find them whatever became of
- * their purchase.
+ * their purchase. Whether released rows ever reach this component is the
+ * caller's decision (occurrence scope always shows them; the program roster
+ * hides them behind a toggle) — this table just renders whatever it is given.
  */
-export default function OccurrenceRosterTable({ entries }: Props) {
+export default function OccurrenceRosterTable({
+  entries,
+  occurrenceContext,
+}: Props) {
+  const columns = useMemo<ColumnDef<RosterEntry, unknown>[]>(
+    () => [{ id: "row" }],
+    [],
+  );
+
+  const table = useReactTable({
+    data: entries,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize: PAGE_SIZE } },
+  });
+
   if (entries.length === 0) {
     return (
       <p className="text-sm text-muted-foreground">
@@ -39,98 +86,153 @@ export default function OccurrenceRosterTable({ entries }: Props) {
     );
   }
 
+  const rows = table.getRowModel().rows;
+  const showPagination = table.getPageCount() > 1;
+
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full min-w-[42rem] text-sm">
-        <thead>
-          <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
-            <th className="px-2 py-2 font-medium">Persona</th>
-            <th className="px-2 py-2 font-medium">Estado</th>
-            <th className="px-2 py-2 font-medium">Entrada</th>
-            <th className="px-2 py-2 font-medium">Monto</th>
-            <th className="px-2 py-2 font-medium">Inscripción</th>
-            <th className="px-2 py-2 font-medium">Compra</th>
-          </tr>
-        </thead>
-        <tbody>
-          {entries.map((entry) => (
-            <tr
-              key={entry.lineId}
-              className="border-b border-border/60 last:border-b-0 align-top"
-            >
-              <td className="px-2 py-3">
-                <p className="font-medium">{entry.attendeeName}</p>
-                <p className="text-xs text-muted-foreground">
-                  {entry.attendeeEmail}
-                </p>
-                {entry.attendeePhone ? (
-                  <p className="text-xs text-muted-foreground">
-                    {entry.attendeePhone}
-                  </p>
-                ) : null}
-                <p className="text-xs text-muted-foreground">
-                  {entry.isGuest ? "Invitado" : "Con cuenta"}
-                </p>
-              </td>
-              <td className="px-2 py-3">
-                <Badge variant={STATE_VARIANT[entry.state]}>
-                  {ROSTER_SEAT_STATE_LABELS[entry.state]}
-                </Badge>
-                {/* Only meaningful while the clock is running; a lapsed hold
-                    already reads as "Liberado". */}
-                {entry.state === "holding" && entry.holdExpiresAt ? (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Vence{" "}
-                    {formatDate(entry.holdExpiresAt).toLocaleString(
-                      DateTime.TIME_SIMPLE,
-                    )}
-                  </p>
-                ) : null}
-              </td>
-              <td className="px-2 py-3">
-                {entry.ticketCode ? (
-                  <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
-                    {entry.ticketCode}
-                  </code>
-                ) : (
-                  <span className="text-xs text-muted-foreground">
-                    Sin emitir
-                  </span>
-                )}
-              </td>
-              <td className="px-2 py-3 whitespace-nowrap">
-                <div>
-                  {entry.isFree ? (
-                    <span className="text-xs text-muted-foreground">
-                      Gratis
-                    </span>
-                  ) : (
-                    <p>{formatMoney(entry.unitPrice)}</p>
-                  )}
-                  {entry.promoCode ? (
-                    <p className="text-xs font-medium text-purple-700">
-                      {entry.promoCode} · {entry.promoPartnerName}
-                    </p>
-                  ) : null}
-                </div>
-              </td>
-              <td className="px-2 py-3 whitespace-nowrap text-xs text-muted-foreground">
-                {formatDate(entry.createdAt).toLocaleString(
-                  DateTime.DATETIME_MED,
-                )}
-              </td>
-              {/* Not a link: `/programs/purchases/[id]` is the buyer's page and
-                  `resolvePurchaseAccess` grants only the owner or a valid
-                  token — there is no admin bypass, so linking there would send
-                  the team to a denied page. The id is here to correlate with
-                  the review queue and with support actions. */}
-              <td className="px-2 py-3 text-xs text-muted-foreground">
-                #{entry.purchaseId}
-              </td>
+    <div className="space-y-3">
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[42rem] text-sm">
+          <thead>
+            <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <th className="px-2 py-2 font-medium">Persona</th>
+              <th className="px-2 py-2 font-medium">Estado</th>
+              <th className="px-2 py-2 font-medium">Entrada</th>
+              <th className="px-2 py-2 font-medium">Monto</th>
+              <th className="px-2 py-2 font-medium">Inscripción</th>
+              <th className="px-2 py-2 font-medium">Compra</th>
+              {occurrenceContext ? (
+                <>
+                  <th className="px-2 py-2 font-medium">Sesión</th>
+                  <th className="px-2 py-2 font-medium">Horario</th>
+                </>
+              ) : null}
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const entry = row.original;
+              const context = occurrenceContext?.get(entry.occurrenceId);
+
+              return (
+                <tr
+                  key={entry.lineId}
+                  className="border-b border-border/60 last:border-b-0 align-top"
+                >
+                  <td className="px-2 py-3">
+                    <p className="font-medium">{entry.attendeeName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {entry.attendeeEmail}
+                    </p>
+                    {entry.attendeePhone ? (
+                      <p className="text-xs text-muted-foreground">
+                        {entry.attendeePhone}
+                      </p>
+                    ) : null}
+                    <p className="text-xs text-muted-foreground">
+                      {entry.isGuest ? "Invitado" : "Con cuenta"}
+                    </p>
+                  </td>
+                  <td className="px-2 py-3">
+                    <Badge variant={STATE_VARIANT[entry.state]}>
+                      {ROSTER_SEAT_STATE_LABELS[entry.state]}
+                    </Badge>
+                    {/* Only meaningful while the clock is running; a lapsed hold
+                        already reads as "Liberado". */}
+                    {entry.state === "holding" && entry.holdExpiresAt ? (
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Vence{" "}
+                        {formatDate(entry.holdExpiresAt).toLocaleString(
+                          DateTime.TIME_SIMPLE,
+                        )}
+                      </p>
+                    ) : null}
+                  </td>
+                  <td className="px-2 py-3">
+                    {entry.ticketCode ? (
+                      <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                        {entry.ticketCode}
+                      </code>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">
+                        Sin emitir
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-2 py-3 whitespace-nowrap">
+                    <div>
+                      {entry.isFree ? (
+                        <span className="text-xs text-muted-foreground">
+                          Gratis
+                        </span>
+                      ) : (
+                        <p>{formatMoney(entry.unitPrice)}</p>
+                      )}
+                      {entry.promoCode ? (
+                        <p className="text-xs font-medium text-purple-700">
+                          {entry.promoCode} · {entry.promoPartnerName}
+                        </p>
+                      ) : null}
+                    </div>
+                  </td>
+                  <td className="px-2 py-3 whitespace-nowrap text-xs text-muted-foreground">
+                    {formatDate(entry.createdAt).toLocaleString(
+                      DateTime.DATETIME_MED,
+                    )}
+                  </td>
+                  {/* Not a link: `/programs/purchases/[id]` is the buyer's page and
+                      `resolvePurchaseAccess` grants only the owner or a valid
+                      token — there is no admin bypass, so linking there would send
+                      the team to a denied page. The id is here to correlate with
+                      the review queue and with support actions. */}
+                  <td className="px-2 py-3 text-xs text-muted-foreground">
+                    #{entry.purchaseId}
+                  </td>
+                  {occurrenceContext ? (
+                    <>
+                      <td className="px-2 py-3 text-xs">
+                        {context?.sessionTitle ?? "—"}
+                      </td>
+                      <td className="px-2 py-3 whitespace-nowrap text-xs">
+                        {context?.occurrenceLabel ?? "—"}
+                      </td>
+                    </>
+                  ) : null}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {showPagination ? (
+        <div className="flex items-center justify-between gap-2 text-sm text-muted-foreground">
+          <p>
+            Página {table.getState().pagination.pageIndex + 1} de{" "}
+            {table.getPageCount()} · {entries.length} entradas
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+            >
+              Anterior
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+            >
+              Siguiente
+            </Button>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/app/dashboard/programs/[id]/enrollments/page.tsx
+++ b/app/dashboard/programs/[id]/enrollments/page.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import ProgramRosterView from "@/app/components/dashboard/programs/enrollments/program-roster-view";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/app/components/ui/card";
+import { fetchProgramForAdmin } from "@/app/lib/programs/data";
+import { fetchProgramRoster } from "@/app/lib/programs/occurrence-queries";
+import { requireAdminOrFestivalAdmin } from "@/app/lib/users/helpers";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function ProgramEnrollmentsPage({ params }: Props) {
+  const profile = await requireAdminOrFestivalAdmin();
+  if (!profile) redirect("/dashboard");
+
+  const { id } = await params;
+  const programId = Number(id);
+  if (!Number.isInteger(programId)) notFound();
+
+  const program = await fetchProgramForAdmin(programId);
+  if (!program) notFound();
+
+  // Pinned once (invariant 1): every tile, group count, and row on this
+  // screen is judged against this same instant.
+  const now = new Date();
+  const roster = await fetchProgramRoster(programId, { now });
+
+  return (
+    <div className="container mx-auto space-y-6 py-6">
+      <div className="space-y-2">
+        <Link
+          href={`/dashboard/programs/${program.id}`}
+          className="text-sm text-muted-foreground underline-offset-2 hover:underline"
+        >
+          ← {program.name}
+        </Link>
+        <h1 className="text-2xl font-bold">Inscritos</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Todas las sesiones</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ProgramRosterView roster={roster} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/dashboard/programs/[id]/page.tsx
+++ b/app/dashboard/programs/[id]/page.tsx
@@ -61,7 +61,12 @@ export default async function ProgramDetailPage({ params }: Props) {
         />
       </div>
 
-      <div>
+      <div className="flex flex-wrap gap-2">
+        <Button asChild variant="outline" size="sm">
+          <Link href={`/dashboard/programs/${program.id}/enrollments`}>
+            Ver inscritos
+          </Link>
+        </Button>
         <Button asChild variant="outline" size="sm">
           <Link
             href={`/dashboard/programs/promo-codes/new?programId=${program.id}`}

--- a/app/lib/programs/definitions.ts
+++ b/app/lib/programs/definitions.ts
@@ -33,6 +33,7 @@ export type OccurrenceScheduleChange =
 
 export type ProgramStatus = Program["status"];
 export type SessionType = ProgramSession["type"];
+export type SessionStatus = ProgramSession["status"];
 export type SessionAudience = ProgramSession["audience"];
 export type SessionSkillLevel = NonNullable<ProgramSession["skillLevel"]>;
 export type OccurrenceLifecycleStatus = SessionOccurrence["lifecycleStatus"];

--- a/app/lib/programs/occurrence-queries.ts
+++ b/app/lib/programs/occurrence-queries.ts
@@ -3,6 +3,12 @@ import "server-only";
 import { and, asc, eq, inArray, notInArray } from "drizzle-orm";
 import { cache } from "react";
 
+import type {
+  OccurrenceLifecycleStatus,
+  ProgramStatus,
+  SessionStatus,
+  SessionType,
+} from "@/app/lib/programs/definitions";
 import { resolveAvailability } from "@/app/lib/programs/inventory";
 import { resolveAttendeeIdentity } from "@/app/lib/programs/registration";
 import {
@@ -14,6 +20,8 @@ import {
 } from "@/app/lib/programs/roster";
 import { db } from "@/db";
 import {
+  programs,
+  programSessions,
   sessionOccurrences,
   sessionPurchaseLines,
   sessionWaitlistEntries,
@@ -23,6 +31,7 @@ import {
 export type RosterEntry = {
   lineId: number;
   purchaseId: number;
+  occurrenceId: number;
   state: RosterSeatState;
   attendeeName: string;
   attendeeEmail: string;
@@ -112,6 +121,7 @@ export async function fetchOccurrenceRosters(
     entries.push({
       lineId: line.id,
       purchaseId: purchase.id,
+      occurrenceId: line.occurrenceId,
       state,
       // An anonymized purchase (a deleted account) keeps its seat but loses its
       // person, so the roster says so rather than rendering an empty cell.
@@ -263,6 +273,129 @@ export async function fetchOccurrenceDashboard(
       waitlist.get(occurrence.id) ?? 0,
     ),
     entries,
+  };
+}
+
+/** One occurrence as the program-wide roster needs it: schedule and lifecycle, no counts. */
+export type ProgramRosterOccurrence = {
+  occurrenceId: number;
+  sessionId: number;
+  startsAt: Date;
+  endsAt: Date;
+  capacity: number;
+  venueName: string | null;
+  room: string | null;
+  lifecycleStatus: OccurrenceLifecycleStatus;
+  rescheduledAt: Date | null;
+  salesStartAt: Date | null;
+  salesEndAt: Date | null;
+  salesClosedAt: Date | null;
+};
+
+export type ProgramRosterSession = {
+  id: number;
+  title: string;
+  type: SessionType;
+  status: SessionStatus;
+};
+
+export type ProgramRoster = {
+  /** Pinned once. Every count on the screen is judged against this instant. */
+  now: Date;
+  programStatus: ProgramStatus;
+  sessions: ProgramRosterSession[];
+  occurrences: ProgramRosterOccurrence[];
+  entries: RosterEntry[];
+  waitlistByOccurrence: Record<number, number>;
+};
+
+/**
+ * Every enrollment in a program, across every session and occurrence, for the
+ * program-wide dashboard (docs/PRD-program-enrollments-dashboard.md).
+ *
+ * Reuses `fetchOccurrenceRosters` unchanged over every occurrence id in the
+ * program rather than a bespoke aggregate query, so this screen's numbers are
+ * structurally the same read as the occurrence page's — invariant 1.
+ *
+ * Display strings for sessions and occurrences are deliberately not joined
+ * onto entries here; the client joins by id (§7.2), so there is one source
+ * per fact instead of a snapshot that can drift from the live schedule.
+ */
+export async function fetchProgramRoster(
+  programId: number,
+  options: { now?: Date } = {},
+): Promise<ProgramRoster> {
+  const now = options.now ?? new Date();
+
+  const [program, sessions] = await Promise.all([
+    db.query.programs.findFirst({
+      where: eq(programs.id, programId),
+      columns: { status: true },
+    }),
+    db.query.programSessions.findMany({
+      where: eq(programSessions.programId, programId),
+      columns: { id: true, title: true, type: true, status: true },
+      orderBy: [asc(programSessions.id)],
+      with: {
+        occurrences: {
+          with: { venue: true },
+          orderBy: [asc(sessionOccurrences.startsAt)],
+        },
+      },
+    }),
+  ]);
+
+  // The route resolves `notFound()` before calling this; a program deleted in
+  // the gap between that check and this query has nothing left to roster.
+  if (!program) {
+    return {
+      now,
+      programStatus: "draft",
+      sessions: [],
+      occurrences: [],
+      entries: [],
+      waitlistByOccurrence: {},
+    };
+  }
+
+  const occurrences: ProgramRosterOccurrence[] = sessions.flatMap((session) =>
+    session.occurrences.map((occurrence) => ({
+      occurrenceId: occurrence.id,
+      sessionId: session.id,
+      startsAt: occurrence.startsAt,
+      endsAt: occurrence.endsAt,
+      capacity: occurrence.capacity,
+      venueName: occurrence.venue?.name ?? null,
+      room: occurrence.room,
+      lifecycleStatus: occurrence.lifecycleStatus,
+      rescheduledAt: occurrence.rescheduledAt,
+      salesStartAt: occurrence.salesStartAt,
+      salesEndAt: occurrence.salesEndAt,
+      salesClosedAt: occurrence.salesClosedAt,
+    })),
+  );
+
+  const occurrenceIds = occurrences.map((occurrence) => occurrence.occurrenceId);
+
+  const [rosters, waitlist] = await Promise.all([
+    fetchOccurrenceRosters(occurrenceIds, { now }),
+    fetchWaitlistCounts(occurrenceIds),
+  ]);
+
+  const entries = occurrenceIds.flatMap((id) => rosters.get(id) ?? []);
+
+  return {
+    now,
+    programStatus: program.status,
+    sessions: sessions.map((session) => ({
+      id: session.id,
+      title: session.title,
+      type: session.type,
+      status: session.status,
+    })),
+    occurrences,
+    entries,
+    waitlistByOccurrence: Object.fromEntries(waitlist),
   };
 }
 

--- a/app/lib/programs/program-roster.test.ts
+++ b/app/lib/programs/program-roster.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ProgramRosterOccurrence,
+  ProgramRosterSession,
+  RosterEntry,
+} from "@/app/lib/programs/occurrence-queries";
+import {
+  buildOccurrenceRollups,
+  buildSessionRollups,
+  groupEntriesByOccurrence,
+  matchesRosterSearch,
+} from "@/app/lib/programs/program-roster";
+import { summarizeRoster, type RosterSeatState } from "@/app/lib/programs/roster";
+
+function occurrence(
+  overrides: Partial<ProgramRosterOccurrence> = {},
+): ProgramRosterOccurrence {
+  return {
+    occurrenceId: 1,
+    sessionId: 10,
+    startsAt: new Date("2026-08-10T18:00:00.000Z"),
+    endsAt: new Date("2026-08-10T20:00:00.000Z"),
+    capacity: 20,
+    venueName: "Sala 2",
+    room: null,
+    lifecycleStatus: "scheduled",
+    rescheduledAt: null,
+    salesStartAt: null,
+    salesEndAt: null,
+    salesClosedAt: null,
+    ...overrides,
+  };
+}
+
+function session(
+  overrides: Partial<ProgramRosterSession> = {},
+): ProgramRosterSession {
+  return {
+    id: 10,
+    title: "Taller A",
+    type: "workshop",
+    status: "published",
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<RosterEntry> = {}): RosterEntry {
+  return {
+    lineId: 1,
+    purchaseId: 100,
+    occurrenceId: 1,
+    state: "confirmed",
+    attendeeName: "Ana Gómez",
+    attendeeEmail: "ana@example.com",
+    attendeePhone: null,
+    isGuest: false,
+    ticketCode: "ABC123",
+    unitPrice: 70,
+    promoCode: null,
+    promoPartnerName: null,
+    isFree: false,
+    holdExpiresAt: null,
+    createdAt: new Date("2026-07-30T15:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("groupEntriesByOccurrence", () => {
+  it("groups by the live occurrence id on the entry, not any snapshot", () => {
+    const entries = [
+      entry({ lineId: 1, occurrenceId: 1 }),
+      entry({ lineId: 2, occurrenceId: 2 }),
+      entry({ lineId: 3, occurrenceId: 1 }),
+    ];
+
+    const grouped = groupEntriesByOccurrence(entries);
+
+    expect(grouped.get(1)?.map((e) => e.lineId)).toEqual([1, 3]);
+    expect(grouped.get(2)?.map((e) => e.lineId)).toEqual([2]);
+  });
+});
+
+describe("buildOccurrenceRollups", () => {
+  it("sums seat states per occurrence and derives remaining from resolveAvailability", () => {
+    const occurrences = [occurrence({ occurrenceId: 1, capacity: 3 })];
+    const entries = [
+      entry({ lineId: 1, occurrenceId: 1, state: "confirmed" }),
+      entry({ lineId: 2, occurrenceId: 1, state: "holding" }),
+      entry({ lineId: 3, occurrenceId: 1, state: "released" }),
+    ];
+
+    const [rollup] = buildOccurrenceRollups(occurrences, entries, {});
+
+    expect(rollup.totals.confirmed).toBe(1);
+    expect(rollup.totals.holding).toBe(1);
+    expect(rollup.totals.released).toBe(1);
+    // Released never occupies a seat, so remaining excludes it.
+    expect(rollup.remaining).toBe(1);
+    expect(rollup.isSoldOut).toBe(false);
+  });
+
+  it("keeps a rescheduled occurrence as one group rather than splitting it", () => {
+    // The occurrence's own `startsAt` moved; entries carry only the live
+    // `occurrenceId`, so every entry still lands in the same rollup.
+    const occurrences = [
+      occurrence({
+        occurrenceId: 1,
+        startsAt: new Date("2026-09-01T18:00:00.000Z"),
+        rescheduledAt: new Date("2026-08-01T00:00:00.000Z"),
+      }),
+    ];
+    const entries = [
+      entry({ lineId: 1, occurrenceId: 1 }),
+      entry({ lineId: 2, occurrenceId: 1 }),
+    ];
+
+    const rollups = buildOccurrenceRollups(occurrences, entries, {});
+
+    expect(rollups).toHaveLength(1);
+    expect(rollups[0].totals.confirmed).toBe(2);
+  });
+
+  it("orders occurrences chronologically ascending", () => {
+    const occurrences = [
+      occurrence({ occurrenceId: 2, startsAt: new Date("2026-08-12T00:00:00.000Z") }),
+      occurrence({ occurrenceId: 1, startsAt: new Date("2026-08-10T00:00:00.000Z") }),
+    ];
+
+    const rollups = buildOccurrenceRollups(occurrences, [], {});
+
+    expect(rollups.map((r) => r.occurrenceId)).toEqual([1, 2]);
+  });
+
+  it("carries the waitlist count for its own occurrence only", () => {
+    const occurrences = [occurrence({ occurrenceId: 1 }), occurrence({ occurrenceId: 2 })];
+
+    const rollups = buildOccurrenceRollups(occurrences, [], { 1: 4 });
+
+    expect(rollups.find((r) => r.occurrenceId === 1)?.waitlistActive).toBe(4);
+    expect(rollups.find((r) => r.occurrenceId === 2)?.waitlistActive).toBe(0);
+  });
+});
+
+describe("buildSessionRollups", () => {
+  it("sums occupied and capacity across a session's occurrences, matching the row-level totals", () => {
+    const occurrences = [
+      occurrence({ occurrenceId: 1, sessionId: 10, capacity: 30 }),
+      occurrence({ occurrenceId: 2, sessionId: 10, capacity: 45 }),
+    ];
+    const entries = [
+      ...Array.from({ length: 20 }, (_, i) =>
+        entry({ lineId: i, occurrenceId: 1, state: "confirmed" }),
+      ),
+      ...Array.from({ length: 38 }, (_, i) =>
+        entry({ lineId: 100 + i, occurrenceId: 2, state: "confirmed" }),
+      ),
+    ];
+
+    const occurrenceRollups = buildOccurrenceRollups(occurrences, entries, {});
+    const [rollup] = buildSessionRollups([session()], occurrenceRollups);
+
+    expect(rollup.capacity).toBe(75);
+    expect(rollup.totals.occupied).toBe(58);
+    expect(rollup.remaining).toBe(17);
+    // Session and occurrence totals must agree — invariant 3.
+    const sumOfOccurrenceOccupied = occurrenceRollups.reduce(
+      (sum, o) => sum + o.totals.occupied,
+      0,
+    );
+    expect(rollup.totals.occupied).toBe(sumOfOccurrenceOccupied);
+  });
+
+  it("keeps the muted released count separate from the headline occupied count", () => {
+    const occurrences = [occurrence({ occurrenceId: 1, sessionId: 10, capacity: 10 })];
+    const entries = [
+      entry({ lineId: 1, occurrenceId: 1, state: "confirmed" }),
+      entry({ lineId: 2, occurrenceId: 1, state: "released" }),
+      entry({ lineId: 3, occurrenceId: 1, state: "released" }),
+    ];
+
+    const occurrenceRollups = buildOccurrenceRollups(occurrences, entries, {});
+    const [rollup] = buildSessionRollups([session()], occurrenceRollups);
+
+    expect(rollup.totals.occupied).toBe(1);
+    expect(rollup.totals.released).toBe(2);
+  });
+
+  it("is sold out only when every occurrence is sold out", () => {
+    const occurrences = [
+      occurrence({ occurrenceId: 1, sessionId: 10, capacity: 2 }),
+      occurrence({ occurrenceId: 2, sessionId: 10, capacity: 2 }),
+    ];
+    const entries = [
+      entry({ lineId: 1, occurrenceId: 1, state: "confirmed" }),
+      entry({ lineId: 2, occurrenceId: 1, state: "confirmed" }),
+      entry({ lineId: 3, occurrenceId: 2, state: "confirmed" }),
+    ];
+
+    const occurrenceRollups = buildOccurrenceRollups(occurrences, entries, {});
+    const [rollup] = buildSessionRollups([session()], occurrenceRollups);
+
+    // Occurrence 1 is full, occurrence 2 has one seat left.
+    expect(rollup.isSoldOut).toBe(false);
+
+    const fullEntries = [...entries, entry({ lineId: 4, occurrenceId: 2, state: "confirmed" })];
+    const fullOccurrenceRollups = buildOccurrenceRollups(occurrences, fullEntries, {});
+    const [fullRollup] = buildSessionRollups([session()], fullOccurrenceRollups);
+    expect(fullRollup.isSoldOut).toBe(true);
+  });
+
+  it("is never sold out when it has no occurrences", () => {
+    const [rollup] = buildSessionRollups([session()], []);
+    expect(rollup.isSoldOut).toBe(false);
+    expect(rollup.occurrenceCount).toBe(0);
+  });
+
+  it("orders sessions by earliest occurrence start, sinking scheduleless sessions last", () => {
+    const sessions = [
+      session({ id: 10 }),
+      session({ id: 20, title: "Charla B" }),
+      session({ id: 30, title: "Charla C" }),
+    ];
+    const occurrences = [
+      occurrence({ occurrenceId: 1, sessionId: 10, startsAt: new Date("2026-08-15T00:00:00.000Z") }),
+      occurrence({ occurrenceId: 2, sessionId: 20, startsAt: new Date("2026-08-05T00:00:00.000Z") }),
+    ];
+
+    const rollups = buildSessionRollups(sessions, buildOccurrenceRollups(occurrences, [], {}));
+
+    expect(rollups.map((r) => r.sessionId)).toEqual([20, 10, 30]);
+  });
+
+  it("sums waitlist counts across a session's occurrences", () => {
+    const occurrences = [
+      occurrence({ occurrenceId: 1, sessionId: 10 }),
+      occurrence({ occurrenceId: 2, sessionId: 10 }),
+    ];
+    const occurrenceRollups = buildOccurrenceRollups(occurrences, [], { 1: 2, 2: 3 });
+    const [rollup] = buildSessionRollups([session()], occurrenceRollups);
+
+    expect(rollup.waitlistActive).toBe(5);
+  });
+});
+
+describe("program totals reconcile at every grain (invariant 3)", () => {
+  it("program tiles equal the sum of session rollups equal the sum of occurrence rollups", () => {
+    const sessions = [session({ id: 10 }), session({ id: 20, title: "Charla B" })];
+    const occurrences = [
+      occurrence({ occurrenceId: 1, sessionId: 10, capacity: 10 }),
+      occurrence({ occurrenceId: 2, sessionId: 10, capacity: 10 }),
+      occurrence({ occurrenceId: 3, sessionId: 20, capacity: 10 }),
+    ];
+    const states: RosterSeatState[] = [
+      "confirmed",
+      "confirmed",
+      "awaiting_review",
+      "changes_requested",
+      "holding",
+      "released",
+      "released",
+    ];
+    const entries = states.map((state, i) =>
+      entry({ lineId: i, occurrenceId: (i % 3) + 1, state }),
+    );
+
+    const programTotals = summarizeRoster(entries.map((e) => e.state));
+    const occurrenceRollups = buildOccurrenceRollups(occurrences, entries, {});
+    const sessionRollups = buildSessionRollups(sessions, occurrenceRollups);
+
+    const sumFromSessions = sessionRollups.reduce(
+      (sum, r) => sum + r.totals.occupied + r.totals.released,
+      0,
+    );
+    const sumFromOccurrences = occurrenceRollups.reduce(
+      (sum, r) => sum + r.totals.occupied + r.totals.released,
+      0,
+    );
+
+    expect(programTotals.occupied + programTotals.released).toBe(sumFromSessions);
+    expect(sumFromSessions).toBe(sumFromOccurrences);
+    expect(sumFromOccurrences).toBe(entries.length);
+  });
+});
+
+describe("matchesRosterSearch", () => {
+  it("matches by attendee name, case-insensitively and partially", () => {
+    expect(matchesRosterSearch(entry({ attendeeName: "Ana Gómez" }), "gómez")).toBe(true);
+    expect(matchesRosterSearch(entry({ attendeeName: "Ana Gómez" }), "ANA")).toBe(true);
+    expect(matchesRosterSearch(entry({ attendeeName: "Ana Gómez" }), "Carlos")).toBe(false);
+  });
+
+  it("matches by email and ticket code", () => {
+    expect(
+      matchesRosterSearch(entry({ attendeeEmail: "ana@example.com" }), "example.com"),
+    ).toBe(true);
+    expect(matchesRosterSearch(entry({ ticketCode: "XYZ789" }), "xyz")).toBe(true);
+    expect(matchesRosterSearch(entry({ ticketCode: null }), "xyz")).toBe(false);
+  });
+
+  it("matches a purchase id whether or not the query has a leading #", () => {
+    expect(matchesRosterSearch(entry({ purchaseId: 1234 }), "1234")).toBe(true);
+    expect(matchesRosterSearch(entry({ purchaseId: 1234 }), "#1234")).toBe(true);
+    expect(matchesRosterSearch(entry({ purchaseId: 1234 }), "5678")).toBe(false);
+  });
+
+  it("matches every seat state, including released", () => {
+    expect(
+      matchesRosterSearch(
+        entry({ state: "released", attendeeName: "Abandonó Checkout" }),
+        "abandonó",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches everything for an empty query", () => {
+    expect(matchesRosterSearch(entry(), "")).toBe(true);
+    expect(matchesRosterSearch(entry(), "   ")).toBe(true);
+  });
+});

--- a/app/lib/programs/program-roster.ts
+++ b/app/lib/programs/program-roster.ts
@@ -1,0 +1,250 @@
+import type {
+  OccurrenceLifecycleStatus,
+  SessionStatus,
+  SessionType,
+} from "@/app/lib/programs/definitions";
+import { resolveAvailability } from "@/app/lib/programs/inventory";
+import type {
+  ProgramRosterOccurrence,
+  ProgramRosterSession,
+  RosterEntry,
+} from "@/app/lib/programs/occurrence-queries";
+import { summarizeRoster, type RosterTotals } from "@/app/lib/programs/roster";
+
+/** One occurrence's rollup row (§5.5): schedule, lifecycle, and seat counts. */
+export type OccurrenceRollup = {
+  occurrenceId: number;
+  sessionId: number;
+  startsAt: Date;
+  endsAt: Date;
+  capacity: number;
+  venueName: string | null;
+  room: string | null;
+  lifecycleStatus: OccurrenceLifecycleStatus;
+  rescheduledAt: Date | null;
+  salesStartAt: Date | null;
+  salesEndAt: Date | null;
+  salesClosedAt: Date | null;
+  totals: RosterTotals;
+  remaining: number;
+  isSoldOut: boolean;
+  waitlistActive: number;
+};
+
+/** One session's rollup row (§5.4): summed across its occurrence rollups. */
+export type SessionRollup = {
+  sessionId: number;
+  title: string;
+  type: SessionType;
+  status: SessionStatus;
+  occurrenceCount: number;
+  earliestStartsAt: Date | null;
+  totals: RosterTotals;
+  capacity: number;
+  remaining: number;
+  isSoldOut: boolean;
+  waitlistActive: number;
+};
+
+/** Every entry, grouped by the live occurrence it belongs to (invariant 2). */
+export function groupEntriesByOccurrence(
+  entries: RosterEntry[],
+): Map<number, RosterEntry[]> {
+  const byOccurrence = new Map<number, RosterEntry[]>();
+
+  for (const entry of entries) {
+    const group = byOccurrence.get(entry.occurrenceId);
+    if (group) {
+      group.push(entry);
+    } else {
+      byOccurrence.set(entry.occurrenceId, [entry]);
+    }
+  }
+
+  return byOccurrence;
+}
+
+/**
+ * One rollup row per occurrence in the program, chronologically ascending.
+ *
+ * Grouped by `occurrence.occurrenceId` — the live occurrence — never by a
+ * purchase-time snapshot, so a rescheduled occurrence stays one group
+ * (invariant 2).
+ */
+export function buildOccurrenceRollups(
+  occurrences: ProgramRosterOccurrence[],
+  entries: RosterEntry[],
+  waitlistByOccurrence: Record<number, number>,
+): OccurrenceRollup[] {
+  const byOccurrence = groupEntriesByOccurrence(entries);
+
+  return occurrences
+    .map((occurrence) => {
+      const occurrenceEntries =
+        byOccurrence.get(occurrence.occurrenceId) ?? [];
+      const totals = summarizeRoster(
+        occurrenceEntries.map((entry) => entry.state),
+      );
+      const availability = resolveAvailability({
+        capacity: occurrence.capacity,
+        validTickets: totals.confirmed,
+        activeHolds:
+          totals.awaitingReview + totals.changesRequested + totals.holding,
+      });
+
+      return {
+        occurrenceId: occurrence.occurrenceId,
+        sessionId: occurrence.sessionId,
+        startsAt: occurrence.startsAt,
+        endsAt: occurrence.endsAt,
+        capacity: occurrence.capacity,
+        venueName: occurrence.venueName,
+        room: occurrence.room,
+        lifecycleStatus: occurrence.lifecycleStatus,
+        rescheduledAt: occurrence.rescheduledAt,
+        salesStartAt: occurrence.salesStartAt,
+        salesEndAt: occurrence.salesEndAt,
+        salesClosedAt: occurrence.salesClosedAt,
+        totals,
+        remaining: availability.remaining,
+        isSoldOut: availability.isSoldOut,
+        waitlistActive: waitlistByOccurrence[occurrence.occurrenceId] ?? 0,
+      };
+    })
+    .sort((a, b) => a.startsAt.getTime() - b.startsAt.getTime());
+}
+
+function sumTotals(list: RosterTotals[]): RosterTotals {
+  const sum: RosterTotals = {
+    confirmed: 0,
+    awaitingReview: 0,
+    changesRequested: 0,
+    holding: 0,
+    released: 0,
+    occupied: 0,
+    needsAction: 0,
+  };
+
+  for (const totals of list) {
+    sum.confirmed += totals.confirmed;
+    sum.awaitingReview += totals.awaitingReview;
+    sum.changesRequested += totals.changesRequested;
+    sum.holding += totals.holding;
+    sum.released += totals.released;
+    sum.occupied += totals.occupied;
+    sum.needsAction += totals.needsAction;
+  }
+
+  return sum;
+}
+
+/**
+ * One rollup row per session, ordered by earliest occurrence start.
+ *
+ * `remaining` is never the sum of each occurrence's own `remaining` — that
+ * would double-floor when one occurrence is over capacity while another has
+ * room. It comes from a single `resolveAvailability` call at the session's
+ * own grain instead (invariant 4).
+ *
+ * `isSoldOut` can't reuse that number, though: the PRD calls a session sold
+ * out only when *every* occurrence is (§5.4), which is a per-occurrence AND,
+ * not a property of the aggregate — the two can disagree exactly in the
+ * over-capacity case above.
+ */
+export function buildSessionRollups(
+  sessions: ProgramRosterSession[],
+  occurrenceRollups: OccurrenceRollup[],
+): SessionRollup[] {
+  const bySession = new Map<number, OccurrenceRollup[]>();
+  for (const rollup of occurrenceRollups) {
+    const group = bySession.get(rollup.sessionId);
+    if (group) {
+      group.push(rollup);
+    } else {
+      bySession.set(rollup.sessionId, [rollup]);
+    }
+  }
+
+  return sessions
+    .map((session) => {
+      const rollups = bySession.get(session.id) ?? [];
+      const totals = sumTotals(rollups.map((rollup) => rollup.totals));
+      const capacity = rollups.reduce(
+        (sum, rollup) => sum + rollup.capacity,
+        0,
+      );
+      const availability = resolveAvailability({
+        capacity,
+        validTickets: totals.confirmed,
+        activeHolds:
+          totals.awaitingReview + totals.changesRequested + totals.holding,
+      });
+      const earliestStartsAt = rollups.reduce<Date | null>(
+        (earliest, rollup) => {
+          if (!earliest) return rollup.startsAt;
+          return rollup.startsAt.getTime() < earliest.getTime()
+            ? rollup.startsAt
+            : earliest;
+        },
+        null,
+      );
+
+      return {
+        sessionId: session.id,
+        title: session.title,
+        type: session.type,
+        status: session.status,
+        occurrenceCount: rollups.length,
+        earliestStartsAt,
+        totals,
+        capacity,
+        remaining: availability.remaining,
+        isSoldOut:
+          rollups.length > 0 && rollups.every((rollup) => rollup.isSoldOut),
+        waitlistActive: rollups.reduce(
+          (sum, rollup) => sum + rollup.waitlistActive,
+          0,
+        ),
+      };
+    })
+    .sort((a, b) => {
+      // A session with no occurrences has no schedule to sort by; it sinks
+      // to the bottom rather than claiming the top slot as an artificial
+      // earliest.
+      if (!a.earliestStartsAt && !b.earliestStartsAt) return 0;
+      if (!a.earliestStartsAt) return 1;
+      if (!b.earliestStartsAt) return -1;
+      return a.earliestStartsAt.getTime() - b.earliestStartsAt.getTime();
+    });
+}
+
+/** Strips a leading "#" so "#1234" and "1234" both match the same purchase id. */
+function normalizeSearchTerm(query: string): string {
+  return query.trim().toLowerCase().replace(/^#/, "");
+}
+
+/**
+ * Whether one entry matches a program-roster search (§5.8): attendee name,
+ * email, ticket code, or purchase id.
+ *
+ * Spans every seat state, including `released` — the toggle that hides
+ * released rows in the browsing view does not apply to search, because a
+ * support request about a dead checkout is exactly when someone needs to be
+ * findable.
+ */
+export function matchesRosterSearch(
+  entry: RosterEntry,
+  query: string,
+): boolean {
+  const term = normalizeSearchTerm(query);
+  if (term.length === 0) return true;
+
+  if (entry.attendeeName.toLowerCase().includes(term)) return true;
+  if (entry.attendeeEmail.toLowerCase().includes(term)) return true;
+  if (entry.ticketCode && entry.ticketCode.toLowerCase().includes(term)) {
+    return true;
+  }
+  if (String(entry.purchaseId).includes(term)) return true;
+
+  return false;
+}


### PR DESCRIPTION
Introduce a dedicated enrollments page with session/occurrence rollups, level filters, and program-wide roster aggregation so staff can review capacity and seats across a program instead of one occurrence at a time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an enrollment dashboard for programs with session and occurrence rollups.
  * View capacity, occupancy, waitlist, released entries, and roster totals.
  * Filter by session or occurrence and search attendee, ticket, and purchase details.
  * Expand sessions and occurrences to inspect roster entries.
  * Added controls to show or hide released entries.
  * Added roster table pagination and contextual schedule information.
  * Added a “Ver inscritos” link from the program dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->